### PR TITLE
Export wireword files for Korean and French

### DIFF
--- a/src/wordfreq/agents/ungurys.py
+++ b/src/wordfreq/agents/ungurys.py
@@ -27,7 +27,9 @@ from wordfreq.trakaido.utils.export_manager import TrakaidoExporter
 # Supported languages and their codes
 SUPPORTED_LANGUAGES = {
     'lt': 'Lithuanian',
-    'zh': 'Chinese'
+    'zh': 'Chinese',
+    'ko': 'Korean',
+    'fr': 'French'
 }
 
 # Configure logging
@@ -322,7 +324,7 @@ def main():
 
     # Language options
     language_help = f'Language code (default: lt). Supported: {", ".join(f"{k}={v}" for k, v in SUPPORTED_LANGUAGES.items())}, zh-Hant=Chinese (Traditional)'
-    parser.add_argument('--language', choices=['lt', 'zh', 'zh-Hant'], default='lt',
+    parser.add_argument('--language', choices=['lt', 'zh', 'zh-Hant', 'ko', 'fr'], default='lt',
                        help=language_help)
     parser.add_argument('--traditional', action='store_true',
                        help='For Chinese (zh): export Traditional characters instead of Simplified (exports to lang_zh_Hant/)')


### PR DESCRIPTION
Extended language export support to include Korean and French alongside existing Lithuanian and Chinese support:

- Added 'ko' (Korean) and 'fr' (French) to SUPPORTED_LANGUAGES in ungurys.py
- Added Korean and French configurations to LANGUAGE_CONFIG in export_manager.py
- Implemented generic grammatical form handler for non-Lithuanian forms
- Added _generate_grammatical_form_label() method with French verb tenses, noun forms, and adjective gender forms
- Added grammar_metadata export to include gender and other grammatical properties from GrammarFact table (critical for French nouns)
- Updated command-line argument choices to include 'ko' and 'fr' options

French support includes:
- Gender metadata (masculine/feminine) via grammar_metadata field
- Verb conjugations (present, imperfect, future, conditional, subjunctive, perfect)
- Adjective forms with gender (masculine/feminine) and number (singular/plural)
- Noun forms (singular/plural)

Korean support:
- Basic export functionality with generic grammatical form handling
- No special character processing required (unlike Chinese pinyin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)