### PR TITLE
Log translation changes to operation log table

### DIFF
--- a/src/wordfreq/storage/crud/operation_log.py
+++ b/src/wordfreq/storage/crud/operation_log.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+
+"""CRUD operations for OperationLog model."""
+
+import json
+from typing import Optional
+
+from wordfreq.storage.models.operation_log import OperationLog
+
+
+def log_translation_change(
+    session,
+    source: str,
+    operation_type: str,
+    lemma_id: Optional[int] = None,
+    language_code: Optional[str] = None,
+    old_translation: Optional[str] = None,
+    new_translation: Optional[str] = None,
+    word_token_id: Optional[int] = None,
+    derivative_form_id: Optional[int] = None,
+    **extra_data
+) -> OperationLog:
+    """
+    Log a translation change operation.
+
+    Args:
+        session: Database session
+        source: Source of the operation (e.g., "voras-agent", "gpt-5-mini", "manual-import")
+        operation_type: Type of operation (e.g., "translation", "definition", "import")
+        lemma_id: ID of the lemma being modified
+        language_code: Language code of the translation (e.g., "fr", "es", "de")
+        old_translation: Previous translation value (None for new translations)
+        new_translation: New translation value (None for deletions)
+        word_token_id: Optional word token ID
+        derivative_form_id: Optional derivative form ID
+        **extra_data: Additional data to include in the fact JSON
+
+    Returns:
+        OperationLog object that was created
+    """
+    # Build the fact JSON
+    fact_data = {
+        "language_code": language_code,
+        "old_translation": old_translation,
+        "new_translation": new_translation,
+    }
+
+    # Add any extra data provided
+    fact_data.update(extra_data)
+
+    # Remove None values to keep JSON compact
+    fact_data = {k: v for k, v in fact_data.items() if v is not None}
+
+    # Create operation log entry
+    log_entry = OperationLog(
+        source=source,
+        operation_type=operation_type,
+        fact=json.dumps(fact_data),
+        lemma_id=lemma_id,
+        word_token_id=word_token_id,
+        derivative_form_id=derivative_form_id
+    )
+
+    session.add(log_entry)
+    session.flush()
+    return log_entry


### PR DESCRIPTION
Created a lightweight operation logging system that tracks all translation changes in the linguistics database. The system logs the agent/source, change type, old and new data, and timestamp for all translation operations.

Changes:
- Created src/wordfreq/storage/crud/operation_log.py with log_translation_change() helper function to track translation operations with minimal overhead
- Updated voras/agent.py set_translation() method to log all translation changes
- Updated voras/batch.py to log translation updates from batch processing
- Updated lemma.py add_lemma() and update_lemma() to log translation changes
- Updated translation query functions to log translation updates

The logging tracks:
- Source: agent name and model (e.g., "voras-agent/gpt-5-mini")
- Operation type: "translation"
- Language code: ISO language code (e.g., "fr", "es", "de")
- Old and new translation values
- Associated lemma_id for querying

All logged data is stored as lightweight JSON in the operation_logs table fact column, keeping the system performant and flexible.