### PR TITLE
Improve per-language difficulty level

### DIFF
--- a/docs/difficulty_overrides.md
+++ b/docs/difficulty_overrides.md
@@ -1,0 +1,177 @@
+# Per-Language Difficulty Level Overrides
+
+## Overview
+
+The Trakaido wordlist system now supports per-language difficulty level overrides. This allows different words to appear at different levels depending on the target language.
+
+For example:
+- 筷子 (chopsticks) can be level 2 in Chinese but level 10 in German
+- Words can be excluded from specific languages entirely using level `-1`
+
+## How It Works
+
+### Default Behavior
+Every `Lemma` has a `difficulty_level` field that serves as the default level across all languages.
+
+### Language-Specific Overrides
+The `LemmaDifficultyOverride` table stores language-specific exceptions:
+- `lemma_id`: References the lemma
+- `language_code`: Two-letter language code (e.g., 'zh', 'fr', 'de')
+- `difficulty_level`: Override level (1-20) or -1 to exclude
+- `notes`: Optional explanation for the override
+
+### Effective Difficulty Level
+When generating wordlists or exporting to WireWord format, the system:
+1. Checks for a language-specific override
+2. If found, uses the override level
+3. Otherwise, uses the default `difficulty_level`
+4. Excludes words with effective level of -1
+
+## Database Schema
+
+```sql
+CREATE TABLE lemma_difficulty_overrides (
+    id INTEGER PRIMARY KEY,
+    lemma_id INTEGER NOT NULL REFERENCES lemmas(id),
+    language_code TEXT NOT NULL,
+    difficulty_level INTEGER NOT NULL,
+    notes TEXT,
+    added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(lemma_id, language_code)
+);
+```
+
+## Usage
+
+### Managing Overrides with CLI Tool
+
+The `manage_difficulty_overrides.py` script provides a command-line interface:
+
+```bash
+# Set chopsticks to level 2 in Chinese
+python src/wordfreq/tools/manage_difficulty_overrides.py set N01_123 zh 2 \
+  --notes "Common eating utensil in Chinese culture"
+
+# Exclude a word from German wordlists
+python src/wordfreq/tools/manage_difficulty_overrides.py set N01_456 de -1 \
+  --notes "Not relevant for German learners"
+
+# View overrides for a specific word
+python src/wordfreq/tools/manage_difficulty_overrides.py view N01_123
+
+# List all overrides for Chinese
+python src/wordfreq/tools/manage_difficulty_overrides.py list zh
+
+# Import overrides from CSV
+python src/wordfreq/tools/manage_difficulty_overrides.py import overrides.csv
+
+# Export overrides to CSV
+python src/wordfreq/tools/manage_difficulty_overrides.py export \
+  --language zh --output zh_overrides.csv
+```
+
+### CSV Format for Bulk Import
+
+```csv
+guid,language_code,difficulty_level,notes
+N01_001,zh,2,"Chopsticks are common in Chinese"
+N01_001,de,10,"Less common in German culture"
+N05_042,fr,-1,"Not used in French"
+```
+
+### Programmatic Access
+
+```python
+from wordfreq.storage.crud.difficulty_override import (
+    add_difficulty_override,
+    get_effective_difficulty_level,
+    get_difficulty_override
+)
+
+# Add an override
+add_difficulty_override(
+    session=session,
+    lemma_id=lemma.id,
+    language_code='zh',
+    difficulty_level=2,
+    notes='Common word in Chinese'
+)
+
+# Get effective level for a language
+effective_level = get_effective_difficulty_level(session, lemma, 'zh')
+
+# Get a specific override
+override = get_difficulty_override(session, lemma.id, 'zh')
+```
+
+## Impact on Wordlist Generation
+
+### dict_generator.py
+The `get_lemmas_by_subtype_and_level()` function now:
+- Joins with `lemma_difficulty_overrides` table
+- Uses `COALESCE` to prefer override over default
+- Filters out words with level -1 for the target language
+
+### export_manager.py / export_wireword.py
+All export functions now:
+- Use effective difficulty levels when filtering
+- Exclude words marked with level -1
+- Include the effective level in exported data
+
+### ungurys.py (WireWord Export Agent)
+The agent automatically uses effective levels for each language when exporting wordlists.
+
+## Design Rationale
+
+### Why Overrides Instead of Separate Levels?
+- **Efficiency**: Most words use the default level
+- **Maintainability**: Only store exceptions, not redundant data
+- **Backward Compatibility**: Existing data continues to work
+- **Clustering**: Words of the same subtype still cluster by default
+
+### Why Level -1 for Exclusion?
+- Clear semantic meaning: "not included"
+- Allows filtering with simple SQL: `WHERE effective_level != -1`
+- Distinguished from NULL (level not set) vs. -1 (explicitly excluded)
+
+## Migration Notes
+
+### Updating Existing Code
+The changes are largely backward compatible:
+- Lemmas without overrides behave exactly as before
+- New filtering is transparent to most code
+
+### Populating Initial Overrides
+After deploying this feature:
+1. Review words that should differ by language
+2. Use the CLI tool or CSV import to add overrides
+3. Re-generate wordlists for affected languages
+
+## Examples of Good Override Candidates
+
+### Cultural Items
+- 筷子 (chopsticks): Early in Chinese/Korean, later in European languages
+- Kimchi: Early in Korean, later elsewhere
+- Baguette: Early in French, later elsewhere
+
+### False Friends / Overlapping Meanings
+- Lithuanian: eiti vs. vykti (both "to go")
+- Chinese: 能 vs. 可以 (both "can/able")
+- French: savoir vs. connaître (both "to know")
+
+One word might be taught early (default level 3), the other later (override to level 8) in the same language.
+
+### Technical or Specialized Terms
+Some technical terms might be:
+- Level 5 by default (general intermediate)
+- Level -1 in languages where they're not commonly used
+- Level 2 in languages where they're basic vocabulary
+
+## Future Enhancements
+
+Possible future improvements:
+- UI for managing overrides in a web interface
+- Automated suggestions based on frequency data per language
+- Batch operations by subtype or pattern
+- Override history/versioning for tracking changes

--- a/src/wordfreq/storage/crud/difficulty_override.py
+++ b/src/wordfreq/storage/crud/difficulty_override.py
@@ -1,0 +1,245 @@
+"""CRUD operations for LemmaDifficultyOverride model."""
+
+from typing import Optional, List, Dict
+from sqlalchemy import and_
+
+from wordfreq.storage.models.schema import LemmaDifficultyOverride, Lemma
+
+
+def add_difficulty_override(
+    session,
+    lemma_id: int,
+    language_code: str,
+    difficulty_level: int,
+    notes: Optional[str] = None
+) -> LemmaDifficultyOverride:
+    """
+    Add or update a difficulty level override for a lemma in a specific language.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code (e.g., 'zh', 'fr', 'de')
+        difficulty_level: Difficulty level (1-20) or -1 to exclude from language
+        notes: Optional notes explaining the override
+
+    Returns:
+        The created or updated LemmaDifficultyOverride
+    """
+    # Check if override already exists
+    existing = session.query(LemmaDifficultyOverride).filter(
+        and_(
+            LemmaDifficultyOverride.lemma_id == lemma_id,
+            LemmaDifficultyOverride.language_code == language_code
+        )
+    ).first()
+
+    if existing:
+        # Update existing override
+        existing.difficulty_level = difficulty_level
+        if notes is not None:
+            existing.notes = notes
+        session.flush()
+        return existing
+
+    # Create new override
+    override = LemmaDifficultyOverride(
+        lemma_id=lemma_id,
+        language_code=language_code,
+        difficulty_level=difficulty_level,
+        notes=notes
+    )
+    session.add(override)
+    session.flush()
+    return override
+
+
+def get_difficulty_override(
+    session,
+    lemma_id: int,
+    language_code: str
+) -> Optional[LemmaDifficultyOverride]:
+    """
+    Get a difficulty override for a specific lemma and language.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code
+
+    Returns:
+        LemmaDifficultyOverride if found, None otherwise
+    """
+    return session.query(LemmaDifficultyOverride).filter(
+        and_(
+            LemmaDifficultyOverride.lemma_id == lemma_id,
+            LemmaDifficultyOverride.language_code == language_code
+        )
+    ).first()
+
+
+def get_all_overrides_for_lemma(
+    session,
+    lemma_id: int
+) -> List[LemmaDifficultyOverride]:
+    """
+    Get all difficulty overrides for a specific lemma across all languages.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+
+    Returns:
+        List of LemmaDifficultyOverride objects
+    """
+    return session.query(LemmaDifficultyOverride).filter(
+        LemmaDifficultyOverride.lemma_id == lemma_id
+    ).all()
+
+
+def get_all_overrides_for_language(
+    session,
+    language_code: str
+) -> List[LemmaDifficultyOverride]:
+    """
+    Get all difficulty overrides for a specific language.
+
+    Args:
+        session: Database session
+        language_code: Language code
+
+    Returns:
+        List of LemmaDifficultyOverride objects
+    """
+    return session.query(LemmaDifficultyOverride).filter(
+        LemmaDifficultyOverride.language_code == language_code
+    ).all()
+
+
+def delete_difficulty_override(
+    session,
+    lemma_id: int,
+    language_code: str
+) -> bool:
+    """
+    Delete a difficulty override.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code
+
+    Returns:
+        True if an override was deleted, False if none existed
+    """
+    override = get_difficulty_override(session, lemma_id, language_code)
+    if override:
+        session.delete(override)
+        session.flush()
+        return True
+    return False
+
+
+def get_effective_difficulty_level(
+    session,
+    lemma: Lemma,
+    language_code: str
+) -> Optional[int]:
+    """
+    Get the effective difficulty level for a lemma in a specific language.
+
+    This checks for language-specific overrides first, then falls back to
+    the default difficulty_level on the lemma.
+
+    A return value of -1 means the word should be excluded from this language.
+    A return value of None means no difficulty level is set.
+
+    Args:
+        session: Database session
+        lemma: Lemma object
+        language_code: Language code (e.g., 'zh', 'fr', 'de')
+
+    Returns:
+        Effective difficulty level (1-20), -1 (excluded), or None (no level set)
+    """
+    # Check for override first
+    override = get_difficulty_override(session, lemma.id, language_code)
+    if override:
+        return override.difficulty_level
+
+    # Fall back to default difficulty level
+    return lemma.difficulty_level
+
+
+def get_lemmas_by_effective_level(
+    session,
+    language_code: str,
+    difficulty_level: int,
+    pos_type: Optional[str] = None,
+    pos_subtype: Optional[str] = None
+) -> List[Lemma]:
+    """
+    Get all lemmas that have a specific effective difficulty level in a language.
+
+    This considers both default levels and language-specific overrides.
+    Excludes lemmas with level -1 (excluded from language).
+
+    Args:
+        session: Database session
+        language_code: Language code
+        difficulty_level: Target difficulty level
+        pos_type: Optional filter by POS type
+        pos_subtype: Optional filter by POS subtype
+
+    Returns:
+        List of Lemma objects
+    """
+    # Start with base query
+    query = session.query(Lemma)
+
+    # Apply POS filters if provided
+    if pos_type:
+        query = query.filter(Lemma.pos_type == pos_type)
+    if pos_subtype:
+        query = query.filter(Lemma.pos_subtype == pos_subtype)
+
+    # Get all matching lemmas
+    all_lemmas = query.all()
+
+    # Filter by effective difficulty level
+    result = []
+    for lemma in all_lemmas:
+        effective_level = get_effective_difficulty_level(session, lemma, language_code)
+        if effective_level == difficulty_level:
+            result.append(lemma)
+
+    return result
+
+
+def bulk_add_overrides(
+    session,
+    overrides: List[Dict[str, any]]
+) -> int:
+    """
+    Bulk add or update difficulty overrides.
+
+    Args:
+        session: Database session
+        overrides: List of dicts with keys: lemma_id, language_code, difficulty_level, notes (optional)
+
+    Returns:
+        Number of overrides added/updated
+    """
+    count = 0
+    for override_data in overrides:
+        add_difficulty_override(
+            session=session,
+            lemma_id=override_data['lemma_id'],
+            language_code=override_data['language_code'],
+            difficulty_level=override_data['difficulty_level'],
+            notes=override_data.get('notes')
+        )
+        count += 1
+
+    session.flush()
+    return count

--- a/src/wordfreq/storage/models/__init__.py
+++ b/src/wordfreq/storage/models/__init__.py
@@ -1,6 +1,6 @@
 """Models package for wordfreq."""
 
-from wordfreq.storage.models.schema import Base, WordToken, Lemma, DerivativeForm, ExampleSentence, Corpus, WordFrequency
+from wordfreq.storage.models.schema import Base, WordToken, Lemma, LemmaTranslation, LemmaDifficultyOverride, DerivativeForm, ExampleSentence, Corpus, WordFrequency
 from wordfreq.storage.models.query_log import QueryLog
 from wordfreq.storage.models.operation_log import OperationLog
 from wordfreq.storage.models.translations import Translation, TranslationSet
@@ -11,6 +11,8 @@ __all__ = [
     'Base',
     'WordToken',
     'Lemma',
+    'LemmaTranslation',
+    'LemmaDifficultyOverride',
     'DerivativeForm',
     'ExampleSentence',
     'Corpus',
@@ -24,5 +26,5 @@ __all__ = [
     'VerbSubtype',
     'AdjectiveSubtype',
     'AdverbSubtype',
-    'GrammaticalForm',
+    'GrammarFact',
 ]

--- a/src/wordfreq/tools/manage_difficulty_overrides.py
+++ b/src/wordfreq/tools/manage_difficulty_overrides.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Utility script to manage per-language difficulty level overrides.
+
+This script allows you to:
+- Set difficulty level overrides for specific words in specific languages
+- View current overrides
+- Bulk import overrides from CSV
+- Examples:
+  - Mark "chopsticks" as level 2 in Chinese but level 10 in German
+  - Exclude words from specific languages (level -1)
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import List, Dict, Optional
+
+# Add src directory to path
+GREENLAND_SRC_PATH = str(Path(__file__).parent.parent.parent)
+if GREENLAND_SRC_PATH not in sys.path:
+    sys.path.insert(0, GREENLAND_SRC_PATH)
+
+import constants
+from wordfreq.storage.database import create_database_session
+from wordfreq.storage.models.schema import Lemma, LemmaDifficultyOverride
+from wordfreq.storage.crud.difficulty_override import (
+    add_difficulty_override,
+    get_difficulty_override,
+    get_all_overrides_for_lemma,
+    get_all_overrides_for_language,
+    delete_difficulty_override,
+    get_effective_difficulty_level
+)
+
+
+def set_override(session, guid: str, language_code: str, difficulty_level: int, notes: Optional[str] = None):
+    """Set a difficulty override for a lemma by GUID."""
+    # Find lemma by GUID
+    lemma = session.query(Lemma).filter(Lemma.guid == guid).first()
+    if not lemma:
+        print(f"❌ Error: No lemma found with GUID '{guid}'")
+        return False
+
+    # Add or update override
+    override = add_difficulty_override(
+        session=session,
+        lemma_id=lemma.id,
+        language_code=language_code,
+        difficulty_level=difficulty_level,
+        notes=notes
+    )
+
+    session.commit()
+
+    effective = get_effective_difficulty_level(session, lemma, language_code)
+    print(f"✅ Set override for '{lemma.lemma_text}' ({guid})")
+    print(f"   Language: {language_code}")
+    print(f"   Level: {difficulty_level} (default: {lemma.difficulty_level})")
+    print(f"   Effective level: {effective}")
+    if notes:
+        print(f"   Notes: {notes}")
+
+    return True
+
+
+def view_override(session, guid: str):
+    """View all overrides for a specific lemma."""
+    lemma = session.query(Lemma).filter(Lemma.guid == guid).first()
+    if not lemma:
+        print(f"❌ Error: No lemma found with GUID '{guid}'")
+        return
+
+    print(f"\n📊 Overrides for '{lemma.lemma_text}' ({guid})")
+    print(f"   Default level: {lemma.difficulty_level}")
+    print(f"   POS: {lemma.pos_type}/{lemma.pos_subtype}")
+    print()
+
+    overrides = get_all_overrides_for_lemma(session, lemma.id)
+    if not overrides:
+        print("   No language-specific overrides set.")
+        return
+
+    print("   Language-specific overrides:")
+    for override in overrides:
+        status = "EXCLUDED" if override.difficulty_level == -1 else f"Level {override.difficulty_level}"
+        print(f"   - {override.language_code}: {status}")
+        if override.notes:
+            print(f"     Notes: {override.notes}")
+
+
+def view_language_overrides(session, language_code: str, limit: int = 50):
+    """View all overrides for a specific language."""
+    overrides = get_all_overrides_for_language(session, language_code)
+
+    print(f"\n📊 Difficulty overrides for language: {language_code}")
+    print(f"   Total overrides: {len(overrides)}")
+
+    if not overrides:
+        print("   No overrides set for this language.")
+        return
+
+    print(f"\n   Showing first {min(limit, len(overrides))} overrides:")
+    print(f"   {'GUID':<15} {'Word':<25} {'Default':<8} {'Override':<10} {'Notes':<30}")
+    print(f"   {'-'*15} {'-'*25} {'-'*8} {'-'*10} {'-'*30}")
+
+    for i, override in enumerate(overrides[:limit]):
+        lemma = session.query(Lemma).filter(Lemma.id == override.lemma_id).first()
+        if lemma:
+            status = "EXCLUDED" if override.difficulty_level == -1 else str(override.difficulty_level)
+            word_text = lemma.lemma_text[:24] if len(lemma.lemma_text) <= 24 else lemma.lemma_text[:21] + "..."
+            notes_text = (override.notes or '')[:29] if override.notes else ''
+            print(f"   {lemma.guid:<15} {word_text:<25} {lemma.difficulty_level or 'N/A':<8} {status:<10} {notes_text:<30}")
+
+
+def remove_override(session, guid: str, language_code: str):
+    """Remove a difficulty override."""
+    lemma = session.query(Lemma).filter(Lemma.guid == guid).first()
+    if not lemma:
+        print(f"❌ Error: No lemma found with GUID '{guid}'")
+        return False
+
+    deleted = delete_difficulty_override(session, lemma.id, language_code)
+    session.commit()
+
+    if deleted:
+        print(f"✅ Removed override for '{lemma.lemma_text}' ({guid}) in language {language_code}")
+        print(f"   Will now use default level: {lemma.difficulty_level}")
+    else:
+        print(f"ℹ️  No override found for '{lemma.lemma_text}' ({guid}) in language {language_code}")
+
+    return deleted
+
+
+def bulk_import_csv(session, csv_path: str):
+    """
+    Bulk import overrides from CSV file.
+
+    CSV format:
+    guid,language_code,difficulty_level,notes
+    N01_001,zh,2,"Chopsticks are common in Chinese"
+    N01_001,de,10,
+    """
+    import_count = 0
+    error_count = 0
+
+    with open(csv_path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+
+        for row in reader:
+            guid = row.get('guid', '').strip()
+            language_code = row.get('language_code', '').strip()
+            difficulty_level_str = row.get('difficulty_level', '').strip()
+            notes = row.get('notes', '').strip() or None
+
+            if not guid or not language_code or not difficulty_level_str:
+                print(f"⚠️  Skipping row with missing data: {row}")
+                error_count += 1
+                continue
+
+            try:
+                difficulty_level = int(difficulty_level_str)
+            except ValueError:
+                print(f"⚠️  Invalid difficulty level '{difficulty_level_str}' for {guid}")
+                error_count += 1
+                continue
+
+            # Find lemma
+            lemma = session.query(Lemma).filter(Lemma.guid == guid).first()
+            if not lemma:
+                print(f"⚠️  No lemma found with GUID '{guid}'")
+                error_count += 1
+                continue
+
+            # Add override
+            try:
+                add_difficulty_override(
+                    session=session,
+                    lemma_id=lemma.id,
+                    language_code=language_code,
+                    difficulty_level=difficulty_level,
+                    notes=notes
+                )
+                import_count += 1
+            except Exception as e:
+                print(f"⚠️  Error adding override for {guid}: {e}")
+                error_count += 1
+
+    session.commit()
+    print(f"\n✅ Import complete!")
+    print(f"   Imported: {import_count}")
+    print(f"   Errors: {error_count}")
+
+
+def export_to_csv(session, language_code: Optional[str], output_path: str):
+    """Export overrides to CSV file."""
+    if language_code:
+        overrides = get_all_overrides_for_language(session, language_code)
+    else:
+        overrides = session.query(LemmaDifficultyOverride).all()
+
+    with open(output_path, 'w', encoding='utf-8', newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow(['guid', 'word', 'language_code', 'default_level', 'override_level', 'notes'])
+
+        for override in overrides:
+            lemma = session.query(Lemma).filter(Lemma.id == override.lemma_id).first()
+            if lemma:
+                writer.writerow([
+                    lemma.guid,
+                    lemma.lemma_text,
+                    override.language_code,
+                    lemma.difficulty_level or '',
+                    override.difficulty_level,
+                    override.notes or ''
+                ])
+
+    print(f"✅ Exported {len(overrides)} overrides to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Manage per-language difficulty level overrides',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Set chopsticks to level 2 in Chinese
+  %(prog)s set N01_123 zh 2 --notes "Common eating utensil"
+
+  # Exclude a word from German wordlists
+  %(prog)s set N01_456 de -1 --notes "Not relevant for German learners"
+
+  # View overrides for a specific word
+  %(prog)s view N01_123
+
+  # View all overrides for Chinese
+  %(prog)s list zh
+
+  # Import overrides from CSV
+  %(prog)s import overrides.csv
+
+  # Export overrides to CSV
+  %(prog)s export --language zh --output zh_overrides.csv
+        """
+    )
+
+    parser.add_argument('--db-path', help='Database path (uses default if not specified)')
+
+    subparsers = parser.add_subparsers(dest='command', help='Command to execute')
+
+    # Set command
+    set_parser = subparsers.add_parser('set', help='Set a difficulty override')
+    set_parser.add_argument('guid', help='Lemma GUID')
+    set_parser.add_argument('language', help='Language code (e.g., zh, fr, de)')
+    set_parser.add_argument('level', type=int, help='Difficulty level (1-20) or -1 to exclude')
+    set_parser.add_argument('--notes', help='Notes explaining the override')
+
+    # View command
+    view_parser = subparsers.add_parser('view', help='View overrides for a specific lemma')
+    view_parser.add_argument('guid', help='Lemma GUID')
+
+    # List command
+    list_parser = subparsers.add_parser('list', help='List all overrides for a language')
+    list_parser.add_argument('language', help='Language code')
+    list_parser.add_argument('--limit', type=int, default=50, help='Limit results (default: 50)')
+
+    # Remove command
+    remove_parser = subparsers.add_parser('remove', help='Remove a difficulty override')
+    remove_parser.add_argument('guid', help='Lemma GUID')
+    remove_parser.add_argument('language', help='Language code')
+
+    # Import command
+    import_parser = subparsers.add_parser('import', help='Bulk import from CSV')
+    import_parser.add_argument('csv_file', help='Path to CSV file')
+
+    # Export command
+    export_parser = subparsers.add_parser('export', help='Export overrides to CSV')
+    export_parser.add_argument('--language', help='Language code (exports all if not specified)')
+    export_parser.add_argument('--output', required=True, help='Output CSV file path')
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    # Create database session
+    try:
+        session = create_database_session(args.db_path) if args.db_path else create_database_session()
+        print("✅ Connected to wordfreq database")
+    except Exception as e:
+        print(f"❌ Failed to connect to database: {e}")
+        return
+
+    try:
+        if args.command == 'set':
+            set_override(session, args.guid, args.language, args.level, args.notes)
+        elif args.command == 'view':
+            view_override(session, args.guid)
+        elif args.command == 'list':
+            view_language_overrides(session, args.language, args.limit)
+        elif args.command == 'remove':
+            remove_override(session, args.guid, args.language)
+        elif args.command == 'import':
+            bulk_import_csv(session, args.csv_file)
+        elif args.command == 'export':
+            export_to_csv(session, args.language, args.output)
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        session.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements a flexible system for customizing Trakaido difficulty levels on a per-language basis, addressing the issue where words like 筷子 (chopsticks) should appear at different levels in different languages.

Key Features:
- Default difficulty_level on Lemma table remains unchanged
- New LemmaDifficultyOverride table stores language-specific exceptions
- Level -1 indicates word should be excluded from that language
- Effective level is override if exists, otherwise default
- Words with subtypes remain clustered by default

Schema Changes:
- Added LemmaDifficultyOverride model with lemma_id, language_code, difficulty_level, and notes fields
- Added relationship to Lemma model

Code Changes:
- Created CRUD operations for difficulty overrides
- Added get_effective_difficulty_level() helper function
- Updated get_lemmas_by_subtype_and_level() to use SQL COALESCE for efficient override lookups
- Updated export_manager.py query_trakaido_data() to filter by effective levels and exclude level -1 words
- Updated export_wireword.py to use effective levels in both noun and verb exports
- All level references in output now use effective levels

Tools:
- Created manage_difficulty_overrides.py CLI tool for:
  - Setting/removing overrides
  - Viewing overrides for words or languages
  - Bulk import/export via CSV

Documentation:
- Added comprehensive docs/difficulty_overrides.md explaining:
  - System design and rationale
  - Usage examples
  - Migration notes
  - Good candidates for overrides

This allows language-specific customization while maintaining the default clustering behavior for most words.