### PR TITLE
Add agents support to BARSUKAS web server

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -16,7 +16,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 
 from config import Config
-from routes import lemmas, translations, overrides, agents, operation_logs, wireword, api
+from routes import lemmas, translations, overrides, agents, operation_logs, wireword, api, agents_launcher
 from wordfreq.storage.utils.session import ensure_tables_exist
 
 
@@ -43,6 +43,7 @@ def create_app(config_class=Config):
     app.register_blueprint(translations.bp)
     app.register_blueprint(overrides.bp)
     app.register_blueprint(agents.bp)
+    app.register_blueprint(agents_launcher.bp)
     app.register_blueprint(operation_logs.bp)
     app.register_blueprint(wireword.bp)
     app.register_blueprint(api.bp)

--- a/src/barsukas/routes/agents_launcher.py
+++ b/src/barsukas/routes/agents_launcher.py
@@ -1,0 +1,273 @@
+#!/usr/bin/python3
+
+"""Routes for listing and launching autonomous agents."""
+
+from flask import Blueprint, render_template, request, jsonify, flash, redirect, url_for, g
+import subprocess
+import os
+from pathlib import Path
+from config import Config
+
+bp = Blueprint('agents_launcher', __name__, url_prefix='/agents-launcher')
+
+# Define all agents in order from the README
+AGENTS = [
+    {
+        'name': 'PRADZIA',
+        'display_name': 'Pradzia',
+        'subtitle': 'Database Initialization',
+        'description': 'Initializes and maintains the wordfreq database, including corpus configuration synchronization, data loading, and rank calculation.',
+        'script': 'pradzia.py',
+        'icon': 'bi-play-circle',
+        'modes': [
+            {'label': 'Check Status', 'args': '--check', 'description': 'Check configuration and database state without making changes'},
+            {'label': 'Sync Config', 'args': '--sync-config', 'description': 'Synchronize corpus configurations from config file to database'},
+            {'label': 'Load Corpora', 'args': '--load', 'description': 'Load all enabled corpora'},
+            {'label': 'Calculate Ranks', 'args': '--calc-ranks', 'description': 'Calculate combined ranks for all words'},
+            {'label': 'Full Init', 'args': '--init-full', 'description': 'Perform complete database initialization'},
+        ],
+        'show_if_empty': True  # Only show if database is empty
+    },
+    {
+        'name': 'LOKYS',
+        'display_name': 'Lokys',
+        'subtitle': 'English Lemma Validation',
+        'description': 'Validates English-language properties including lemma forms, definitions, and POS types.',
+        'script': 'lokys.py',
+        'icon': 'bi-check-circle',
+        'modes': [
+            {'label': 'Run Validation', 'args': '', 'description': 'Validate all English lemmas'},
+            {'label': 'Sample Check', 'args': '--sample-rate 0.1', 'description': 'Check 10% sample of lemmas'},
+        ],
+    },
+    {
+        'name': 'DRAMBLYS',
+        'display_name': 'Dramblys',
+        'subtitle': 'Missing Words Detector',
+        'description': 'Identifies missing words that should be in the dictionary by scanning frequency corpora.',
+        'script': 'dramblys.py',
+        'icon': 'bi-search',
+        'modes': [
+            {'label': 'Check All', 'args': '--check all', 'description': 'Run all checks (reporting only)'},
+            {'label': 'Check Frequency', 'args': '--check frequency', 'description': 'Find high-frequency words missing from database'},
+            {'label': 'Fix Missing', 'args': '--fix', 'description': 'Process high-frequency missing words using LLM'},
+        ],
+    },
+    {
+        'name': 'BEBRAS',
+        'display_name': 'Bebras',
+        'subtitle': 'Database Integrity Checker',
+        'description': 'Ensures database structural integrity by identifying orphaned records, missing fields, and constraint violations.',
+        'script': 'bebras.py',
+        'icon': 'bi-shield-check',
+        'modes': [
+            {'label': 'Check All', 'args': '--check all', 'description': 'Run all integrity checks'},
+            {'label': 'Check Orphaned', 'args': '--check orphaned', 'description': 'Find orphaned records'},
+            {'label': 'Check Missing Fields', 'args': '--check missing-fields', 'description': 'Find records with missing required fields'},
+        ],
+    },
+    {
+        'name': 'VORAS',
+        'display_name': 'Voras',
+        'subtitle': 'Translation Validator',
+        'description': 'Validates multi-lingual translations for correctness and proper lemma form, reports on coverage.',
+        'script': 'voras.py',
+        'icon': 'bi-globe',
+        'modes': [
+            {'label': 'Coverage Report', 'args': '--mode coverage', 'description': 'Report on translation coverage (no LLM calls)'},
+            {'label': 'Check Only', 'args': '--mode check-only', 'description': 'Validate existing translations'},
+            {'label': 'Populate Only', 'args': '--mode populate-only', 'description': 'Add missing translations'},
+            {'label': 'Check & Populate', 'args': '--mode both', 'description': 'Validate and populate translations'},
+        ],
+    },
+    {
+        'name': 'VILKAS',
+        'display_name': 'Vilkas',
+        'subtitle': 'Word Forms Checker',
+        'description': 'Monitors the presence and completeness of word forms across multiple languages.',
+        'script': 'vilkas.py',
+        'icon': 'bi-pencil-square',
+        'modes': [
+            {'label': 'Check All', 'args': '--check all', 'description': 'Run all checks and generate report'},
+            {'label': 'Fix Forms', 'args': '--fix', 'description': 'Generate missing word forms'},
+        ],
+    },
+    {
+        'name': 'PAPUGA',
+        'display_name': 'Papuga',
+        'subtitle': 'Pronunciation Validator',
+        'description': 'Validates and generates pronunciations (IPA and simplified phonetic) for derivative forms.',
+        'script': 'papuga.py',
+        'icon': 'bi-mic',
+        'modes': [
+            {'label': 'Check Pronunciations', 'args': '--check', 'description': 'Validate existing pronunciations'},
+            {'label': 'Populate Missing', 'args': '--populate', 'description': 'Generate missing pronunciations'},
+            {'label': 'Check & Populate', 'args': '--both', 'description': 'Validate and populate pronunciations'},
+        ],
+    },
+    {
+        'name': 'ZVIRBLIS',
+        'display_name': 'Žvirblis',
+        'subtitle': 'Sentence Generator',
+        'description': 'Generates example sentences for vocabulary words using LLM, with automatic difficulty calculation.',
+        'script': 'zvirblis.py',
+        'icon': 'bi-chat-quote',
+        'modes': [
+            {'label': 'Generate by GUID', 'args': '--guid', 'description': 'Generate sentences for specific word by GUID', 'requires_input': True, 'input_placeholder': 'Enter GUID (e.g., N07_008)'},
+            {'label': 'Generate by Level', 'args': '--level', 'description': 'Generate sentences for all nouns at difficulty level', 'requires_input': True, 'input_placeholder': 'Enter level (1-20)'},
+        ],
+    },
+    {
+        'name': 'POVAS',
+        'display_name': 'Povas',
+        'subtitle': 'HTML Generator',
+        'description': 'Generates static HTML pages displaying words organized by part-of-speech subtypes.',
+        'script': 'povas.py',
+        'icon': 'bi-file-earmark-code',
+        'modes': [
+            {'label': 'Generate All', 'args': '', 'description': 'Generate all POS subtype HTML pages'},
+            {'label': 'Index Only', 'args': '--index-only', 'description': 'Generate only the index page'},
+        ],
+    },
+    {
+        'name': 'UNGURYS',
+        'display_name': 'Ungurys',
+        'subtitle': 'WireWord Export',
+        'description': 'Exports word data to WireWord API format for external system integration.',
+        'script': 'ungurys.py',
+        'icon': 'bi-cloud-download',
+        'redirect_to': 'wireword.export_page',  # Redirect to existing wireword export page
+    },
+]
+
+
+def check_database_empty():
+    """Check if the database is empty or if key tables are empty."""
+    from wordfreq.storage.models.schema import Lemma, WordToken
+
+    try:
+        # Check if we have any lemmas or word tokens
+        lemma_count = g.db.query(Lemma).count()
+        token_count = g.db.query(WordToken).count()
+
+        return lemma_count == 0 or token_count == 0
+    except Exception as e:
+        # If we can't query, assume database needs initialization
+        return True
+
+
+@bp.route('/')
+def list_agents():
+    """Display the list of available agents."""
+    # Check if database is empty to determine PRADZIA visibility
+    db_empty = check_database_empty()
+
+    # Filter agents based on database state
+    visible_agents = []
+    for agent in AGENTS:
+        # Show PRADZIA only if database is empty
+        if agent.get('show_if_empty'):
+            if db_empty:
+                visible_agents.append(agent)
+        else:
+            # Show all other agents only if database is NOT empty
+            if not db_empty:
+                visible_agents.append(agent)
+
+    return render_template('agents_launcher/list.html',
+                         agents=visible_agents,
+                         db_empty=db_empty)
+
+
+@bp.route('/launch/<agent_name>', methods=['GET'])
+def launch_form(agent_name):
+    """Display the launch form for a specific agent."""
+    # Find the agent
+    agent = next((a for a in AGENTS if a['name'] == agent_name), None)
+    if not agent:
+        flash(f'Agent {agent_name} not found', 'error')
+        return redirect(url_for('agents_launcher.list_agents'))
+
+    # If agent has redirect_to, redirect there
+    if 'redirect_to' in agent:
+        return redirect(url_for(agent['redirect_to']))
+
+    return render_template('agents_launcher/launch.html', agent=agent)
+
+
+@bp.route('/execute/<agent_name>', methods=['POST'])
+def execute_agent(agent_name):
+    """Execute an agent with specified parameters (async)."""
+    # Find the agent
+    agent = next((a for a in AGENTS if a['name'] == agent_name), None)
+    if not agent:
+        return jsonify({'success': False, 'error': f'Agent {agent_name} not found'}), 404
+
+    # Get parameters from form
+    mode = request.form.get('mode', '')
+    custom_args = request.form.get('custom_args', '')
+    dry_run = request.form.get('dry_run') == 'true'
+
+    # Build command
+    agents_dir = Path(Config.DB_PATH).parent.parent / 'agents'
+    script_path = agents_dir / agent['script']
+
+    if not script_path.exists():
+        return jsonify({'success': False, 'error': f'Script not found: {script_path}'}), 404
+
+    # Build arguments
+    args = ['python3', str(script_path)]
+
+    # Add mode arguments if provided
+    if mode:
+        # Find the mode in agent config
+        mode_config = next((m for m in agent.get('modes', []) if m['label'] == mode), None)
+        if mode_config and mode_config['args']:
+            args.extend(mode_config['args'].split())
+
+    # Add custom arguments
+    if custom_args:
+        args.extend(custom_args.split())
+
+    # Add dry-run flag if requested
+    if dry_run:
+        args.append('--dry-run')
+
+    # Add database path
+    args.extend(['--db-path', Config.DB_PATH])
+
+    try:
+        # Execute asynchronously (non-blocking)
+        # Note: In production, you'd want to use Celery or similar
+        # For now, we'll run in background and return immediately
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+
+        # For now, wait for completion (in production, make this truly async)
+        stdout, stderr = process.communicate(timeout=300)  # 5 min timeout
+
+        success = process.returncode == 0
+
+        return jsonify({
+            'success': success,
+            'stdout': stdout,
+            'stderr': stderr,
+            'returncode': process.returncode
+        })
+
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return jsonify({
+            'success': False,
+            'error': 'Agent execution timed out (5 minutes)',
+            'timeout': True
+        }), 408
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500

--- a/src/barsukas/templates/agents_launcher/launch.html
+++ b/src/barsukas/templates/agents_launcher/launch.html
@@ -1,0 +1,218 @@
+{% extends "base.html" %}
+
+{% block title %}Launch {{ agent.display_name }}{% endblock %}
+
+{% block content %}
+<div class="py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="{{ url_for('agents_launcher.list_agents') }}">Agents</a></li>
+            <li class="breadcrumb-item active">{{ agent.display_name }}</li>
+        </ol>
+    </nav>
+
+    <h1><i class="{{ agent.icon }}"></i> {{ agent.display_name }}</h1>
+    <p class="lead">{{ agent.subtitle }}</p>
+    <p>{{ agent.description }}</p>
+
+    <hr class="my-4">
+
+    <div class="card">
+        <div class="card-body">
+            <h5 class="card-title">Launch Agent</h5>
+
+            <form id="launchForm">
+                <!-- Mode Selection -->
+                <div class="mb-3">
+                    <label for="mode" class="form-label">Select Mode</label>
+                    <select class="form-select" id="mode" name="mode">
+                        <option value="">-- Select a mode --</option>
+                        {% for mode in agent.modes %}
+                        <option value="{{ mode.label }}"
+                                data-requires-input="{{ 'true' if mode.get('requires_input') else 'false' }}"
+                                data-input-placeholder="{{ mode.get('input_placeholder', '') }}">
+                            {{ mode.label }} - {{ mode.description }}
+                        </option>
+                        {% endfor %}
+                    </select>
+                </div>
+
+                <!-- Dynamic Input (for modes that require input like GUID or level) -->
+                <div class="mb-3" id="modeInputContainer" style="display: none;">
+                    <label for="modeInput" class="form-label" id="modeInputLabel">Input</label>
+                    <input type="text" class="form-control" id="modeInput" name="mode_input" placeholder="">
+                </div>
+
+                <!-- Custom Arguments -->
+                <div class="mb-3">
+                    <label for="customArgs" class="form-label">Additional Arguments (optional)</label>
+                    <input type="text" class="form-control" id="customArgs" name="custom_args"
+                           placeholder="e.g., --limit 10 --yes">
+                    <div class="form-text">
+                        Add any additional command-line arguments. Use --help to see all available options.
+                    </div>
+                </div>
+
+                <!-- Dry Run Option -->
+                <div class="form-check mb-3">
+                    <input class="form-check-input" type="checkbox" id="dryRun" name="dry_run" value="true">
+                    <label class="form-check-label" for="dryRun">
+                        Dry run (show what would be done without making changes)
+                    </label>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary" id="launchBtn">
+                        <i class="bi bi-play-circle"></i> Launch Agent
+                    </button>
+                    <a href="{{ url_for('agents_launcher.list_agents') }}" class="btn btn-secondary">
+                        <i class="bi bi-arrow-left"></i> Back to Agents
+                    </a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Output Display -->
+    <div id="outputContainer" style="display: none;" class="mt-4">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">
+                    <i class="bi bi-terminal"></i> Agent Output
+                    <span id="statusBadge" class="badge ms-2"></span>
+                </h5>
+            </div>
+            <div class="card-body">
+                <div id="outputContent"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+#outputContent pre {
+    background: #f8f9fa;
+    padding: 15px;
+    border-radius: 5px;
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.spinner-border {
+    width: 1rem;
+    height: 1rem;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('launchForm');
+    const modeSelect = document.getElementById('mode');
+    const modeInputContainer = document.getElementById('modeInputContainer');
+    const modeInput = document.getElementById('modeInput');
+    const modeInputLabel = document.getElementById('modeInputLabel');
+    const launchBtn = document.getElementById('launchBtn');
+    const outputContainer = document.getElementById('outputContainer');
+    const outputContent = document.getElementById('outputContent');
+    const statusBadge = document.getElementById('statusBadge');
+
+    // Handle mode selection - show/hide input based on mode requirements
+    modeSelect.addEventListener('change', function() {
+        const selectedOption = this.options[this.selectedIndex];
+        const requiresInput = selectedOption.getAttribute('data-requires-input') === 'true';
+        const placeholder = selectedOption.getAttribute('data-input-placeholder');
+
+        if (requiresInput) {
+            modeInputContainer.style.display = 'block';
+            modeInput.placeholder = placeholder;
+            modeInput.required = true;
+        } else {
+            modeInputContainer.style.display = 'none';
+            modeInput.required = false;
+            modeInput.value = '';
+        }
+    });
+
+    // Handle form submission
+    form.addEventListener('submit', async function(e) {
+        e.preventDefault();
+
+        // Validate mode selection
+        if (!modeSelect.value) {
+            alert('Please select a mode');
+            return;
+        }
+
+        // Show loading state
+        launchBtn.disabled = true;
+        launchBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span>Launching...';
+        outputContainer.style.display = 'none';
+
+        // Build form data
+        const formData = new FormData();
+        formData.append('mode', modeSelect.value);
+        formData.append('dry_run', document.getElementById('dryRun').checked);
+
+        // Add custom args with mode input if provided
+        let customArgs = document.getElementById('customArgs').value;
+        if (modeInput.value) {
+            customArgs = modeInput.value + (customArgs ? ' ' + customArgs : '');
+        }
+        formData.append('custom_args', customArgs);
+
+        try {
+            // Execute agent
+            const response = await fetch('{{ url_for("agents_launcher.execute_agent", agent_name=agent.name) }}', {
+                method: 'POST',
+                body: formData
+            });
+
+            const result = await response.json();
+
+            // Show output
+            outputContainer.style.display = 'block';
+
+            if (result.success) {
+                statusBadge.className = 'badge bg-success';
+                statusBadge.textContent = 'Success';
+                outputContent.innerHTML = `<pre>${escapeHtml(result.stdout)}</pre>`;
+            } else {
+                statusBadge.className = 'badge bg-danger';
+                statusBadge.textContent = 'Error';
+                outputContent.innerHTML = `
+                    <div class="alert alert-danger">
+                        <strong>Error:</strong> ${escapeHtml(result.error || 'Unknown error')}
+                    </div>
+                    ${result.stdout ? '<h6>Standard Output:</h6><pre>' + escapeHtml(result.stdout) + '</pre>' : ''}
+                    ${result.stderr ? '<h6>Error Output:</h6><pre>' + escapeHtml(result.stderr) + '</pre>' : ''}
+                `;
+            }
+
+            // Scroll to output
+            outputContainer.scrollIntoView({ behavior: 'smooth' });
+
+        } catch (error) {
+            outputContainer.style.display = 'block';
+            statusBadge.className = 'badge bg-danger';
+            statusBadge.textContent = 'Error';
+            outputContent.innerHTML = `
+                <div class="alert alert-danger">
+                    <strong>Error:</strong> ${escapeHtml(error.message)}
+                </div>
+            `;
+        } finally {
+            // Reset button
+            launchBtn.disabled = false;
+            launchBtn.innerHTML = '<i class="bi bi-play-circle"></i> Launch Agent';
+        }
+    });
+
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+});
+</script>
+{% endblock %}

--- a/src/barsukas/templates/agents_launcher/list.html
+++ b/src/barsukas/templates/agents_launcher/list.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}Agents{% endblock %}
+
+{% block content %}
+<div class="py-4">
+    <h1><i class="bi bi-robot"></i> Autonomous Agents</h1>
+    <p class="lead">Launch data quality and maintenance agents for the wordfreq database</p>
+
+    {% if db_empty %}
+    <div class="alert alert-warning">
+        <i class="bi bi-exclamation-triangle"></i>
+        <strong>Database is empty or not initialized.</strong>
+        Run the PRADZIA agent to initialize the database before using other agents.
+    </div>
+    {% endif %}
+
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mt-2">
+        {% for agent in agents %}
+        <div class="col">
+            <div class="card h-100 agent-card">
+                <div class="card-body">
+                    <h5 class="card-title">
+                        <i class="{{ agent.icon }}"></i>
+                        {{ agent.display_name }}
+                        {% if agent.show_if_empty %}
+                        <span class="badge bg-primary ms-2">Init Required</span>
+                        {% endif %}
+                    </h5>
+                    <h6 class="card-subtitle mb-2 text-muted">{{ agent.subtitle }}</h6>
+                    <p class="card-text">{{ agent.description }}</p>
+                </div>
+                <div class="card-footer bg-transparent">
+                    {% if agent.redirect_to %}
+                        <a href="{{ url_for(agent.redirect_to) }}" class="btn btn-primary">
+                            <i class="bi bi-arrow-right-circle"></i> Open Export Page
+                        </a>
+                    {% else %}
+                        <a href="{{ url_for('agents_launcher.launch_form', agent_name=agent.name) }}"
+                           class="btn btn-primary">
+                            <i class="bi bi-play-circle"></i> Launch Agent
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    {% if not agents %}
+    <div class="alert alert-info mt-4">
+        <i class="bi bi-info-circle"></i>
+        {% if db_empty %}
+        Initialize the database first by running the PRADZIA agent.
+        {% else %}
+        All agents are available. Database is initialized.
+        {% endif %}
+    </div>
+    {% endif %}
+</div>
+
+<style>
+.agent-card {
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.agent-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+}
+
+.agent-card .card-title {
+    color: #0d6efd;
+}
+</style>
+{% endblock %}

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -37,8 +37,8 @@
                         </a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{{ url_for('wireword.export_page') }}">
-                            <i class="bi bi-cloud-download"></i> WireWord Export
+                        <a class="nav-link" href="{{ url_for('agents_launcher.list_agents') }}">
+                            <i class="bi bi-robot"></i> Agents
                         </a>
                     </li>
                     <li class="nav-item">


### PR DESCRIPTION
Replace "WireWord Export" in navigation with "Agents" tab that lists all autonomous agents from the README in order. Features:

- New agents_launcher blueprint with listing and launch functionality
- Agents displayed as cards with descriptions and modes
- PRADZIA only shown if database is empty/uninitialized
- Each agent has multiple execution modes with web form for parameters
- UNGURYS redirects to existing WireWord export page
- Async agent execution with output display
- Support for dry-run mode and custom command-line arguments

All 10 agents are supported: PRADZIA, LOKYS, DRAMBLYS, BEBRAS, VORAS, VILKAS, PAPUGA, ŽVIRBLIS, POVAS, and UNGURYS.