### PR TITLE
Add Pinyin transliteration to Chinese words

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from config import Config
 from routes import lemmas, translations, overrides, agents, operation_logs, wireword, api, agents_launcher
 from wordfreq.storage.utils.session import ensure_tables_exist
+from pinyin_helper import generate_pinyin, generate_pinyin_ruby_html, is_chinese
 
 
 def create_app(config_class=Config):
@@ -47,6 +48,11 @@ def create_app(config_class=Config):
     app.register_blueprint(operation_logs.bp)
     app.register_blueprint(wireword.bp)
     app.register_blueprint(api.bp)
+
+    # Register Jinja2 filters for Pinyin
+    app.jinja_env.filters['pinyin'] = generate_pinyin
+    app.jinja_env.filters['pinyin_ruby'] = generate_pinyin_ruby_html
+    app.jinja_env.filters['is_chinese'] = is_chinese
 
     @app.before_request
     def before_request():

--- a/src/barsukas/pinyin_helper.py
+++ b/src/barsukas/pinyin_helper.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""
+Pinyin helper module for converting Chinese text to Pinyin.
+
+This module provides utilities for generating Pinyin transliterations
+with graceful degradation if pypinyin is not available.
+"""
+
+import re
+from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Try to import pypinyin, gracefully handle if not available
+try:
+    from pypinyin import lazy_pinyin, Style
+    PYPINYIN_AVAILABLE = True
+except ImportError:
+    PYPINYIN_AVAILABLE = False
+    logger.warning("pypinyin not available - Chinese pinyin transliteration will be disabled")
+
+
+def is_chinese(text: str) -> bool:
+    """
+    Check if the text contains Chinese characters.
+
+    Args:
+        text: Text to check
+
+    Returns:
+        True if text contains Chinese characters, False otherwise
+    """
+    if not text:
+        return False
+    # Check for CJK Unified Ideographs range
+    return bool(re.search(r'[\u4e00-\u9fff]', text))
+
+
+def generate_pinyin(chinese_text: str) -> Optional[str]:
+    """
+    Generate pinyin for Chinese text with tone marks.
+
+    Args:
+        chinese_text: Chinese text to convert to pinyin
+
+    Returns:
+        Pinyin string with tone marks (e.g., "nǐ hǎo"), or None if:
+        - pypinyin is not available
+        - text is empty
+        - text doesn't contain Chinese characters
+    """
+    if not PYPINYIN_AVAILABLE or not chinese_text:
+        return None
+
+    # Only generate pinyin if text actually contains Chinese characters
+    if not is_chinese(chinese_text):
+        return None
+
+    try:
+        # Use Style.TONE to get pinyin with tone marks (e.g., "nǐ hǎo")
+        pinyin_list = lazy_pinyin(chinese_text, style=Style.TONE)
+        return ' '.join(pinyin_list)
+    except Exception as e:
+        logger.warning(f"Failed to generate pinyin for '{chinese_text}': {e}")
+        return None
+
+
+def generate_pinyin_ruby_html(chinese_text: str) -> str:
+    """
+    Generate HTML with ruby annotations for Chinese text with Pinyin.
+
+    This creates elegant ruby text similar to Japanese furigana, with Pinyin
+    displayed above each Chinese character.
+
+    Args:
+        chinese_text: Chinese text to annotate with pinyin
+
+    Returns:
+        HTML string with <ruby> tags, or plain text if:
+        - pypinyin is not available
+        - text doesn't contain Chinese characters
+
+    Example:
+        Input: "你好"
+        Output: '<ruby>你<rt>nǐ</rt></ruby><ruby>好<rt>hǎo</rt></ruby>'
+    """
+    if not PYPINYIN_AVAILABLE or not chinese_text:
+        return chinese_text
+
+    # Only generate ruby text if text contains Chinese characters
+    if not is_chinese(chinese_text):
+        return chinese_text
+
+    try:
+        # Generate pinyin for each character separately
+        result = []
+        for char in chinese_text:
+            if is_chinese(char):
+                # Get pinyin for this character
+                pinyin_list = lazy_pinyin(char, style=Style.TONE)
+                if pinyin_list:
+                    pinyin = pinyin_list[0]
+                    result.append(f'<ruby>{char}<rt>{pinyin}</rt></ruby>')
+                else:
+                    result.append(char)
+            else:
+                # Non-Chinese character (punctuation, space, etc.)
+                result.append(char)
+
+        return ''.join(result)
+    except Exception as e:
+        logger.warning(f"Failed to generate ruby HTML for '{chinese_text}': {e}")
+        return chinese_text

--- a/src/barsukas/requirements.txt
+++ b/src/barsukas/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 SQLAlchemy==2.0.23
+pypinyin==0.52.0

--- a/src/barsukas/static/style.css
+++ b/src/barsukas/static/style.css
@@ -141,3 +141,46 @@ body {
     font-family: monospace;
     font-size: 0.85rem;
 }
+
+/* Pinyin Ruby Text Styling */
+/* Elegant, minimal display inspired by Japanese furigana */
+
+ruby {
+    ruby-align: center;
+    ruby-position: over;
+}
+
+rt {
+    font-size: 0.5em;
+    color: #6c757d;
+    font-weight: normal;
+    letter-spacing: 0.05em;
+    line-height: 1.2;
+}
+
+/* Ensure proper spacing for Chinese text with pinyin */
+.chinese-with-pinyin ruby {
+    display: inline-block;
+    margin-right: 0.1em;
+}
+
+/* Make pinyin slightly larger in headings for better readability */
+h1 ruby rt, h2 ruby rt, h3 ruby rt {
+    font-size: 0.4em;
+}
+
+/* Ensure pinyin doesn't get too large in very small text */
+.small ruby rt, small ruby rt {
+    font-size: 0.6em;
+}
+
+/* Optional: Add a subtle separator line between Chinese and pinyin */
+ruby.with-separator {
+    position: relative;
+}
+
+ruby.with-separator rt {
+    border-top: 1px solid rgba(108, 117, 125, 0.2);
+    padding-top: 0.1em;
+    margin-top: 0.1em;
+}

--- a/src/barsukas/templates/agents/sentence_generation_results.html
+++ b/src/barsukas/templates/agents/sentence_generation_results.html
@@ -67,7 +67,7 @@
                     {% for translation in sentence.translations|sort(attribute='language_code') %}
                         <div class="mb-2">
                             <strong class="text-uppercase">{{ translation.language_code }}:</strong>
-                            <span class="ms-2">{{ translation.translation_text }}</span>
+                            <span class="ms-2 chinese-with-pinyin">{{ translation.translation_text|pinyin_ruby|safe }}</span>
                             {% if not translation.verified %}
                                 <small class="text-muted">(unverified)</small>
                             {% endif %}

--- a/src/barsukas/templates/agents/view_sentences.html
+++ b/src/barsukas/templates/agents/view_sentences.html
@@ -82,7 +82,7 @@
                     {% for translation in sentence.translations|sort(attribute='language_code') %}
                         <div class="mb-2">
                             <strong class="text-uppercase text-primary">{{ translation.language_code }}:</strong>
-                            <span class="ms-2">{{ translation.translation_text }}</span>
+                            <span class="ms-2 chinese-with-pinyin">{{ translation.translation_text|pinyin_ruby|safe }}</span>
                             {% if not translation.verified %}
                                 <small class="text-muted">(unverified)</small>
                             {% endif %}

--- a/src/barsukas/templates/lemmas/view.html
+++ b/src/barsukas/templates/lemmas/view.html
@@ -261,7 +261,7 @@
                                 <td><strong>{{ lang_name }}</strong> <small class="text-muted">({{ lang_code }})</small></td>
                                 <td>
                                     {% if translations[lang_code] %}
-                                        {{ translations[lang_code] }}
+                                        <span class="chinese-with-pinyin">{{ translations[lang_code]|pinyin_ruby|safe }}</span>
                                         {% if '/' in translations[lang_code] %}
                                             <span class="badge bg-warning text-dark" title="Contains slash">
                                                 <i class="bi bi-exclamation-triangle"></i>


### PR DESCRIPTION
This commit adds elegant Pinyin (拼音) transliteration display for Chinese text throughout the BARSUKAS web interface, using HTML ruby annotations inspired by Japanese furigana.

Changes:
- Add pypinyin library to requirements.txt for Chinese-to-Pinyin conversion
- Create pinyin_helper.py module with graceful degradation if pypinyin unavailable
  - generate_pinyin(): converts Chinese text to Pinyin with tone marks
  - generate_pinyin_ruby_html(): creates HTML ruby annotations for display
  - is_chinese(): detects Chinese characters in text
- Register Jinja2 template filters in app.py (pinyin, pinyin_ruby, is_chinese)
- Add elegant CSS styling for ruby text in style.css
  - Minimal, clean design at 0.5em size with subtle gray color
  - Responsive sizing for headings and small text
  - Optional separator line variant
- Update templates to display Pinyin above Chinese characters:
  - lemmas/view.html: translation table
  - agents/view_sentences.html: sentence translations
  - agents/sentence_generation_results.html: sentence translations

The implementation gracefully handles non-Chinese text and missing pypinyin, displaying text normally when Pinyin cannot be generated.

Example output: 你(nǐ) 好(hǎo) with Pinyin rendered above each character.