### PR TITLE
Add support for synonym generation

### DIFF
--- a/src/barsukas/routes/agents_launcher.py
+++ b/src/barsukas/routes/agents_launcher.py
@@ -69,6 +69,15 @@ AGENTS = [
         'use_dynamic_form': True,
     },
     {
+        'name': 'SERNAS',
+        'display_name': 'Šernas',
+        'subtitle': 'Synonym Generator',
+        'description': 'Generates synonyms and alternative forms for vocabulary words across all supported languages.',
+        'script': 'sernas.py',
+        'icon': 'bi-shuffle',
+        'use_dynamic_form': True,
+    },
+    {
         'name': 'PAPUGA',
         'display_name': 'Papuga',
         'subtitle': 'Pronunciation Validator',

--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -227,12 +227,31 @@ def view_lemma(lemma_id):
         DerivativeForm.grammatical_form
     ).all()
 
-    # Group forms by language
+    # Group forms by language and type
     forms_by_language = {}
+    synonyms_by_language = {}
+    alternative_forms_by_language = {}
+
     for form in derivative_forms:
-        if form.language_code not in forms_by_language:
-            forms_by_language[form.language_code] = []
-        forms_by_language[form.language_code].append(form)
+        lang_code = form.language_code
+
+        # Separate synonyms and alternative forms
+        if form.grammatical_form == 'synonym':
+            if lang_code not in synonyms_by_language:
+                synonyms_by_language[lang_code] = []
+            synonyms_by_language[lang_code].append(form)
+        elif form.grammatical_form == 'alternative_form':
+            if lang_code not in alternative_forms_by_language:
+                alternative_forms_by_language[lang_code] = []
+            alternative_forms_by_language[lang_code].append(form)
+        else:
+            # Regular grammatical forms (conjugations, declensions, etc.)
+            if lang_code not in forms_by_language:
+                forms_by_language[lang_code] = []
+            forms_by_language[lang_code].append(form)
+
+    # Get all languages that have synonyms or alternatives
+    all_synonym_languages = sorted(set(list(synonyms_by_language.keys()) + list(alternative_forms_by_language.keys())))
 
     # Get count of sentences using this lemma (for nouns)
     sentence_count = 0
@@ -249,6 +268,9 @@ def view_lemma(lemma_id):
                          effective_levels=effective_levels,
                          difficulty_stats=difficulty_stats,
                          forms_by_language=forms_by_language,
+                         synonyms_by_language=synonyms_by_language,
+                         alternative_forms_by_language=alternative_forms_by_language,
+                         all_synonym_languages=all_synonym_languages,
                          sentence_count=sentence_count)
 
 

--- a/src/barsukas/templates/lemmas/view.html
+++ b/src/barsukas/templates/lemmas/view.html
@@ -227,6 +227,102 @@
 </div>
 {% endif %}
 
+<!-- Synonyms & Alternative Forms -->
+{% if synonyms_by_language or alternative_forms_by_language %}
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-shuffle"></i> Synonyms & Alternative Forms</span>
+                <div>
+                    <button type="button" class="btn btn-sm btn-light" data-bs-toggle="modal" data-bs-target="#generateSynonymsModal">
+                        <i class="bi bi-plus-circle"></i> Generate Synonyms
+                    </button>
+                </div>
+            </div>
+            <div class="card-body">
+                {% for lang_code in all_synonym_languages %}
+                    {% set synonyms = synonyms_by_language.get(lang_code, []) %}
+                    {% set alternatives = alternative_forms_by_language.get(lang_code, []) %}
+                    {% if synonyms or alternatives %}
+                        <h5 class="mt-3">
+                            {{ language_names.get(lang_code, lang_code) }}
+                        </h5>
+
+                        {% if synonyms %}
+                            <div class="mb-3">
+                                <strong>Synonyms:</strong>
+                                <div class="d-flex flex-wrap gap-2 mt-2">
+                                    {% for syn in synonyms %}
+                                        <span class="badge bg-primary" style="font-size: 0.9rem;">{{ syn.derivative_form_text }}</span>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+
+                        {% if alternatives %}
+                            <div class="mb-3">
+                                <strong>Alternative Forms:</strong>
+                                <div class="d-flex flex-wrap gap-2 mt-2">
+                                    {% for alt in alternatives %}
+                                        <span class="badge bg-secondary" style="font-size: 0.9rem;">{{ alt.derivative_form_text }}</span>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Generate Synonyms Modal -->
+<div class="modal fade" id="generateSynonymsModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Generate Synonyms & Alternative Forms</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <form method="post" action="{{ url_for('agents.generate_synonyms', lemma_id=lemma.id) }}">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="syn_lang_code" class="form-label">Language</label>
+                        <select class="form-select" id="syn_lang_code" name="lang_code" required>
+                            <option value="en" selected>English</option>
+                            <option value="lt">Lithuanian</option>
+                            <option value="zh">Chinese</option>
+                            <option value="ko">Korean</option>
+                            <option value="fr">French</option>
+                            <option value="es">Spanish</option>
+                            <option value="de">German</option>
+                            <option value="pt">Portuguese</option>
+                            <option value="sw">Swahili</option>
+                            <option value="vi">Vietnamese</option>
+                        </select>
+                    </div>
+                    <div class="alert alert-info">
+                        <i class="bi bi-info-circle"></i>
+                        <strong>Note:</strong> This will use AI to generate:
+                        <ul class="mb-0 mt-2">
+                            <li><strong>Synonyms:</strong> Different words with similar meanings (e.g., "street" → "road")</li>
+                            <li><strong>Alternative forms:</strong> Shortened versions or spelling variants (e.g., "one thousand" → "thousand")</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-robot"></i> Generate
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Translations -->
 <div class="row mb-4">
     <div class="col">

--- a/src/wordfreq/agents/README.md
+++ b/src/wordfreq/agents/README.md
@@ -10,6 +10,7 @@ Autonomous agents for data quality monitoring and maintenance tasks. These agent
 - **Bebras** (beaver) - Ensures database structural integrity by identifying orphaned records, missing fields, and constraint violations.
 - **Voras** (spider) - Validates multi-lingual translations for correctness, reports on coverage, and can populate missing translations using LLM.
 - **Vilkas** (wolf) - Monitors the presence and completeness of word forms across multiple languages in the database and can automatically generate missing forms.
+- **Šernas** (boar) - Generates synonyms and alternative forms for vocabulary words across all supported languages.
 - **Papuga** (parrot) - Validates and generates pronunciations (both IPA and simplified phonetic) for derivative forms.
 - **Žvirblis** (sparrow) - Generates example sentences for vocabulary words using LLM, with automatic difficulty calculation and word linkage.
 - **Povas** (peacock) - Generates HTML pages displaying words organized by part-of-speech subtypes with comprehensive linguistic information.
@@ -451,6 +452,113 @@ In fix mode:
 - Number of forms successfully generated
 - Number of failures
 - Detailed logs of each generation attempt
+
+---
+
+### Šernas (Synonym and Alternative Form Generator)
+
+**Name:** "Šernas" means "boar" in Lithuanian - persistent in finding similar things.
+
+**Purpose:** Generates synonyms and alternative forms for vocabulary words across all supported languages, distinguishing between true synonyms (different words with similar meanings) and alternative forms (shortened versions, spelling variants).
+
+**Supported Languages:**
+- English (en)
+- Lithuanian (lt)
+- Chinese (zh)
+- Korean (ko)
+- French (fr)
+- Spanish (es)
+- German (de)
+- Portuguese (pt)
+- Swahili (sw)
+- Vietnamese (vi)
+
+**Form Types:**
+1. **Synonyms** - Different words with similar or related meanings
+   - Examples: "street" → "road", "mad" → "angry", "big" → "large"
+   - Appropriate for language learners in Trakaido context
+
+2. **Alternative Forms** - Shortened versions, abbreviations, or spelling variants
+   - Examples: "one thousand" → "thousand", "gray" → "grey", "television" → "TV"
+   - Essentially the same word in different forms
+
+**Usage:**
+```bash
+# Check/reporting mode (no changes made)
+python sernas.py --check [CHECK_TYPE] [--language LANG] [--type TYPE]
+
+# Fix mode (generate synonyms and alternatives)
+python sernas.py --fix [--language LANG] [--type TYPE] [--limit N] [--dry-run]
+```
+
+**Check Mode (Reporting Only):**
+- `--check all` - Check all languages for missing synonyms/alternatives (default)
+- `--check by-language` - Check specific language only
+- `--language LANG` - Language code to check (default: en)
+- `--type TYPE` - Type to check: 'synonym', 'alternative_form', or 'both' (default: both)
+
+**Fix Mode (Generate Forms):**
+- `--fix` - Enable fix mode to generate missing synonyms and alternatives
+- `--language LANG` - Language code for generation (default: en). Supports: en, lt, zh, ko, fr, es, de, pt, sw, vi
+- `--type TYPE` - Type to generate: 'synonym', 'alternative_form', or 'both' (default: both)
+- `--limit N` - Maximum number of lemmas to process (default: 10)
+- `--model MODEL` - LLM model to use for generation (default: gpt-5-mini)
+- `--throttle SECONDS` - Seconds to wait between API calls (default: 1.0)
+- `--dry-run` - Show what would be generated **WITHOUT making any LLM calls or database changes**
+- `--yes`, `-y` - Skip confirmation prompt
+
+**Options:**
+- `--db-path PATH` - Use custom database path (defaults to `constants.WORDFREQ_DB_PATH`)
+- `--debug` - Enable debug logging
+
+**Example Usage:**
+
+Check all languages for missing synonyms:
+```bash
+python sernas.py --check all
+```
+
+Check English lemmas only:
+```bash
+python sernas.py --check by-language --language en
+```
+
+Generate English synonyms (dry run):
+```bash
+python sernas.py --fix --language en --dry-run
+```
+
+Generate Lithuanian synonyms only (not alternatives):
+```bash
+python sernas.py --fix --language lt --type synonym --limit 20 --yes
+```
+
+Generate Chinese synonyms and alternatives:
+```bash
+python sernas.py --fix --language zh --limit 10 --yes
+```
+
+**Output:**
+
+The agent provides:
+- Count of lemmas missing synonyms/alternatives per language
+- Sample lemmas needing forms
+- Lists with POS type, difficulty level, and current translation
+
+In fix mode:
+- Number of synonyms generated
+- Number of alternative forms generated
+- Number of successful/failed generations
+- Detailed logs of each generation attempt
+
+**Per-Language Generation:**
+Each language generates its synonyms independently - English word "street" gets English synonyms ("road", "avenue"), and Lithuanian translation "gatvė" gets Lithuanian synonyms separately. No cross-language mapping is attempted.
+
+**BARSUKAS Web Interface:**
+On individual lemma pages, you can:
+- View existing synonyms and alternative forms grouped by language
+- Click "Generate Synonyms" to generate for a specific language
+- Forms are displayed with badges (synonyms in blue, alternatives in gray)
 
 ---
 

--- a/src/wordfreq/agents/sernas.py
+++ b/src/wordfreq/agents/sernas.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Šernas - Synonym and Alternative Form Generator Agent
+
+This is a compatibility wrapper that imports from the refactored šernas package.
+The actual implementation is in wordfreq/agents/sernas/
+
+"Šernas" means "boar" in Lithuanian - persistent in finding similar things.
+
+Generates synonyms and alternative forms across multiple languages including English,
+Lithuanian, Chinese, Korean, French, Spanish, German, Portuguese, Swahili, and Vietnamese.
+"""
+
+# Add src directory to path
+import sys
+from pathlib import Path
+GREENLAND_SRC_PATH = str(Path(__file__).parent.parent.parent)
+if GREENLAND_SRC_PATH not in sys.path:
+    sys.path.insert(0, GREENLAND_SRC_PATH)
+
+from wordfreq.agents.sernas.agent import SernasAgent
+from wordfreq.agents.sernas.cli import main
+
+__all__ = ['SernasAgent', 'main']
+
+if __name__ == '__main__':
+    main()

--- a/src/wordfreq/agents/sernas/__init__.py
+++ b/src/wordfreq/agents/sernas/__init__.py
@@ -1,0 +1,1 @@
+"""Šernas agent for synonym and alternative form generation."""

--- a/src/wordfreq/agents/sernas/agent.py
+++ b/src/wordfreq/agents/sernas/agent.py
@@ -1,0 +1,523 @@
+"""
+Šernas - Synonym and Alternative Form Generator Agent
+
+This agent generates synonyms and alternative forms for lemmas across all supported
+languages. It distinguishes between:
+- Alternative forms: Shortened versions, spelling variants (e.g., "one thousand" → "thousand", "gray" → "grey")
+- Synonyms: Different words with similar meanings (e.g., "street" → "road", "mad" → "angry")
+
+"Šernas" means "boar" in Lithuanian - persistent in finding similar things.
+
+Supported languages:
+- English (en)
+- Lithuanian (lt)
+- Chinese (zh)
+- Korean (ko)
+- French (fr)
+- Spanish (es)
+- German (de)
+- Portuguese (pt)
+- Swahili (sw)
+- Vietnamese (vi)
+"""
+
+import logging
+import time
+import json
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+import constants
+from wordfreq.storage.database import create_database_session
+from wordfreq.storage.models.schema import Lemma, DerivativeForm
+from wordfreq.storage.crud.derivative_form import add_derivative_form
+from wordfreq.storage.crud.word_token import add_word_token
+from wordfreq.storage.translation_helpers import get_translation, get_supported_languages
+from wordfreq.translation.client import LinguisticClient
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+
+class SernasAgent:
+    """Agent for generating synonyms and alternative forms across multiple languages."""
+
+    def __init__(self, db_path: str = None, debug: bool = False):
+        """
+        Initialize the Šernas agent.
+
+        Args:
+            db_path: Database path (uses default if None)
+            debug: Enable debug logging
+        """
+        self.db_path = db_path or constants.WORDFREQ_DB_PATH
+        self.debug = debug
+
+        if debug:
+            logger.setLevel(logging.DEBUG)
+
+    def get_session(self):
+        """Get database session."""
+        return create_database_session(self.db_path)
+
+    def check_missing_synonyms(
+        self,
+        language_code: Optional[str] = None,
+        form_type: Optional[str] = None
+    ) -> Dict[str, any]:
+        """
+        Check for lemmas missing synonyms or alternative forms.
+
+        Args:
+            language_code: Language to check (e.g., 'en', 'lt'). If None, check all.
+            form_type: Type to check ('synonym' or 'alternative_form'). If None, check both.
+
+        Returns:
+            Dictionary with check results
+        """
+        logger.info(f"Checking for lemmas missing synonyms/alternative forms...")
+
+        session = self.get_session()
+        try:
+            # Get all lemmas
+            lemmas = session.query(Lemma).all()
+            logger.info(f"Found {len(lemmas)} lemmas in database")
+
+            # Determine which language codes to check
+            if language_code:
+                lang_codes = [language_code]
+            else:
+                lang_codes = ['en'] + list(get_supported_languages().keys())
+
+            # Determine which form types to check
+            if form_type:
+                form_types = [form_type]
+            else:
+                form_types = ['synonym', 'alternative_form']
+
+            missing_by_language = {}
+            for lang in lang_codes:
+                missing_by_language[lang] = []
+
+            for lemma in lemmas:
+                for lang in lang_codes:
+                    # Get the translation for this language
+                    if lang == 'en':
+                        translation = lemma.lemma_text
+                    else:
+                        translation = get_translation(session, lemma, lang)
+
+                    # Skip if no translation exists
+                    if not translation or not translation.strip():
+                        continue
+
+                    # Check for existing synonyms/alternatives
+                    existing_forms = session.query(DerivativeForm).filter(
+                        DerivativeForm.lemma_id == lemma.id,
+                        DerivativeForm.language_code == lang,
+                        DerivativeForm.grammatical_form.in_(form_types)
+                    ).all()
+
+                    if not existing_forms:
+                        missing_by_language[lang].append({
+                            'guid': lemma.guid,
+                            'english': lemma.lemma_text,
+                            'translation': translation,
+                            'pos_type': lemma.pos_type,
+                            'pos_subtype': lemma.pos_subtype,
+                            'difficulty_level': lemma.difficulty_level
+                        })
+
+            # Calculate statistics
+            total_missing = sum(len(items) for items in missing_by_language.values())
+
+            logger.info(f"Found {total_missing} lemmas missing synonyms/alternatives across all languages")
+
+            return {
+                'total_missing': total_missing,
+                'missing_by_language': missing_by_language,
+                'checked_languages': lang_codes,
+                'checked_form_types': form_types
+            }
+
+        except Exception as e:
+            logger.error(f"Error checking missing synonyms: {e}")
+            return {
+                'error': str(e),
+                'total_missing': 0,
+                'missing_by_language': {}
+            }
+        finally:
+            session.close()
+
+    def generate_synonyms_for_lemma(
+        self,
+        lemma_id: int,
+        language_code: str,
+        model: str = 'gpt-5-mini',
+        dry_run: bool = False
+    ) -> Dict[str, any]:
+        """
+        Generate synonyms and alternative forms for a specific lemma and language.
+
+        Args:
+            lemma_id: ID of the lemma
+            language_code: Language code (e.g., 'en', 'lt', 'zh')
+            model: LLM model to use
+            dry_run: If True, only show what would be generated without saving
+
+        Returns:
+            Dictionary with generated forms
+        """
+        session = self.get_session()
+        try:
+            # Get the lemma
+            lemma = session.query(Lemma).get(lemma_id)
+            if not lemma:
+                return {'error': f'Lemma ID {lemma_id} not found'}
+
+            # Get the translation for the target language
+            if language_code == 'en':
+                word = lemma.lemma_text
+            else:
+                word = get_translation(session, lemma, language_code)
+
+            if not word or not word.strip():
+                return {
+                    'error': f'No translation found for language {language_code}',
+                    'lemma_id': lemma_id,
+                    'language_code': language_code
+                }
+
+            logger.info(f"Generating synonyms for '{word}' ({language_code})")
+
+            # Initialize LLM client
+            client = LinguisticClient(model=model, db_path=self.db_path, debug=self.debug)
+
+            # Generate synonyms using LLM
+            result = self._query_synonyms(
+                client=client,
+                word=word,
+                language_code=language_code,
+                pos_type=lemma.pos_type,
+                definition=lemma.definition_text,
+                english_word=lemma.lemma_text
+            )
+
+            if not result['success']:
+                return {
+                    'error': result.get('error', 'Failed to generate synonyms'),
+                    'lemma_id': lemma_id,
+                    'language_code': language_code
+                }
+
+            # Extract results
+            synonyms = result.get('synonyms', [])
+            alternative_forms = result.get('alternative_forms', [])
+
+            if dry_run:
+                return {
+                    'dry_run': True,
+                    'lemma_id': lemma_id,
+                    'language_code': language_code,
+                    'word': word,
+                    'synonyms': synonyms,
+                    'alternative_forms': alternative_forms,
+                    'total_count': len(synonyms) + len(alternative_forms)
+                }
+
+            # Store the forms in the database
+            stored_synonyms = 0
+            stored_alternatives = 0
+
+            for synonym in synonyms:
+                try:
+                    word_token = add_word_token(session, synonym, language_code)
+                    add_derivative_form(
+                        session=session,
+                        lemma=lemma,
+                        derivative_form_text=synonym,
+                        language_code=language_code,
+                        grammatical_form='synonym',
+                        word_token=word_token,
+                        verified=False
+                    )
+                    stored_synonyms += 1
+                except Exception as e:
+                    logger.warning(f"Failed to store synonym '{synonym}': {e}")
+
+            for alt_form in alternative_forms:
+                try:
+                    word_token = add_word_token(session, alt_form, language_code)
+                    add_derivative_form(
+                        session=session,
+                        lemma=lemma,
+                        derivative_form_text=alt_form,
+                        language_code=language_code,
+                        grammatical_form='alternative_form',
+                        word_token=word_token,
+                        verified=False
+                    )
+                    stored_alternatives += 1
+                except Exception as e:
+                    logger.warning(f"Failed to store alternative form '{alt_form}': {e}")
+
+            session.commit()
+
+            logger.info(f"Stored {stored_synonyms} synonyms and {stored_alternatives} alternative forms")
+
+            return {
+                'success': True,
+                'lemma_id': lemma_id,
+                'language_code': language_code,
+                'word': word,
+                'synonyms': synonyms,
+                'alternative_forms': alternative_forms,
+                'stored_synonyms': stored_synonyms,
+                'stored_alternatives': stored_alternatives
+            }
+
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error generating synonyms for lemma {lemma_id}: {e}")
+            return {
+                'error': str(e),
+                'lemma_id': lemma_id,
+                'language_code': language_code
+            }
+        finally:
+            session.close()
+
+    def _query_synonyms(
+        self,
+        client: LinguisticClient,
+        word: str,
+        language_code: str,
+        pos_type: str,
+        definition: str,
+        english_word: str
+    ) -> Dict[str, any]:
+        """
+        Query LLM for synonyms and alternative forms.
+
+        Args:
+            client: LinguisticClient instance
+            word: The word to find synonyms for
+            language_code: Language code
+            pos_type: Part of speech
+            definition: English definition
+            english_word: Original English lemma (for context)
+
+        Returns:
+            Dictionary with synonyms, alternative_forms, and success flag
+        """
+        # Get language name
+        language_names = get_supported_languages()
+        if language_code == 'en':
+            language_name = 'English'
+        else:
+            language_name = language_names.get(language_code, language_code)
+
+        # Build the prompt
+        prompt = f"""You are a linguistic expert helping to generate synonyms and alternative forms for vocabulary learning software called Trakaido.
+
+**Task:** For the {language_name} word "{word}" (part of speech: {pos_type}), generate:
+1. **Alternative forms**: Shortened versions, abbreviations, or spelling variants of the SAME word (e.g., "one thousand" → "thousand", "gray" → "grey", "TV" for "television")
+2. **Synonyms**: Different words with similar or related meanings that would be appropriate for language learners (e.g., "street" → "road", "mad" → "angry")
+
+**Context:**
+- English lemma: {english_word}
+- Definition: {definition}
+- This is for language learning, so focus on common, useful synonyms that learners might encounter
+- Consider whether synonyms would be appropriate/correct in Trakaido learning context
+
+**Guidelines:**
+- For alternative_forms: Only include forms that are essentially the same word (shortened, abbreviated, or variant spellings)
+- For synonyms: Include words with similar meanings, but be mindful of context appropriateness
+- Return 0-5 items for each category (not all words have synonyms or alternative forms)
+- Do NOT include the original word itself
+- Prefer common, useful words over rare or archaic ones
+- Consider the part of speech and usage context
+"""
+
+        if language_code == 'zh':
+            prompt += "\n- For Chinese, provide simplified Chinese characters (e.g., 街道, 马路 for 'street')"
+        elif language_code == 'ko':
+            prompt += "\n- For Korean, provide words in Hangul (e.g., 거리, 길 for 'street')"
+
+        prompt += """
+
+**Output Format (JSON):**
+{
+  "alternative_forms": ["form1", "form2"],
+  "synonyms": ["syn1", "syn2", "syn3"],
+  "explanation": "Brief note about your choices"
+}
+
+Respond ONLY with valid JSON, no other text."""
+
+        try:
+            # Query the LLM
+            response = client.client.query(
+                model=client.model,
+                system_prompt="You are a linguistic expert. Respond only with valid JSON.",
+                user_prompt=prompt,
+                response_format='json'
+            )
+
+            if not response or not response.strip():
+                return {
+                    'success': False,
+                    'error': 'Empty response from LLM'
+                }
+
+            # Parse JSON response
+            result = json.loads(response)
+
+            return {
+                'success': True,
+                'synonyms': result.get('synonyms', []),
+                'alternative_forms': result.get('alternative_forms', []),
+                'explanation': result.get('explanation', '')
+            }
+
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse JSON response: {e}")
+            logger.debug(f"Response was: {response}")
+            return {
+                'success': False,
+                'error': f'Invalid JSON response: {e}'
+            }
+        except Exception as e:
+            logger.error(f"Error querying LLM: {e}")
+            return {
+                'success': False,
+                'error': str(e)
+            }
+
+    def fix_missing_synonyms(
+        self,
+        language_code: Optional[str] = None,
+        form_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        model: str = 'gpt-5-mini',
+        throttle: float = 1.0,
+        dry_run: bool = False
+    ) -> Dict[str, any]:
+        """
+        Generate missing synonyms and alternative forms for lemmas.
+
+        Args:
+            language_code: Language to fix (e.g., 'en', 'lt'). If None, defaults to English.
+            form_type: Type to generate ('synonym' or 'alternative_form'). If None, generates both.
+            limit: Maximum number of lemmas to process
+            model: LLM model to use
+            throttle: Seconds to wait between API calls
+            dry_run: If True, show what would be fixed without making changes
+
+        Returns:
+            Dictionary with fix results
+        """
+        # Default to English if no language specified
+        if not language_code:
+            language_code = 'en'
+            logger.info("No language specified, defaulting to English")
+
+        # Check what's missing
+        check_results = self.check_missing_synonyms(
+            language_code=language_code,
+            form_type=form_type
+        )
+
+        if 'error' in check_results:
+            return check_results
+
+        lemmas_missing = check_results['missing_by_language'].get(language_code, [])
+        total_needs_fix = len(lemmas_missing)
+
+        if total_needs_fix == 0:
+            logger.info(f"No lemmas need synonyms/alternatives for {language_code}!")
+            return {
+                'total_needing_fix': 0,
+                'processed': 0,
+                'successful': 0,
+                'failed': 0,
+                'dry_run': dry_run
+            }
+
+        logger.info(f"Found {total_needs_fix} lemmas needing synonyms/alternatives for {language_code}")
+
+        # Apply limit if specified
+        if limit:
+            lemmas_to_process = lemmas_missing[:limit]
+            logger.info(f"Processing limited to {limit} lemmas")
+        else:
+            lemmas_to_process = lemmas_missing
+
+        if dry_run:
+            logger.info(f"DRY RUN: Would process {len(lemmas_to_process)} lemmas:")
+            for lemma_info in lemmas_to_process[:10]:  # Show first 10
+                logger.info(f"  - {lemma_info['english']} -> {lemma_info['translation']} (level {lemma_info['difficulty_level']})")
+            if len(lemmas_to_process) > 10:
+                logger.info(f"  ... and {len(lemmas_to_process) - 10} more")
+            return {
+                'total_needing_fix': total_needs_fix,
+                'would_process': len(lemmas_to_process),
+                'dry_run': True,
+                'sample': lemmas_to_process[:10]
+            }
+
+        # Process each lemma
+        successful = 0
+        failed = 0
+        session = self.get_session()
+
+        try:
+            for i, lemma_info in enumerate(lemmas_to_process, 1):
+                logger.info(f"\n[{i}/{len(lemmas_to_process)}] Processing: {lemma_info['english']} -> {lemma_info['translation']}")
+
+                # Get lemma object
+                lemma = session.query(Lemma).filter(Lemma.guid == lemma_info['guid']).first()
+                if not lemma:
+                    logger.error(f"Could not find lemma with GUID {lemma_info['guid']}")
+                    failed += 1
+                    continue
+
+                # Generate synonyms
+                result = self.generate_synonyms_for_lemma(
+                    lemma_id=lemma.id,
+                    language_code=language_code,
+                    model=model,
+                    dry_run=False
+                )
+
+                if result.get('success'):
+                    successful += 1
+                    logger.info(f"Successfully generated {result.get('stored_synonyms', 0)} synonyms and {result.get('stored_alternatives', 0)} alternatives")
+                else:
+                    failed += 1
+                    logger.error(f"Failed: {result.get('error', 'Unknown error')}")
+
+                # Throttle to avoid overloading the API
+                if i < len(lemmas_to_process):
+                    time.sleep(throttle)
+
+        finally:
+            session.close()
+
+        logger.info(f"\n{'='*60}")
+        logger.info(f"Fix complete:")
+        logger.info(f"  Total needing fix: {total_needs_fix}")
+        logger.info(f"  Processed: {len(lemmas_to_process)}")
+        logger.info(f"  Successful: {successful}")
+        logger.info(f"  Failed: {failed}")
+        logger.info(f"{'='*60}")
+
+        return {
+            'total_needing_fix': total_needs_fix,
+            'processed': len(lemmas_to_process),
+            'successful': successful,
+            'failed': failed,
+            'dry_run': dry_run,
+            'language_code': language_code
+        }

--- a/src/wordfreq/agents/sernas/cli.py
+++ b/src/wordfreq/agents/sernas/cli.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Šernas Agent - Command Line Interface
+
+This module handles all CLI argument parsing and the main entry point.
+"""
+
+import argparse
+import sys
+
+
+def get_argument_parser():
+    """Return the argument parser for introspection.
+
+    This function allows external tools to introspect the available
+    command-line arguments without executing the main function.
+    """
+    parser = argparse.ArgumentParser(
+        description="Šernas - Synonym and Alternative Form Generator Agent"
+    )
+    parser.add_argument('--db-path', help='Database path (uses default if not specified)')
+    parser.add_argument('--debug', action='store_true', help='Enable debug logging')
+
+    # Check mode options (reporting only, no changes)
+    parser.add_argument('--check',
+                       choices=['all', 'by-language'],
+                       default='all',
+                       help='Check which lemmas are missing synonyms/alternatives (default: all)')
+
+    # Fix mode options (generate missing synonyms)
+    parser.add_argument('--fix', action='store_true',
+                       help='Fix mode: Generate missing synonyms and alternative forms')
+    parser.add_argument('--language', default='en',
+                       help='Language code for operations (en=English, lt=Lithuanian, etc., default: en)')
+    parser.add_argument('--type',
+                       choices=['synonym', 'alternative_form', 'both'],
+                       help='[Check/Fix mode] Type to check/generate (synonym, alternative_form, or both). Default: both')
+    parser.add_argument('--limit', type=int, default=10,
+                       help='[Fix mode] Maximum number of lemmas to process (default: 10)')
+    parser.add_argument('--model', default='gpt-5-mini',
+                       help='[Fix mode] LLM model to use for generation (default: gpt-5-mini)')
+    parser.add_argument('--throttle', type=float, default=1.0,
+                       help='[Fix mode] Seconds to wait between API calls (default: 1.0)')
+    parser.add_argument('--dry-run', action='store_true',
+                       help='[Fix mode] Show what would be generated WITHOUT making any LLM calls or database changes')
+    parser.add_argument('--yes', '-y', action='store_true',
+                       help='[Fix mode] Skip confirmation prompt when fixing')
+
+    return parser
+
+
+def main():
+    """Main entry point for the šernas agent."""
+    # Import here to avoid circular imports
+    from wordfreq.agents.sernas.agent import SernasAgent
+
+    parser = get_argument_parser()
+    args = parser.parse_args()
+
+    agent = SernasAgent(db_path=args.db_path, debug=args.debug)
+
+    # Convert --type argument to form_type
+    form_type = None
+    if args.type and args.type != 'both':
+        form_type = args.type
+
+    # Handle --fix mode
+    if args.fix:
+        # Confirmation prompt (unless --yes or --dry-run)
+        if not args.yes and not args.dry_run:
+            # Get check results to show how many need fixing
+            check_results = agent.check_missing_synonyms(
+                language_code=args.language,
+                form_type=form_type
+            )
+
+            if 'error' in check_results:
+                print(f"Error checking synonyms: {check_results['error']}")
+                return
+
+            missing_count = len(check_results['missing_by_language'].get(args.language, []))
+
+            print(f"\n{'='*60}")
+            print(f"Ready to generate synonyms/alternatives for {args.language}")
+            print(f"Lemmas needing forms: {missing_count}")
+            print(f"Will process: {min(args.limit, missing_count) if args.limit else missing_count}")
+            print(f"Model: {args.model}")
+            print(f"Throttle: {args.throttle}s between calls")
+            print(f"{'='*60}")
+
+            response = input("\nContinue? [y/N]: ")
+            if response.lower() not in ['y', 'yes']:
+                print("Aborted.")
+                return
+
+        results = agent.fix_missing_synonyms(
+            language_code=args.language,
+            form_type=form_type,
+            limit=args.limit,
+            model=args.model,
+            throttle=args.throttle,
+            dry_run=args.dry_run
+        )
+
+        # Print results
+        print(f"\n{'='*60}")
+        if args.dry_run:
+            print("DRY RUN COMPLETE")
+            print(f"Would process: {results.get('would_process', 0)} lemmas")
+        else:
+            print("FIX COMPLETE")
+            print(f"Total needing fix: {results.get('total_needing_fix', 0)}")
+            print(f"Processed: {results.get('processed', 0)}")
+            print(f"Successful: {results.get('successful', 0)}")
+            print(f"Failed: {results.get('failed', 0)}")
+        print(f"{'='*60}")
+        return
+
+    # Handle check mode
+    if args.check == 'all':
+        results = agent.check_missing_synonyms(form_type=form_type)
+
+        if 'error' in results:
+            print(f"Error: {results['error']}")
+            return
+
+        print(f"\n{'='*60}")
+        print("ŠERNAS AGENT REPORT - Synonyms and Alternative Forms Check")
+        print(f"{'='*60}")
+        print(f"Total lemmas missing forms: {results['total_missing']}")
+        print(f"Checked form types: {', '.join(results['checked_form_types'])}")
+        print("")
+
+        for lang_code in results['checked_languages']:
+            missing = results['missing_by_language'].get(lang_code, [])
+            print(f"{lang_code.upper()}: {len(missing)} lemmas missing forms")
+
+        print(f"{'='*60}")
+
+    elif args.check == 'by-language':
+        results = agent.check_missing_synonyms(
+            language_code=args.language,
+            form_type=form_type
+        )
+
+        if 'error' in results:
+            print(f"Error: {results['error']}")
+            return
+
+        missing = results['missing_by_language'].get(args.language, [])
+
+        print(f"\n{'='*60}")
+        print(f"ŠERNAS AGENT REPORT - {args.language.upper()}")
+        print(f"{'='*60}")
+        print(f"Lemmas missing forms: {len(missing)}")
+        print(f"Checked form types: {', '.join(results['checked_form_types'])}")
+        print("")
+
+        if missing:
+            print("Sample lemmas needing forms:")
+            for i, lemma in enumerate(missing[:10], 1):
+                print(f"  {i}. {lemma['english']} -> {lemma['translation']} ({lemma['pos_type']})")
+            if len(missing) > 10:
+                print(f"  ... and {len(missing) - 10} more")
+
+        print(f"{'='*60}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements a new autonomous agent (ŠERNAS - "boar" in Lithuanian) that generates synonyms and alternative forms for vocabulary words across all supported languages.

Key features:
- Distinguishes between two form types:
  * Synonyms: Different words with similar meanings (e.g., "street" → "road")
  * Alternative forms: Shortened/variant spellings (e.g., "gray" → "grey")
- Per-language generation using LLM (independent for each language)
- Command-line interface with check and fix modes
- BARSUKAS web UI integration with per-lemma synonym generation
- Stores forms in DerivativeForm table with grammatical_form='synonym' or 'alternative_form'

Components added:
- Agent core: src/wordfreq/agents/sernas/agent.py
- CLI: src/wordfreq/agents/sernas/cli.py
- Entry point: src/wordfreq/agents/sernas.py
- BARSUKAS route: generate_synonyms endpoint in agents.py
- UI: Synonyms section and modal in lemmas/view.html template
- Updated lemma view route to separate synonyms from other forms
- Registered in agent launcher configuration
- Comprehensive documentation in agents README

The agent uses LLM prompts tailored for Trakaido learning context, considering appropriateness of synonyms for language learners.