### PR TITLE
Enforce Traditional Chinese characters in all LLM prompts

### DIFF
--- a/src/wordfreq/agents/sernas/agent.py
+++ b/src/wordfreq/agents/sernas/agent.py
@@ -341,7 +341,7 @@ class SernasAgent:
 """
 
         if language_code == 'zh':
-            prompt += "\n- For Chinese, provide simplified Chinese characters (e.g., 街道, 马路 for 'street')"
+            prompt += "\n- For Chinese, provide Traditional Chinese characters (繁體字) (e.g., 街道, 馬路 for 'street')"
         elif language_code == 'ko':
             prompt += "\n- For Korean, provide words in Hangul (e.g., 거리, 길 for 'street')"
 

--- a/src/wordfreq/prompts/word_analysis/context.txt
+++ b/src/wordfreq/prompts/word_analysis/context.txt
@@ -14,7 +14,7 @@ The Trakaido system organizes words by:
 
 For translations:
 - Lithuanian: Provide the most common, standard Lithuanian equivalent in base form
-- Chinese: Provide simplified Chinese characters in base form
+- Chinese: Provide Traditional Chinese characters (繁體字) in base form
 - Korean: Provide Hangul in base form
 - French: Provide standard French in base form (infinitive for verbs, singular for nouns)
 - Swahili: Provide standard Swahili in base form


### PR DESCRIPTION
Updated all LLM prompts in src/wordfreq/ that expect Chinese output to explicitly specify Traditional Chinese characters (繁體字) instead of Simplified Chinese. This ensures consistency across the codebase and allows for easier conversion to Simplified Chinese for exports when needed.

Changes:
- Updated Šernas agent prompt to request Traditional Chinese (with Traditional character examples: 馬路 instead of 马路)
- Updated word_analysis context prompt to specify Traditional Chinese characters

This aligns with the existing standard in translation/constants.py which already specified Traditional Chinese for translation generation.