### PR TITLE
Add measure word property to Chinese grammar table

### DIFF
--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -324,6 +324,10 @@ def view_lemma(lemma_id):
         ).count()
         needs_disambiguation_check = duplicate_count > 0
 
+    # Get grammar facts for this lemma
+    from wordfreq.storage.crud.grammar_fact import get_grammar_facts
+    grammar_facts = get_grammar_facts(g.db, lemma_id)
+
     return render_template('lemmas/view.html',
                          lemma=lemma,
                          translations=translations,
@@ -336,7 +340,8 @@ def view_lemma(lemma_id):
                          alternative_forms_by_language=alternative_forms_by_language,
                          all_synonym_languages=all_synonym_languages,
                          sentence_count=sentence_count,
-                         needs_disambiguation_check=needs_disambiguation_check)
+                         needs_disambiguation_check=needs_disambiguation_check,
+                         grammar_facts=grammar_facts)
 
 
 @bp.route('/<int:lemma_id>/edit', methods=['GET', 'POST'])

--- a/src/barsukas/templates/lemmas/view.html
+++ b/src/barsukas/templates/lemmas/view.html
@@ -498,6 +498,130 @@ document.addEventListener('DOMContentLoaded', function() {
     </div>
 </div>
 
+<!-- Grammar Facts -->
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-card-list"></i> Grammar Facts</span>
+                {% if lemma.pos_type == 'noun' %}
+                <div>
+                    <button type="button" class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#generateGrammarFactModal">
+                        <i class="bi bi-plus-circle"></i> Generate Grammar Fact
+                    </button>
+                </div>
+                {% endif %}
+            </div>
+            <div class="card-body">
+                {% if grammar_facts %}
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>Language</th>
+                            <th>Fact Type</th>
+                            <th>Value</th>
+                            <th>Notes</th>
+                            <th>Verified</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for fact in grammar_facts %}
+                        <tr>
+                            <td><span class="badge bg-secondary">{{ fact.language_code }}</span></td>
+                            <td>{{ fact.fact_type|replace('_', ' ')|title }}</td>
+                            <td>
+                                {% if fact.language_code == 'zh' %}
+                                <span class="chinese-with-pinyin">{{ fact.fact_value|pinyin_ruby|safe }}</span>
+                                {% else %}
+                                <strong>{{ fact.fact_value }}</strong>
+                                {% endif %}
+                            </td>
+                            <td><small class="text-muted">{{ fact.notes or '-' }}</small></td>
+                            <td>
+                                {% if fact.verified %}
+                                <i class="bi bi-check-circle-fill text-success"></i>
+                                {% else %}
+                                <i class="bi bi-circle text-muted"></i>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% else %}
+                <p class="text-muted mb-0">
+                    <i class="bi bi-info-circle"></i> No grammar facts recorded for this lemma yet.
+                    {% if lemma.pos_type == 'noun' %}
+                    Use the <strong>Lape agent</strong> to generate language-specific grammar facts like Chinese measure words.
+                    {% endif %}
+                </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Generate Grammar Fact Modal (for nouns) -->
+{% if lemma.pos_type == 'noun' %}
+<div class="modal fade" id="generateGrammarFactModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Generate Grammar Fact</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <form method="post" action="{{ url_for('agents.generate_grammar_fact', lemma_id=lemma.id) }}">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">Lemma</label>
+                        <p class="form-control-plaintext"><strong>{{ lemma.lemma_text }}</strong> - {{ lemma.definition_text[:50] }}...</p>
+                    </div>
+                    <div class="mb-3">
+                        <label for="fact_type" class="form-label">Fact Type</label>
+                        <select class="form-select" id="fact_type" name="fact_type" required>
+                            <option value="measure_words" selected>Measure Words (Chinese classifiers)</option>
+                            <!-- Future options:
+                            <option value="grammatical_gender">Grammatical Gender (French, Spanish, German, etc.)</option>
+                            <option value="number_type">Number Type (Plurale tantum, Singulare tantum)</option>
+                            <option value="declension_class">Declension Class (Lithuanian, Latin, etc.)</option>
+                            -->
+                        </select>
+                        <small class="form-text text-muted">
+                            Select the type of grammar fact to generate
+                        </small>
+                    </div>
+                    <div class="mb-3">
+                        <label for="language_code" class="form-label">Language</label>
+                        <select class="form-select" id="language_code" name="language_code" required>
+                            <option value="zh" selected>Chinese (zh)</option>
+                            <!-- Future options based on fact type:
+                            <option value="fr">French (fr)</option>
+                            <option value="es">Spanish (es)</option>
+                            <option value="de">German (de)</option>
+                            <option value="lt">Lithuanian (lt)</option>
+                            -->
+                        </select>
+                        <small class="form-text text-muted">
+                            Language for the grammar fact
+                        </small>
+                    </div>
+                    <div class="alert alert-info">
+                        <i class="bi bi-info-circle"></i>
+                        <strong>About Measure Words:</strong> The Lape agent uses AI to determine the appropriate Chinese classifier/measure word (量词) for this noun. The measure word is required when using numbers with nouns in Chinese.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-robot"></i> Generate with AI
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 <!-- Example Sentences (for nouns only) -->
 {% if lemma.pos_type == 'noun' %}
 <div class="row mb-4">

--- a/src/wordfreq/agents/lape.py
+++ b/src/wordfreq/agents/lape.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""
+Lape - Grammar Facts Generator Agent
+
+This agent generates language-specific grammatical facts for lemmas using LLM queries.
+It supports various types of grammar facts that can be specified via command line parameters.
+
+Currently supported fact types:
+- measure_words (Chinese): Generate appropriate measure words/classifiers for nouns
+
+Future expansions (commented examples):
+- grammatical_gender (French, Spanish, German, etc.): Determine noun gender (masculine, feminine, neuter)
+- number_type (English, etc.): Identify plurale tantum (scissors, pants) or singulare tantum (furniture, information)
+- declension_class (Lithuanian, Latin, etc.): Determine which declension pattern a noun follows
+- verb_aspect (Russian, Polish, etc.): Identify perfective vs imperfective verb pairs
+- honorific_level (Japanese, Korean): Determine appropriate honorific/politeness level
+- tone_pattern (Vietnamese, Thai): Identify tone patterns for words
+- definiteness (Arabic, Hebrew): Whether nouns are definite or indefinite by default
+- animacy (Russian, Czech): Whether nouns are animate or inanimate (affects grammar)
+
+"Lape" means "fox" in Lithuanian - clever and precise in analyzing grammar!
+"""
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Add src directory to path
+GREENLAND_SRC_PATH = str(Path(__file__).parent.parent.parent)
+if GREENLAND_SRC_PATH not in sys.path:
+    sys.path.insert(0, GREENLAND_SRC_PATH)
+
+import constants
+import util.prompt_loader
+from wordfreq.storage.database import create_database_session
+from wordfreq.storage.models.schema import Lemma
+from wordfreq.storage.crud.grammar_fact import (
+    add_grammar_fact,
+    get_grammar_fact_value,
+    get_grammar_facts
+)
+from wordfreq.storage.crud.operation_log import log_operation
+from wordfreq.storage.translation_helpers import get_translation
+from wordfreq.translation.client import LinguisticClient
+from clients.unified_client import UnifiedLLMClient
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class LapeAgent:
+    """Agent for generating grammar facts for lemmas."""
+
+    # Supported fact types and their required parameters
+    SUPPORTED_FACT_TYPES = {
+        'measure_words': {
+            'languages': ['zh'],  # Chinese only for now
+            'required_pos': ['noun'],
+            'description': 'Generate Chinese measure words/classifiers for nouns'
+        },
+        # Future expansions:
+        # 'grammatical_gender': {
+        #     'languages': ['fr', 'es', 'de', 'ru', 'it', 'pt'],
+        #     'required_pos': ['noun'],
+        #     'description': 'Determine grammatical gender (masculine, feminine, neuter)'
+        # },
+        # 'number_type': {
+        #     'languages': ['en', 'lt', 'fr', 'es'],
+        #     'required_pos': ['noun'],
+        #     'description': 'Identify plurale tantum or singulare tantum nouns'
+        # },
+        # 'declension_class': {
+        #     'languages': ['lt', 'la', 'ru', 'de'],
+        #     'required_pos': ['noun', 'adjective'],
+        #     'description': 'Determine declension class/pattern'
+        # },
+    }
+
+    def __init__(self, db_path: str = None, debug: bool = False, model: str = None):
+        """
+        Initialize the Lape agent.
+
+        Args:
+            db_path: Database path (uses default if None)
+            debug: Enable debug logging
+            model: LLM model to use (default: gpt-5-mini)
+        """
+        self.db_path = db_path or constants.WORDFREQ_DB_PATH
+        self.debug = debug
+        self.model = model or "gpt-5-mini"
+        self.linguistic_client = None  # Lazy initialization
+        self.llm_client = None  # For direct LLM calls
+
+        if debug:
+            logger.setLevel(logging.DEBUG)
+
+    def get_session(self):
+        """Get database session."""
+        return create_database_session(self.db_path)
+
+    def get_linguistic_client(self):
+        """Get or create linguistic client for LLM queries."""
+        if self.linguistic_client is None:
+            self.linguistic_client = LinguisticClient(
+                model=self.model,
+                db_path=self.db_path,
+                debug=self.debug
+            )
+        return self.linguistic_client
+
+    def get_llm_client(self):
+        """Get or create LLM client for direct queries."""
+        if self.llm_client is None:
+            self.llm_client = UnifiedLLMClient(debug=self.debug)
+            self.llm_client.warm_model(self.model)
+        return self.llm_client
+
+    def generate_measure_words(
+        self,
+        lemma: Lemma,
+        chinese_translation: str,
+        session=None
+    ) -> Tuple[Optional[str], Optional[str], float]:
+        """
+        Generate Chinese measure word(s) for a noun using LLM.
+
+        Args:
+            lemma: The Lemma object
+            chinese_translation: The Chinese translation of the word
+            session: Database session (optional)
+
+        Returns:
+            Tuple of (measure_word, explanation, confidence)
+        """
+        if lemma.pos_type != 'noun':
+            logger.warning(f"Lemma '{lemma.lemma_text}' is not a noun, skipping measure word generation")
+            return None, None, 0.0
+
+        # Load prompts
+        try:
+            context = util.prompt_loader.get_context("wordfreq", "measure_words")
+            prompt_template = util.prompt_loader.get_prompt("wordfreq", "measure_words")
+        except Exception as e:
+            logger.error(f"Failed to load measure_words prompts: {e}")
+            return None, None, 0.0
+
+        # Format prompt
+        prompt_text = prompt_template.format(
+            english_word=lemma.lemma_text,
+            chinese_translation=chinese_translation,
+            pos_type=lemma.pos_type,
+            definition=lemma.definition or "N/A"
+        )
+
+        # Query LLM
+        try:
+            client = self.get_llm_client()
+            response = client.query(
+                prompt=prompt_text,
+                system_prompt=context,
+                model=self.model,
+                response_format="json"
+            )
+
+            # Parse response
+            if isinstance(response, str):
+                result = json.loads(response)
+            else:
+                result = response
+
+            measure_word = result.get('primary_measure_word', None)
+            alternatives = result.get('alternative_measure_words', [])
+            explanation = result.get('explanation', '')
+            confidence = float(result.get('confidence', 0.5))
+
+            # Combine primary and alternatives
+            if alternatives:
+                all_measure_words = f"{measure_word} (alt: {', '.join(alternatives)})"
+            else:
+                all_measure_words = measure_word
+
+            logger.info(
+                f"Generated measure word for '{lemma.lemma_text}': {all_measure_words} "
+                f"(confidence: {confidence:.2f})"
+            )
+
+            return measure_word, explanation, confidence
+
+        except Exception as e:
+            logger.error(f"Failed to generate measure word for '{lemma.lemma_text}': {e}")
+            return None, None, 0.0
+
+    def generate_grammar_facts(
+        self,
+        fact_type: str,
+        language_code: str,
+        limit: Optional[int] = None,
+        skip_existing: bool = True,
+        min_confidence: float = 0.7,
+        dry_run: bool = False
+    ) -> Dict[str, any]:
+        """
+        Generate grammar facts for lemmas.
+
+        Args:
+            fact_type: Type of grammar fact to generate (e.g., 'measure_words')
+            language_code: Language code (e.g., 'zh', 'fr')
+            limit: Maximum number of lemmas to process
+            skip_existing: Skip lemmas that already have this fact
+            min_confidence: Minimum confidence to save the fact
+            dry_run: If True, don't save to database
+
+        Returns:
+            Dictionary with generation results
+        """
+        # Validate fact type
+        if fact_type not in self.SUPPORTED_FACT_TYPES:
+            raise ValueError(
+                f"Unsupported fact type: {fact_type}. "
+                f"Supported types: {', '.join(self.SUPPORTED_FACT_TYPES.keys())}"
+            )
+
+        fact_config = self.SUPPORTED_FACT_TYPES[fact_type]
+
+        # Validate language
+        if language_code not in fact_config['languages']:
+            raise ValueError(
+                f"Fact type '{fact_type}' does not support language '{language_code}'. "
+                f"Supported languages: {', '.join(fact_config['languages'])}"
+            )
+
+        logger.info(f"Generating {fact_type} for language {language_code}...")
+        if dry_run:
+            logger.info("DRY RUN MODE - No changes will be saved")
+
+        session = self.get_session()
+        try:
+            # Get lemmas that need this fact
+            query = session.query(Lemma).filter(
+                Lemma.pos_type.in_(fact_config['required_pos'])
+            ).order_by(Lemma.id)
+
+            if limit:
+                query = query.limit(limit * 2)  # Get extra in case we skip some
+
+            lemmas = query.all()
+            logger.info(f"Found {len(lemmas)} candidate lemmas")
+
+            # Process lemmas
+            processed_count = 0
+            skipped_count = 0
+            success_count = 0
+            failed_count = 0
+            results = []
+
+            for lemma in lemmas:
+                if limit and processed_count >= limit:
+                    break
+
+                # Check if fact already exists
+                if skip_existing:
+                    existing_fact = get_grammar_fact_value(
+                        session, lemma.id, language_code, fact_type
+                    )
+                    if existing_fact is not None:
+                        skipped_count += 1
+                        continue
+
+                # Get translation for target language
+                translation = get_translation(session, lemma, language_code)
+                if not translation:
+                    logger.debug(f"No {language_code} translation for '{lemma.lemma_text}', skipping")
+                    skipped_count += 1
+                    continue
+
+                processed_count += 1
+                logger.info(f"Processing {processed_count}/{limit or '∞'}: {lemma.lemma_text}")
+
+                # Generate fact based on type
+                if fact_type == 'measure_words':
+                    fact_value, notes, confidence = self.generate_measure_words(
+                        lemma, translation, session
+                    )
+                else:
+                    # Placeholder for future fact types
+                    logger.error(f"Fact type {fact_type} not yet implemented")
+                    failed_count += 1
+                    continue
+
+                if fact_value and confidence >= min_confidence:
+                    # Save to database (unless dry run)
+                    if not dry_run:
+                        add_grammar_fact(
+                            session,
+                            lemma_id=lemma.id,
+                            language_code=language_code,
+                            fact_type=fact_type,
+                            fact_value=fact_value,
+                            notes=notes,
+                            verified=False
+                        )
+                        session.commit()
+
+                        # Log operation
+                        log_operation(
+                            session,
+                            operation_type='grammar_fact_generated',
+                            entity_type='grammar_fact',
+                            entity_id=lemma.id,
+                            details={
+                                'fact_type': fact_type,
+                                'language_code': language_code,
+                                'fact_value': fact_value,
+                                'confidence': confidence,
+                                'agent': 'lape',
+                                'model': self.model
+                            }
+                        )
+                        session.commit()
+
+                    success_count += 1
+                    results.append({
+                        'lemma_id': lemma.id,
+                        'lemma_text': lemma.lemma_text,
+                        'translation': translation,
+                        'fact_value': fact_value,
+                        'notes': notes,
+                        'confidence': confidence
+                    })
+                    logger.info(f"  ✓ Generated: {fact_value} (confidence: {confidence:.2f})")
+                else:
+                    failed_count += 1
+                    logger.warning(
+                        f"  ✗ Failed or low confidence: {fact_value} (confidence: {confidence:.2f})"
+                    )
+
+            logger.info(
+                f"Complete! Processed: {processed_count}, Success: {success_count}, "
+                f"Failed: {failed_count}, Skipped: {skipped_count}"
+            )
+
+            return {
+                'fact_type': fact_type,
+                'language_code': language_code,
+                'processed': processed_count,
+                'success': success_count,
+                'failed': failed_count,
+                'skipped': skipped_count,
+                'results': results,
+                'dry_run': dry_run
+            }
+
+        except Exception as e:
+            logger.error(f"Error generating grammar facts: {e}")
+            if session:
+                session.rollback()
+            raise
+        finally:
+            if session:
+                session.close()
+
+
+def main():
+    """Command-line interface for the Lape agent."""
+    parser = argparse.ArgumentParser(
+        description='Lape - Grammar Facts Generator Agent',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Generate Chinese measure words for nouns
+  python lape.py --fact-type measure_words --language zh --limit 10
+
+  # Dry run to see what would be generated
+  python lape.py --fact-type measure_words --language zh --limit 5 --dry-run
+
+  # Generate for all lemmas without existing facts
+  python lape.py --fact-type measure_words --language zh
+
+  # Use a different model
+  python lape.py --fact-type measure_words --language zh --model gpt-5 --limit 10
+
+Supported fact types:
+  - measure_words: Chinese measure words/classifiers for nouns
+
+Future fact types (see code comments):
+  - grammatical_gender: Noun gender (masculine, feminine, neuter)
+  - number_type: Plurale tantum or singulare tantum identification
+  - declension_class: Declension pattern classification
+  - verb_aspect: Perfective vs imperfective verbs
+  - honorific_level: Politeness/honorific level
+  - And more...
+        """
+    )
+
+    parser.add_argument(
+        '--fact-type',
+        required=True,
+        choices=LapeAgent.SUPPORTED_FACT_TYPES.keys(),
+        help='Type of grammar fact to generate'
+    )
+    parser.add_argument(
+        '--language',
+        required=True,
+        help='Language code (e.g., zh, fr, es)'
+    )
+    parser.add_argument(
+        '--limit',
+        type=int,
+        help='Maximum number of lemmas to process'
+    )
+    parser.add_argument(
+        '--skip-existing',
+        action='store_true',
+        default=True,
+        help='Skip lemmas that already have this fact (default: True)'
+    )
+    parser.add_argument(
+        '--no-skip-existing',
+        dest='skip_existing',
+        action='store_false',
+        help='Process all lemmas, even if they have existing facts'
+    )
+    parser.add_argument(
+        '--min-confidence',
+        type=float,
+        default=0.7,
+        help='Minimum confidence score to save fact (default: 0.7)'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Run without saving to database'
+    )
+    parser.add_argument(
+        '--model',
+        default='gpt-5-mini',
+        help='LLM model to use (default: gpt-5-mini)'
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug logging'
+    )
+    parser.add_argument(
+        '--db-path',
+        help='Database path (default: from constants)'
+    )
+
+    args = parser.parse_args()
+
+    # Create agent
+    agent = LapeAgent(
+        db_path=args.db_path,
+        debug=args.debug,
+        model=args.model
+    )
+
+    # Generate facts
+    try:
+        results = agent.generate_grammar_facts(
+            fact_type=args.fact_type,
+            language_code=args.language,
+            limit=args.limit,
+            skip_existing=args.skip_existing,
+            min_confidence=args.min_confidence,
+            dry_run=args.dry_run
+        )
+
+        # Print summary
+        print("\n" + "=" * 60)
+        print("GRAMMAR FACTS GENERATION SUMMARY")
+        print("=" * 60)
+        print(f"Fact Type: {results['fact_type']}")
+        print(f"Language: {results['language_code']}")
+        print(f"Processed: {results['processed']}")
+        print(f"Success: {results['success']}")
+        print(f"Failed: {results['failed']}")
+        print(f"Skipped: {results['skipped']}")
+        if results['dry_run']:
+            print("\n⚠️  DRY RUN - No changes saved to database")
+        print("=" * 60)
+
+        # Print some examples
+        if results['results']:
+            print("\nSample results:")
+            for i, result in enumerate(results['results'][:5], 1):
+                print(f"{i}. {result['lemma_text']} ({result['translation']})")
+                print(f"   → {result['fact_value']}")
+                print(f"   Confidence: {result['confidence']:.2f}")
+                if result['notes']:
+                    print(f"   Notes: {result['notes']}")
+
+    except Exception as e:
+        logger.error(f"Failed to generate grammar facts: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/wordfreq/prompts/measure_words/context.txt
+++ b/src/wordfreq/prompts/measure_words/context.txt
@@ -1,0 +1,31 @@
+You are a linguistic expert specializing in Chinese grammar for the Trakaido language learning system. Your task is to identify appropriate Chinese measure words (量词/classifier words) for nouns.
+
+CRITICAL REQUIREMENTS:
+1. Measure words (classifiers) are required in Chinese when using numbers with nouns
+2. Different nouns require different measure words based on their characteristics
+3. Provide the most common/standard measure word(s) for the given noun
+4. Return results in Traditional Chinese characters (繁體字)
+5. Focus on the primary measure word, but may include alternatives if commonly used
+
+ABOUT MEASURE WORDS:
+- Measure words classify nouns by their physical properties, shape, or category
+- 个 (gè) is the most general measure word, used for people and many common objects
+- 条 (tiáo) is used for long, thin objects (fish, rivers, roads, etc.)
+- 本 (běn) is used for books, magazines, and bound items
+- 张 (zhāng) is used for flat objects (paper, tables, beds, etc.)
+- 只 (zhī) is used for animals, birds, and certain objects
+- 杯 (bēi) is used for cups/glasses of liquid
+- 件 (jiàn) is used for clothing, matters, and affairs
+- Many other specific measure words exist for different categories
+
+CONFIDENCE GUIDELINES:
+- High confidence (0.8-1.0): Common nouns with clear, standard measure words
+- Medium confidence (0.5-0.7): Nouns with multiple acceptable measure words
+- Lower confidence (0.3-0.5): Abstract concepts or nouns where measure word usage varies
+
+RESPONSE FORMAT:
+Provide the measure word(s) in Traditional Chinese characters, along with:
+1. Primary measure word (most common)
+2. Alternative measure words (if commonly used)
+3. Brief explanation of why this measure word is used
+4. Confidence score (0.0-1.0)

--- a/src/wordfreq/prompts/measure_words/prompt.txt
+++ b/src/wordfreq/prompts/measure_words/prompt.txt
@@ -1,0 +1,18 @@
+Identify the appropriate Chinese measure word(s) (量词/classifier) for the following noun:
+
+English word: {english_word}
+Chinese translation: {chinese_translation}
+Part of speech: {pos_type}
+Definition: {definition}
+
+Provide:
+1. Primary measure word (Traditional Chinese characters)
+2. Alternative measure words (if commonly used)
+3. Brief explanation (1-2 sentences) of why this measure word is appropriate
+4. Confidence score (0.0-1.0)
+
+IMPORTANT:
+- Focus on the most common, standard measure word
+- If multiple measure words are acceptable, list them in order of frequency
+- Consider the semantic category and physical properties of the noun
+- Return Traditional Chinese characters (繁體字)

--- a/src/wordfreq/storage/crud/grammar_fact.py
+++ b/src/wordfreq/storage/crud/grammar_fact.py
@@ -255,3 +255,65 @@ def get_alternate_forms_facts(session, lemma_id: int, language_code: str) -> Opt
         results[fact_type] = (value == "true")
 
     return results
+
+
+def get_measure_word(session, lemma_id: int, language_code: str = "zh") -> Optional[str]:
+    """
+    Get the measure word (classifier) for a Chinese noun.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code (default: "zh" for Chinese)
+
+    Returns:
+        The measure word string, or None if not found
+
+    Example:
+        measure_word = get_measure_word(session, lemma_id=123, language_code="zh")
+        if measure_word:
+            print(f"Use: 一{measure_word}...")  # e.g., "一个..." (one [classifier]...)
+    """
+    return get_grammar_fact_value(session, lemma_id, language_code, "measure_words")
+
+
+def get_grammatical_gender(session, lemma_id: int, language_code: str) -> Optional[str]:
+    """
+    Get the grammatical gender for a noun in gendered languages.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code (e.g., "fr", "es", "de", "ru")
+
+    Returns:
+        The gender string ("masculine", "feminine", "neuter"), or None if not found
+
+    Example:
+        gender = get_grammatical_gender(session, lemma_id=456, language_code="fr")
+        if gender == "masculine":
+            print("Use: le/un")  # masculine articles in French
+        elif gender == "feminine":
+            print("Use: la/une")  # feminine articles in French
+    """
+    return get_grammar_fact_value(session, lemma_id, language_code, "gender")
+
+
+def get_declension_class(session, lemma_id: int, language_code: str) -> Optional[str]:
+    """
+    Get the declension class for a noun in languages with declensions.
+
+    Args:
+        session: Database session
+        lemma_id: ID of the lemma
+        language_code: Language code (e.g., "lt", "la", "ru", "de")
+
+    Returns:
+        The declension class string (e.g., "1", "2", "3"), or None if not found
+
+    Example:
+        declension = get_declension_class(session, lemma_id=789, language_code="lt")
+        if declension:
+            print(f"This noun follows declension pattern {declension}")
+    """
+    return get_grammar_fact_value(session, lemma_id, language_code, "declension")


### PR DESCRIPTION
This commit adds comprehensive support for Chinese measure words (量词/classifiers) in the Grammar Facts system, with a flexible architecture for future grammar fact types.

Changes:
- Created Lape agent (src/wordfreq/agents/lape.py): General-purpose Grammar Facts generator with command-line interface. Currently supports Chinese measure words, with comments outlining future expansions (grammatical gender, plurale tantum, etc.)

- Added LLM prompts (src/wordfreq/prompts/measure_words/): Context and prompt templates for generating Chinese measure words using AI

- Extended database helpers (src/wordfreq/storage/crud/grammar_fact.py): Added convenience functions get_measure_word(), get_grammatical_gender(), and get_declension_class() for accessing grammar facts

- Web interface support (BARSUKAS):
  * Added generate_grammar_fact route in src/barsukas/routes/agents.py
  * Updated lemma view template to display grammar facts table
  * Added modal dialog for generating grammar facts with AI
  * Updated lemmas.py route to fetch and display grammar facts

Usage:
- Command line: python lape.py --fact-type measure_words --language zh --limit 10
- Web interface: View any noun lemma and click "Generate Grammar Fact" button

The agent is designed to be extensible for additional grammar fact types across multiple languages (French gender, Lithuanian declension, etc.) as noted in comments.