### PR TITLE
Add multilingual rhyme browsing and Papuga language targeting (French/Spanish)

### DIFF
--- a/src/agents/papuga/agent.py
+++ b/src/agents/papuga/agent.py
@@ -75,6 +75,22 @@ class PapugaAgent:
             )
         return self.cache_client
 
+    @staticmethod
+    def _resolve_language_codes(
+        *,
+        only_english: bool,
+        language_codes: Optional[List[str]],
+    ) -> Optional[List[str]]:
+        """Return normalized language codes to filter by, or ``None`` for all languages."""
+        if language_codes:
+            normalized_codes = sorted(
+                {language.strip().lower() for language in language_codes if language.strip()}
+            )
+            return normalized_codes if normalized_codes else None
+        if only_english:
+            return ["en"]
+        return None
+
     def _get_example_sentence(self, session: Session, lemma: Lemma) -> Optional[str]:
         """
         Get an example sentence featuring this lemma from the new sentences system.
@@ -119,6 +135,7 @@ class PapugaAgent:
         sample_rate: float = 1.0,
         confidence_threshold: float = 0.7,
         only_english: bool = True,
+        language_codes: Optional[List[str]] = None,
         dry_run: bool = False,
         lemma_id: Optional[int] = None,
         lemmas: Optional[List[Lemma]] = None,
@@ -131,6 +148,7 @@ class PapugaAgent:
             sample_rate: Fraction of forms to sample (0.0-1.0)
             confidence_threshold: Minimum confidence to flag issues
             only_english: Only check English forms (language_code='en')
+            language_codes: Optional explicit languages to process (overrides only_english)
             dry_run: If True, don't make LLM API calls, just count what would be checked
             lemma_id: Optional lemma ID to filter to a specific lemma
             lemmas: Optional pre-filtered list of lemmas to check
@@ -155,8 +173,12 @@ class PapugaAgent:
             elif lemma_id:
                 query = query.filter(DerivativeForm.lemma_id == lemma_id)
 
-            if only_english:
-                query = query.filter(DerivativeForm.language_code == "en")
+            selected_languages = self._resolve_language_codes(
+                only_english=only_english,
+                language_codes=language_codes,
+            )
+            if selected_languages:
+                query = query.filter(DerivativeForm.language_code.in_(selected_languages))
 
             query = query.order_by(DerivativeForm.id)
 
@@ -257,6 +279,7 @@ class PapugaAgent:
         self,
         limit: Optional[int] = None,
         only_english: bool = True,
+        language_codes: Optional[List[str]] = None,
         only_base_forms: bool = False,
         all_forms_pronunciation: bool = False,
         lemma_id: Optional[int] = None,
@@ -268,6 +291,7 @@ class PapugaAgent:
         Args:
             limit: Maximum number to report
             only_english: Only check English forms (language_code='en')
+            language_codes: Optional explicit languages to process (overrides only_english)
             only_base_forms: Only check base forms (is_base_form=True)
             lemma_id: Optional lemma ID to filter to a specific lemma
             lemmas: Optional pre-filtered list of lemmas to check
@@ -294,8 +318,12 @@ class PapugaAgent:
             elif lemma_id:
                 query = query.filter(DerivativeForm.lemma_id == lemma_id)
 
-            if only_english:
-                query = query.filter(DerivativeForm.language_code == "en")
+            selected_languages = self._resolve_language_codes(
+                only_english=only_english,
+                language_codes=language_codes,
+            )
+            if selected_languages:
+                query = query.filter(DerivativeForm.language_code.in_(selected_languages))
 
             if only_base_forms:
                 query = query.filter(DerivativeForm.is_base_form == True)
@@ -320,8 +348,10 @@ class PapugaAgent:
             elif lemma_id:
                 translation_query = translation_query.filter(LemmaTranslation.lemma_id == lemma_id)
 
-            if only_english:
-                translation_query = translation_query.filter(LemmaTranslation.language_code == "en")
+            if selected_languages:
+                translation_query = translation_query.filter(
+                    LemmaTranslation.language_code.in_(selected_languages)
+                )
 
             missing_translations = translation_query.order_by(LemmaTranslation.id).all()
 
@@ -362,6 +392,7 @@ class PapugaAgent:
                 "total_missing": total_missing,
                 "missing_forms": missing_list,
                 "only_english": only_english,
+                "language_codes": selected_languages,
                 "only_base_forms": only_base_forms,
                 "all_forms_pronunciation": all_forms_pronunciation,
             }
@@ -376,6 +407,7 @@ class PapugaAgent:
         self,
         limit: Optional[int] = None,
         only_english: bool = True,
+        language_codes: Optional[List[str]] = None,
         only_base_forms: bool = False,
         all_forms_pronunciation: bool = False,
         dry_run: bool = False,
@@ -391,6 +423,7 @@ class PapugaAgent:
         Args:
             limit: Maximum number of lemmas to process
             only_english: Only process English forms
+            language_codes: Optional explicit languages to process (overrides only_english)
             only_base_forms: Only process base forms
             dry_run: If True, don't actually update the database
             lemma_id: Optional lemma ID to filter to a specific lemma
@@ -418,8 +451,12 @@ class PapugaAgent:
             elif lemma_id:
                 query = query.filter(DerivativeForm.lemma_id == lemma_id)
 
-            if only_english:
-                query = query.filter(DerivativeForm.language_code == "en")
+            selected_languages = self._resolve_language_codes(
+                only_english=only_english,
+                language_codes=language_codes,
+            )
+            if selected_languages:
+                query = query.filter(DerivativeForm.language_code.in_(selected_languages))
 
             if only_base_forms:
                 query = query.filter(DerivativeForm.is_base_form == True)
@@ -452,8 +489,10 @@ class PapugaAgent:
             elif lemma_id:
                 translation_query = translation_query.filter(LemmaTranslation.lemma_id == lemma_id)
 
-            if only_english:
-                translation_query = translation_query.filter(LemmaTranslation.language_code == "en")
+            if selected_languages:
+                translation_query = translation_query.filter(
+                    LemmaTranslation.language_code.in_(selected_languages)
+                )
 
             translation_pairs = {
                 (translation_obj.lemma_id, translation_obj.language_code)
@@ -706,6 +745,7 @@ class PapugaAgent:
         sample_rate: float = 1.0,
         confidence_threshold: float = 0.7,
         only_english: bool = True,
+        language_codes: Optional[List[str]] = None,
         dry_run: bool = False,
         lemma_id: Optional[int] = None,
         lemmas: Optional[List[Lemma]] = None,
@@ -719,6 +759,7 @@ class PapugaAgent:
             sample_rate: Fraction to sample (0.0-1.0)
             confidence_threshold: Minimum confidence to flag issues
             only_english: Only check English forms
+            language_codes: Optional explicit languages to process (overrides only_english)
             dry_run: If True, don't make LLM API calls, just count what would be checked
             lemma_id: Optional lemma ID to filter to a specific lemma
             lemmas: Optional pre-filtered list of lemmas to check
@@ -735,6 +776,7 @@ class PapugaAgent:
             "sample_rate": sample_rate,
             "confidence_threshold": confidence_threshold,
             "only_english": only_english,
+            "language_codes": language_codes,
             "dry_run": dry_run,
             "checks": {},
         }
@@ -745,6 +787,7 @@ class PapugaAgent:
             sample_rate=sample_rate,
             confidence_threshold=confidence_threshold,
             only_english=only_english,
+            language_codes=language_codes,
             dry_run=dry_run,
             lemma_id=lemma_id,
             lemmas=lemmas,
@@ -754,6 +797,7 @@ class PapugaAgent:
         results["checks"]["missing_pronunciations"] = self.check_missing_pronunciations(
             limit=limit,
             only_english=only_english,
+            language_codes=language_codes,
             only_base_forms=False,
             lemma_id=lemma_id,
             lemmas=lemmas,

--- a/src/agents/papuga/cli.py
+++ b/src/agents/papuga/cli.py
@@ -8,7 +8,7 @@ This module handles all CLI argument parsing and the main entry point.
 import argparse
 import logging
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from agents.common.common_args import (
     add_backend_args,
@@ -37,6 +37,16 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _parse_language_codes(raw_languages: Optional[str]) -> Optional[List[str]]:
+    """Parse a comma-separated language-code string into normalized codes."""
+    if not raw_languages:
+        return None
+    normalized_codes = sorted(
+        {language.strip().lower() for language in raw_languages.split(",") if language.strip()}
+    )
+    return normalized_codes if normalized_codes else None
+
+
 def get_argument_parser() -> argparse.ArgumentParser:
     """Return the argument parser for introspection.
 
@@ -60,6 +70,11 @@ def get_argument_parser() -> argparse.ArgumentParser:
     # Papuga-specific arguments
     parser.add_argument(
         "--all-languages", action="store_true", help="Process all languages (default: English only)"
+    )
+    parser.add_argument(
+        "--languages",
+        type=str,
+        help="Comma-separated language codes to process (e.g., 'fr,es')",
     )
 
     # Mode selection - mutually exclusive flags
@@ -101,6 +116,7 @@ def enqueue_papuga_work(
     session: Any,
     lemmas: List[Any],
     only_english: bool = True,
+    language_codes: Optional[List[str]] = None,
     base_forms_only: bool = False,
     all_forms_pronunciation: bool = False,
     dry_run: bool = False,
@@ -111,6 +127,7 @@ def enqueue_papuga_work(
         session: Database session
         lemmas: List of lemmas to process
         only_english: Only process English forms
+        language_codes: Optional explicit languages to process (overrides only_english)
         base_forms_only: Only process base forms
         all_forms_pronunciation: Include optional forms (legacy behavior)
         dry_run: If True, don't actually enqueue
@@ -130,8 +147,9 @@ def enqueue_papuga_work(
         needs_pronunciation_update_filter(),
         pronunciation_required_filter(include_optional_forms=all_forms_pronunciation),
     )
-    if only_english:
-        query = query.filter(DerivativeForm.language_code == "en")
+    selected_languages = language_codes if language_codes else (["en"] if only_english else None)
+    if selected_languages:
+        query = query.filter(DerivativeForm.language_code.in_(selected_languages))
     if base_forms_only:
         query = query.filter(DerivativeForm.is_base_form == True)
 
@@ -176,6 +194,8 @@ def main() -> None:
 
     parser = get_argument_parser()
     args = parser.parse_args()
+    if args.all_languages and args.languages:
+        parser.error("--all-languages and --languages cannot be used together")
 
     # Validate cache arguments
     validate_cache_args(args)
@@ -189,7 +209,8 @@ def main() -> None:
     else:
         mode = "coverage"  # default
 
-    only_english = not args.all_languages
+    selected_languages = _parse_language_codes(args.languages)
+    only_english = not args.all_languages and selected_languages is None
 
     # Get lemmas to process (either single lemma from --guid or batch)
     agent_temp = PapugaAgent(config=config)
@@ -221,6 +242,7 @@ def main() -> None:
                 session=session,
                 lemmas=lemmas,
                 only_english=only_english,
+                language_codes=selected_languages,
                 base_forms_only=args.base_forms_only,
                 all_forms_pronunciation=args.all_forms_pronunciation,
                 dry_run=args.dry_run,
@@ -248,7 +270,9 @@ def main() -> None:
             )
             if lemma_id:
                 query = query.filter(DerivativeForm.lemma_id == lemma_id)
-            if only_english:
+            if selected_languages:
+                query = query.filter(DerivativeForm.language_code.in_(selected_languages))
+            elif only_english:
                 query = query.filter(DerivativeForm.language_code == "en")
             if args.base_forms_only:
                 query = query.filter(DerivativeForm.is_base_form == True)
@@ -278,6 +302,7 @@ def main() -> None:
         result = agent.check_missing_pronunciations(
             limit=args.limit,
             only_english=only_english,
+            language_codes=selected_languages,
             only_base_forms=args.base_forms_only,
             all_forms_pronunciation=args.all_forms_pronunciation,
             lemma_id=lemma_id,
@@ -290,6 +315,7 @@ def main() -> None:
         result = agent.populate_missing_pronunciations(
             limit=args.limit,
             only_english=only_english,
+            language_codes=selected_languages,
             only_base_forms=args.base_forms_only,
             all_forms_pronunciation=args.all_forms_pronunciation,
             dry_run=args.dry_run,

--- a/src/barsukas/routes/rhymes.py
+++ b/src/barsukas/routes/rhymes.py
@@ -3,7 +3,7 @@
 """
 Rhyming dictionary routes.
 
-Provides a two-tier browse of rhyme families derived from English IPA
+Provides a two-tier browse of rhyme families derived from language-specific IPA
 pronunciations stored on DerivativeForm.rhyme_key.
 
 Tier 1 (index):  Select a final sound (consonant or vowel cluster).
@@ -24,6 +24,7 @@ from langtools.rhyme_keys import (
     rhyme_key_penultimate_sound,
 )
 from storage.models.schema import DerivativeForm, Lemma
+from storage.translation_helpers import get_supported_languages
 
 bp = Blueprint("rhymes", __name__, url_prefix="/rhymes")
 
@@ -41,6 +42,15 @@ def _validated_language_code(raw_language: Optional[str]) -> str:
     if candidate in RHYME_KEY_LANGUAGES:
         return candidate
     return "en"
+
+
+def _rhyme_language_options() -> List[Tuple[str, str]]:
+    """Return sorted (language_code, language_name) options for rhyme browsing."""
+    language_names = get_supported_languages()
+    options: List[Tuple[str, str]] = []
+    for language_code in sorted(RHYME_KEY_LANGUAGES):
+        options.append((language_code, language_names.get(language_code, language_code)))
+    return options
 
 
 def _rhyme_family_rows(language_code: str) -> List[Tuple[str, int, str]]:
@@ -209,6 +219,7 @@ def index() -> ResponseReturnValue:
         families=families,
         total_families=total_families,
         selected_language=selected_language,
+        language_options=_rhyme_language_options(),
     )
 
 
@@ -244,4 +255,5 @@ def family() -> ResponseReturnValue:
         related_families=related,
         final_sound=final_sound,
         selected_language=selected_language,
+        language_options=_rhyme_language_options(),
     )

--- a/src/barsukas/templates/rhymes/family.html
+++ b/src/barsukas/templates/rhymes/family.html
@@ -15,6 +15,23 @@
     </div>
 </div>
 
+<form method="get" class="row g-2 align-items-end mb-3">
+    <input type="hidden" name="key" value="{{ rhyme_key or '' }}">
+    <div class="col-auto">
+        <label for="language" class="form-label mb-1">Language</label>
+        <select class="form-select form-select-sm" id="language" name="language">
+            {% for lang_code, lang_name in language_options %}
+                <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
+                    {{ lang_name }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+    </div>
+</form>
+
 {% if rhyme_key %}
 <div class="row mb-3">
     <div class="col">

--- a/src/barsukas/templates/rhymes/index.html
+++ b/src/barsukas/templates/rhymes/index.html
@@ -16,6 +16,28 @@
     </div>
 </div>
 
+<form method="get" class="row g-2 align-items-end mb-3">
+    <div class="col-auto">
+        <label for="language" class="form-label mb-1">Language</label>
+        <select class="form-select form-select-sm" id="language" name="language">
+            {% for lang_code, lang_name in language_options %}
+                <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
+                    {{ lang_name }}
+                </option>
+            {% endfor %}
+        </select>
+    </div>
+    {% if selected_sound %}
+        <input type="hidden" name="sound" value="{{ selected_sound }}">
+    {% endif %}
+    {% if selected_penultimate %}
+        <input type="hidden" name="pen" value="{{ selected_penultimate }}">
+    {% endif %}
+    <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+    </div>
+</form>
+
 <!-- Tier 1: Final sound navigation -->
 {% if final_sounds %}
 <nav class="rhyme-nav mb-3" aria-label="Final sound navigation">

--- a/src/tests/agents/test_papuga.py
+++ b/src/tests/agents/test_papuga.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from agents.papuga.agent import PapugaAgent
-from agents.papuga.cli import enqueue_papuga_work
+from agents.papuga.cli import _parse_language_codes, enqueue_papuga_work
 from storage.backend.config import BackendType, DataSourceConfig
 from storage.models.schema import Base, DerivativeForm, Lemma, LemmaTranslation
 from workqueue.handlers.papuga import generate_pronunciations_for_lemma
@@ -121,7 +121,7 @@ def test_enqueue_papuga_work_enqueues_once_per_lemma_language() -> None:
         )
         session.commit()
 
-        captured_calls = []
+        captured_calls: list[dict[str, object]] = []
 
         class _Result:
             created = True
@@ -149,6 +149,81 @@ def test_enqueue_papuga_work_enqueues_once_per_lemma_language() -> None:
             "lemma_id": lemma.id,
             "all_forms_pronunciation": False,
         }
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_parse_language_codes_normalizes_and_deduplicates() -> None:
+    """CLI language parsing should normalize case/spacing and remove duplicates."""
+    assert _parse_language_codes(" FR,es, fr ,ES ") == ["es", "fr"]
+    assert _parse_language_codes("") is None
+
+
+def test_enqueue_papuga_work_filters_selected_languages() -> None:
+    """Workqueue enqueue should honor explicit language filters."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    session = Session(engine)
+    try:
+        lemma = Lemma(
+            lemma_text="run",
+            definition_text="to move quickly",
+            pos_type="verb",
+            guid="V00_00X",
+        )
+        session.add(lemma)
+        session.flush()
+
+        session.add_all(
+            [
+                DerivativeForm(
+                    lemma_id=lemma.id,
+                    derivative_form_text="run",
+                    language_code="en",
+                    grammatical_form="infinitive",
+                    is_base_form=True,
+                    ipa_pronunciation=None,
+                    phonetic_pronunciation=None,
+                ),
+                DerivativeForm(
+                    lemma_id=lemma.id,
+                    derivative_form_text="corro",
+                    language_code="es",
+                    grammatical_form="present_1s",
+                    is_base_form=False,
+                    ipa_pronunciation=None,
+                    phonetic_pronunciation=None,
+                ),
+            ]
+        )
+        session.commit()
+
+        captured_calls = []
+
+        class _Result:
+            created = True
+
+        def _fake_enqueue_task(db_session: Session, **kwargs: object) -> _Result:
+            captured_calls.append(kwargs)
+            return _Result()
+
+        with patch("workqueue.task_queue.enqueue_task", side_effect=_fake_enqueue_task):
+            results = enqueue_papuga_work(
+                session=session,
+                lemmas=[lemma],
+                only_english=False,
+                language_codes=["es"],
+                all_forms_pronunciation=True,
+                dry_run=False,
+            )
+
+        assert results["enqueued"] == 1
+        assert len(captured_calls) == 1
+        payload = captured_calls[0]["payload"]
+        assert isinstance(payload, dict)
+        assert payload["lang_code"] == "es"
     finally:
         session.close()
         engine.dispose()

--- a/src/tests/barsukas/test_rhymes_routes.py
+++ b/src/tests/barsukas/test_rhymes_routes.py
@@ -143,6 +143,9 @@ def test_rhyme_index_renders_french_and_spanish_families(client: FlaskClient, db
     fr_response = client.get("/rhymes/?language=fr")
     assert fr_response.status_code == 200
     fr_html = fr_response.data.decode()
+    assert 'name="language"' in fr_html
+    assert 'option value="fr"' in fr_html
+    assert 'option value="es"' in fr_html
     assert "-e" in fr_html
     assert "chanter" in fr_html or "danser" in fr_html
 


### PR DESCRIPTION
### Motivation
- Enable the rhyming dictionary and pronunciation generator to support additional languages (French and Spanish first) by surfacing language selection in the Barsukas UI and allowing Papuga to target non-English languages. 

### Description
- Add language-selection plumbing to rhyme routes and templates so the rhymes index and family pages can be browsed by any supported rhyme-key language and preserve selected sound/key filters when switching languages. 
- Use shared supported-language metadata via `get_supported_languages()` and `RHYME_KEY_LANGUAGES` so UI options are localized and limited to rhyme-capable languages. 
- Extend the PAPUGA CLI with a `--languages` comma-separated option (and validation vs `--all-languages`) and thread explicit language filters through `enqueue_papuga_work` and PapugaAgent methods. 
- Add agent-side filtering (`language_codes`) to `check_pronunciations`, `check_missing_pronunciations`, `populate_missing_pronunciations`, and `run_full_check` so targeted IPA generation and coverage checks operate consistently for non-English languages. 

### Testing
- Ran formatting and static checks: `python -m black ...` and `PYTHONPATH=src mypy ...`, both succeeded with no issues. 
- Ran unit tests: `PYTHONPATH=src pytest -q src/tests/agents/test_papuga.py src/tests/barsukas/test_rhymes_routes.py`, all tests passed (`14 passed`). 
- Updated/added tests include CLI parsing and enqueue filtering tests in `src/tests/agents/test_papuga.py` and route-level rendering tests in `src/tests/barsukas/test_rhymes_routes.py`, which passed under CI-style test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd07d78b08327a381feec1153682c)