### PR TITLE
barsukas: add namespaced UI strings and localize /dictionary view

### DIFF
--- a/src/barsukas/helpers/strings.py
+++ b/src/barsukas/helpers/strings.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+
+"""Helpers for loading Barsukas UI strings from namespaced JSON files."""
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, cast
+
+SUPPORTED_UI_LANGS = frozenset({"en", "lt"})
+_STRINGS_ROOT = Path(__file__).resolve().parents[3] / "strings" / "barsukas"
+
+
+@lru_cache(maxsize=64)
+def _load_namespace_file(namespace: str, ui_lang: str) -> Dict[str, Any]:
+    """Load one namespace JSON file with English fallback."""
+    if ui_lang not in SUPPORTED_UI_LANGS:
+        ui_lang = "en"
+
+    namespace_path = _STRINGS_ROOT / namespace / f"{ui_lang}.json"
+    fallback_path = _STRINGS_ROOT / namespace / "en.json"
+
+    if namespace_path.exists():
+        with namespace_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+            return cast(Dict[str, Any], loaded)
+
+    if fallback_path.exists():
+        with fallback_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+            return cast(Dict[str, Any], loaded)
+
+    return {}
+
+
+def load_barsukas_strings(namespace: str, ui_lang: str) -> Dict[str, Any]:
+    """Public helper for route handlers to fetch namespace strings."""
+    return _load_namespace_file(namespace=namespace, ui_lang=ui_lang)

--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -14,6 +14,7 @@ from flask.typing import ResponseReturnValue
 from sqlalchemy import func
 from sqlalchemy.orm import Query
 
+from barsukas.helpers.strings import SUPPORTED_UI_LANGS, load_barsukas_strings
 from barsukas.routes.categories import (
     ADJECTIVE_GROUPS,
     ADVERB_GROUPS,
@@ -33,18 +34,18 @@ DICT_ITEMS_PER_PAGE = 200
 
 # Languages available as a source (browsing) language.
 # Order determines display in the dropdown.
-DICTIONARY_SOURCE_LANGUAGES: List[Tuple[str, str]] = [
-    ("en", "English"),
-    ("lt", "Lithuanian"),
-    ("zh", "Chinese"),
-    ("fr", "French"),
-    ("es", "Spanish"),
-    ("de", "German"),
-    ("it", "Italian"),
-    ("pt", "Portuguese"),
-    ("ja", "Japanese"),
-    ("ko", "Korean"),
-    ("vi", "Vietnamese"),
+DICTIONARY_SOURCE_LANGUAGES: List[str] = [
+    "en",
+    "lt",
+    "zh",
+    "fr",
+    "es",
+    "de",
+    "it",
+    "pt",
+    "ja",
+    "ko",
+    "vi",
 ]
 
 # The pool of translation languages to display alongside headwords.
@@ -104,6 +105,18 @@ def _get_display_langs(source_lang: str) -> List[str]:
 def _get_alphabet(source_lang: str) -> List[str]:
     """Return the alphabet to use for the letter bar."""
     return LANGUAGE_ALPHABETS.get(source_lang, list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+
+
+def _localized_language_names(ui_lang: str) -> Dict[str, str]:
+    """Return language names in the selected UI language with English fallback."""
+    strings = load_barsukas_strings(namespace="languages", ui_lang=ui_lang)
+    result: Dict[str, str] = {}
+    for code in DICTIONARY_SOURCE_LANGUAGES:
+        result[code] = strings.get(code, LANGUAGE_NAMES.get(code, code))
+    for code in DICTIONARY_DISPLAY_POOL:
+        if code not in result:
+            result[code] = strings.get(code, LANGUAGE_NAMES.get(code, code))
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -227,9 +240,9 @@ def _available_letters(lang: str) -> set[str]:
             return {KANA_TO_ROW.get(c, c) for c in raw_initials}
         elif lang == "zh":
             return {c.upper() for c in raw_initials if c.isalpha()}
-        else:
-            # Korean jamo — direct match.
-            return raw_initials
+
+        # Korean jamo — direct match.
+        return raw_initials
 
     # Latin-alphabet languages (including those with sort keys).
     rows = (
@@ -321,14 +334,17 @@ def dictionary() -> ResponseReturnValue:
     """Dictionary browse view."""
     lang = request.args.get("lang", "en").strip().lower()
     sort = request.args.get("sort", "alpha").strip().lower()
+    ui_lang = request.args.get("ui", "en").strip().lower()
     page = request.args.get("page", 1, type=int)
 
     # Validate inputs.
-    valid_codes = {code for code, _ in DICTIONARY_SOURCE_LANGUAGES}
+    valid_codes = set(DICTIONARY_SOURCE_LANGUAGES)
     if lang not in valid_codes:
         lang = "en"
     if sort not in ("alpha", "level", "category"):
         sort = "alpha"
+    if ui_lang not in SUPPORTED_UI_LANGS:
+        ui_lang = "en"
 
     display_langs = _get_display_langs(lang)
     alphabet = _get_alphabet(lang)
@@ -404,8 +420,8 @@ def dictionary() -> ResponseReturnValue:
             )
             .all()
         )
-        for r in rows:
-            translations_map.setdefault(r.lemma_id, {})[r.language_code] = r.translation
+        for row in rows:
+            translations_map.setdefault(row.lemma_id, {})[row.language_code] = row.translation
 
     # --- Build entry dicts for template ---
 
@@ -428,9 +444,23 @@ def dictionary() -> ResponseReturnValue:
             }
         )
 
+    dictionary_strings = load_barsukas_strings(namespace="dictionary", ui_lang=ui_lang)
+    navigation_strings = load_barsukas_strings(namespace="navigation", ui_lang=ui_lang)
+    pagination_strings = load_barsukas_strings(namespace="pagination", ui_lang=ui_lang)
+
+    entries_label_template = dictionary_strings.get("entries_count", "{count} entries")
+    entries_label = entries_label_template.format(count=total)
+
+    language_names = _localized_language_names(ui_lang)
+    available_languages: List[Tuple[str, str]] = [
+        (code, language_names.get(code, LANGUAGE_NAMES.get(code, code)))
+        for code in DICTIONARY_SOURCE_LANGUAGES
+    ]
+
     return render_template(
         "dictionary/index.html",
         lang=lang,
+        ui_lang=ui_lang,
         letter=letter,
         sort=sort,
         selected_level=selected_level,
@@ -444,6 +474,10 @@ def dictionary() -> ResponseReturnValue:
         display_langs=display_langs,
         alphabet=alphabet,
         available_letters=available_letters,
-        available_languages=DICTIONARY_SOURCE_LANGUAGES,
-        language_names=LANGUAGE_NAMES,
+        available_languages=available_languages,
+        language_names=language_names,
+        dictionary_strings=dictionary_strings,
+        navigation_strings=navigation_strings,
+        pagination_strings=pagination_strings,
+        entries_label=entries_label,
     )

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dictionary - {{ language_names[lang] }}{% endblock %}
+{% block title %}{{ dictionary_strings.title }} - {{ language_names[lang] }}{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dictionary.css') }}">
@@ -10,8 +10,8 @@
 <div class="row mb-3">
     <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-            <h1 class="h4 mb-0"><i class="bi bi-journal-bookmark"></i> Dictionary</h1>
-            <span class="text-muted">{{ total }} entries</span>
+            <h1 class="h4 mb-0"><i class="bi bi-journal-bookmark"></i> {{ dictionary_strings.title }}</h1>
+            <span class="text-muted">{{ entries_label }}</span>
         </div>
     </div>
 </div>
@@ -19,8 +19,9 @@
 <!-- Language selector and sort control -->
 <div class="dict-controls mb-3">
     <form method="get" action="{{ url_for('peleda.dictionary') }}" class="row g-2 align-items-end">
+        <input type="hidden" name="ui" value="{{ ui_lang }}">
         <div class="col-auto">
-            <label for="lang" class="form-label mb-0 small text-muted">Source language</label>
+            <label for="lang" class="form-label mb-0 small text-muted">{{ dictionary_strings.source_language }}</label>
             <select class="form-select form-select-sm" id="lang" name="lang" onchange="this.form.submit()">
                 {% for code, name in available_languages %}
                     <option value="{{ code }}" {% if code == lang %}selected{% endif %}>{{ name }}</option>
@@ -28,16 +29,16 @@
             </select>
         </div>
         <div class="col-auto">
-            <label for="sort" class="form-label mb-0 small text-muted">Sort by</label>
+            <label for="sort" class="form-label mb-0 small text-muted">{{ navigation_strings.sort_by }}</label>
             <select class="form-select form-select-sm" id="sort" name="sort" onchange="this.form.submit()">
-                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>Alphabetical</option>
-                <option value="level" {% if sort == 'level' %}selected{% endif %}>Level</option>
-                <option value="category" {% if sort == 'category' %}selected{% endif %}>Category</option>
+                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ dictionary_strings.sort_alpha }}</option>
+                <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ dictionary_strings.sort_level }}</option>
+                <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ dictionary_strings.sort_category }}</option>
             </select>
         </div>
         {% if sort == 'category' %}
         <div class="col-auto">
-            <label for="category" class="form-label mb-0 small text-muted">Category</label>
+            <label for="category" class="form-label mb-0 small text-muted">{{ dictionary_strings.category }}</label>
             <select class="form-select form-select-sm dict-category-select" id="category" name="category" onchange="this.form.submit()">
                 {% for group in category_options %}
                     <optgroup label="{{ group.label }}">
@@ -63,7 +64,7 @@
         {% if l == letter %}
             <span class="dict-letter dict-letter-active">{{ l }}</span>
         {% elif l in available_letters %}
-            <a href="{{ url_for('peleda.dictionary', lang=lang, letter=l, sort='alpha') }}"
+            <a href="{{ url_for('peleda.dictionary', lang=lang, letter=l, sort='alpha', ui=ui_lang) }}"
                class="dict-letter">{{ l }}</a>
         {% else %}
             <span class="dict-letter dict-letter-disabled">{{ l }}</span>
@@ -77,7 +78,7 @@
         {% if lv == selected_level %}
             <span class="dict-letter dict-letter-active">{{ lv }}</span>
         {% else %}
-            <a href="{{ url_for('peleda.dictionary', lang=lang, sort='level', level=lv) }}"
+            <a href="{{ url_for('peleda.dictionary', lang=lang, sort='level', level=lv, ui=ui_lang) }}"
                class="dict-letter">{{ lv }}</a>
         {% endif %}
     {% endfor %}
@@ -93,7 +94,7 @@
                 {% for code in display_langs %}
                     <th class="dict-trans-col">{{ language_names[code] }}</th>
                 {% endfor %}
-                <th class="dict-pos-col">POS</th>
+                <th class="dict-pos-col">{{ dictionary_strings.pos }}</th>
             </tr>
         </thead>
         <tbody>
@@ -128,7 +129,15 @@
             {% if not entries %}
                 <tr>
                     <td colspan="{{ display_langs|length + 2 }}" class="text-center text-muted py-4">
-                        No entries{% if sort == 'alpha' %} for this letter{% elif sort == 'level' %} for this level{% elif sort == 'category' %} for this category{% endif %}.
+                        {% if sort == 'alpha' %}
+                            {{ dictionary_strings.no_entries_for_letter }}
+                        {% elif sort == 'level' %}
+                            {{ dictionary_strings.no_entries_for_level }}
+                        {% elif sort == 'category' %}
+                            {{ dictionary_strings.no_entries_for_category }}
+                        {% else %}
+                            {{ dictionary_strings.no_entries }}
+                        {% endif %}
                     </td>
                 </tr>
             {% endif %}
@@ -139,16 +148,16 @@
 <!-- Pagination -->
 {% if total_pages > 1 %}
     {% if sort == 'category' %}
-        {% set page_params = {'lang': lang, 'sort': 'category', 'category': selected_category} %}
+        {% set page_params = {'lang': lang, 'sort': 'category', 'category': selected_category, 'ui': ui_lang} %}
     {% elif sort == 'level' %}
-        {% set page_params = {'lang': lang, 'sort': 'level', 'level': selected_level} %}
+        {% set page_params = {'lang': lang, 'sort': 'level', 'level': selected_level, 'ui': ui_lang} %}
     {% else %}
-        {% set page_params = {'lang': lang, 'sort': 'alpha', 'letter': letter} %}
+        {% set page_params = {'lang': lang, 'sort': 'alpha', 'letter': letter, 'ui': ui_lang} %}
     {% endif %}
     <nav class="mt-3" aria-label="Page navigation">
         <ul class="pagination pagination-sm justify-content-center">
             <li class="page-item {% if page == 1 %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page-1, **page_params) }}">Prev</a>
+                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page-1, **page_params) }}">{{ pagination_strings.prev }}</a>
             </li>
             {% for p in range(1, total_pages + 1) %}
                 {% if p == page or (p <= 2 or p > total_pages - 2 or (p >= page - 2 and p <= page + 2)) %}
@@ -160,7 +169,7 @@
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if page == total_pages %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page+1, **page_params) }}">Next</a>
+                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page+1, **page_params) }}">{{ pagination_strings.next }}</a>
             </li>
         </ul>
     </nav>

--- a/strings/barsukas/dictionary/en.json
+++ b/strings/barsukas/dictionary/en.json
@@ -1,0 +1,14 @@
+{
+  "title": "Dictionary",
+  "source_language": "Source language",
+  "entries_count": "{count} entries",
+  "pos": "POS",
+  "category": "Category",
+  "sort_alpha": "Alphabetical",
+  "sort_level": "Level",
+  "sort_category": "Category",
+  "no_entries": "No entries",
+  "no_entries_for_letter": "No entries for this letter.",
+  "no_entries_for_level": "No entries for this level.",
+  "no_entries_for_category": "No entries for this category."
+}

--- a/strings/barsukas/dictionary/lt.json
+++ b/strings/barsukas/dictionary/lt.json
@@ -1,0 +1,14 @@
+{
+  "title": "Žodynas",
+  "source_language": "Pradinė kalba",
+  "entries_count": "{count} įrašų",
+  "pos": "Kalbos dalis",
+  "category": "Kategorija",
+  "sort_alpha": "Abėcėlė",
+  "sort_level": "Lygis",
+  "sort_category": "Kategorija",
+  "no_entries": "Įrašų nėra",
+  "no_entries_for_letter": "Šiai raidei įrašų nėra.",
+  "no_entries_for_level": "Šiam lygiui įrašų nėra.",
+  "no_entries_for_category": "Šiai kategorijai įrašų nėra."
+}

--- a/strings/barsukas/languages/en.json
+++ b/strings/barsukas/languages/en.json
@@ -1,0 +1,13 @@
+{
+  "en": "English",
+  "lt": "Lithuanian",
+  "zh": "Chinese",
+  "fr": "French",
+  "es": "Spanish",
+  "de": "German",
+  "it": "Italian",
+  "pt": "Portuguese",
+  "ja": "Japanese",
+  "ko": "Korean",
+  "vi": "Vietnamese"
+}

--- a/strings/barsukas/languages/lt.json
+++ b/strings/barsukas/languages/lt.json
@@ -1,0 +1,13 @@
+{
+  "en": "Anglų",
+  "lt": "Lietuvių",
+  "zh": "Kinų",
+  "fr": "Prancūzų",
+  "es": "Ispanų",
+  "de": "Vokiečių",
+  "it": "Italų",
+  "pt": "Portugalų",
+  "ja": "Japonų",
+  "ko": "Korėjiečių",
+  "vi": "Vietnamiečių"
+}

--- a/strings/barsukas/navigation/en.json
+++ b/strings/barsukas/navigation/en.json
@@ -1,0 +1,3 @@
+{
+  "sort_by": "Sort by"
+}

--- a/strings/barsukas/navigation/lt.json
+++ b/strings/barsukas/navigation/lt.json
@@ -1,0 +1,3 @@
+{
+  "sort_by": "Rikiuoti pagal"
+}

--- a/strings/barsukas/pagination/en.json
+++ b/strings/barsukas/pagination/en.json
@@ -1,0 +1,4 @@
+{
+  "prev": "Prev",
+  "next": "Next"
+}

--- a/strings/barsukas/pagination/lt.json
+++ b/strings/barsukas/pagination/lt.json
@@ -1,0 +1,4 @@
+{
+  "prev": "Ankst.",
+  "next": "Toliau"
+}


### PR DESCRIPTION
### Motivation
- Move hardcoded UI labels for the dictionary view into namespaced, language-specific string files so the Barsukas UI can be localized and extended.
- Provide initial English and Lithuanian translations and a small runtime to load them with fallback to English.
- Preserve existing route/query logic while exposing a UI language choice so users can view the dictionary controls in `en` or `lt`.

### Description
- Added a small strings loader `load_barsukas_strings(namespace, ui_lang)` in `src/barsukas/helpers/strings.py` that reads `strings/barsukas/<namespace>/<lang>.json` with English fallback and caching via `lru_cache`.
- Updated the dictionary route logic in `src/barsukas/routes/peleda.py` to accept a `ui` query parameter, load the `dictionary`, `navigation`, and `pagination` namespaces, localize visible language names via a `_localized_language_names()` helper, and format the entries count using the loaded template string.
- Reworked the template `src/barsukas/templates/dictionary/index.html` to use the loaded strings (labels like `Source language`, `Sort by`, sort options, POS header, empty-state messages, and pagination `Prev`/`Next`) and to preserve the `ui` query param across form submits and pagination/alphabet links.
- Added initial namespaced JSON files for English and Lithuanian under `strings/barsukas/` for these namespaces: `dictionary`, `navigation`, `languages`, and `pagination` (created `en.json` and `lt.json` for each namespace).

### Testing
- Ran formatter: `black src/barsukas/routes/peleda.py src/barsukas/helpers/strings.py` and it completed successfully.
- Ran static type checks: `PYTHONPATH=src mypy src/barsukas/routes/peleda.py src/barsukas/helpers/strings.py` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd361e5b88327be50127583f83c03)