### PR TITLE
Skip WireWord sentence export when below minimum threshold (with tests)

### DIFF
--- a/src/agents/ungurys/agent.py
+++ b/src/agents/ungurys/agent.py
@@ -55,6 +55,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+MIN_WIREWORD_SENTENCE_EXPORT_COUNT = 25
+
 
 class UngurysAgent:
     """Agent for exporting word data to WireWord format."""
@@ -526,6 +528,7 @@ class UngurysAgent:
                 output_path=output_path,
                 include_all_languages=False,
                 exclude_conversation_sentences=True,
+                min_sentences_to_export=MIN_WIREWORD_SENTENCE_EXPORT_COUNT,
             )
             logger.info(f"Successfully exported {count} sentences to {output_path}")
             return True, count

--- a/src/tests/agents/test_ungurys_agent.py
+++ b/src/tests/agents/test_ungurys_agent.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from agents.ungurys.agent import MIN_WIREWORD_SENTENCE_EXPORT_COUNT, UngurysAgent
+
+
+class _DummySentenceExporter:
+    def __init__(self, sentence_count: int) -> None:
+        self.sentence_count = sentence_count
+        self.last_min_sentences_to_export: int | None = None
+
+    def export_to_file(
+        self,
+        output_path: str,
+        include_all_languages: bool = False,
+        exclude_conversation_sentences: bool = True,
+        min_sentences_to_export: int = 0,
+    ) -> int:
+        del include_all_languages, exclude_conversation_sentences
+        self.last_min_sentences_to_export = min_sentences_to_export
+        sentence_payload = {"sentences": [{"id": idx} for idx in range(self.sentence_count)]}
+        Path(output_path).write_text(
+            json.dumps(sentence_payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return self.sentence_count
+
+
+def _build_agent_with_sentence_exporter(
+    sentence_count: int,
+) -> tuple[UngurysAgent, _DummySentenceExporter]:
+    agent = UngurysAgent.__new__(UngurysAgent)
+    exporter = _DummySentenceExporter(sentence_count)
+    setattr(agent, "sentence_exporter", cast(Any, exporter))
+    return agent, exporter
+
+
+def test_export_wireword_sentences_passes_threshold_to_exporter(tmp_path: Path) -> None:
+    output_path = tmp_path / "wireword_sentences.json"
+    agent, exporter = _build_agent_with_sentence_exporter(sentence_count=10)
+
+    success, sentence_count = agent.export_wireword_sentences(output_path=str(output_path))
+
+    assert success is True
+    assert sentence_count == 10
+    assert exporter.last_min_sentences_to_export == MIN_WIREWORD_SENTENCE_EXPORT_COUNT
+
+
+def test_export_wireword_sentences_returns_exporter_count(tmp_path: Path) -> None:
+    output_path = tmp_path / "wireword_sentences.json"
+    agent, _ = _build_agent_with_sentence_exporter(
+        sentence_count=MIN_WIREWORD_SENTENCE_EXPORT_COUNT
+    )
+
+    success, sentence_count = agent.export_wireword_sentences(output_path=str(output_path))
+
+    assert success is True
+    assert sentence_count == MIN_WIREWORD_SENTENCE_EXPORT_COUNT

--- a/src/tests/wireword/test_export_wireword_sentences.py
+++ b/src/tests/wireword/test_export_wireword_sentences.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from wireword.export_wireword_sentences import WirewordSentenceExporter
+
+
+def _build_exporter_with_data(sentence_count: int) -> WirewordSentenceExporter:
+    exporter = WirewordSentenceExporter.__new__(WirewordSentenceExporter)
+
+    def _fake_export_sentences(
+        include_all_languages: bool = False,
+        exclude_conversation_sentences: bool = True,
+    ) -> dict[str, Any]:
+        del include_all_languages, exclude_conversation_sentences
+        return {"sentences": [{"id": idx} for idx in range(sentence_count)]}
+
+    setattr(exporter, "export_sentences", cast(Any, _fake_export_sentences))
+    return exporter
+
+
+def test_export_to_file_writes_empty_payload_below_minimum_threshold(tmp_path: Path) -> None:
+    output_path = tmp_path / "wireword_sentences.json"
+    exporter = _build_exporter_with_data(sentence_count=3)
+
+    sentence_count = exporter.export_to_file(
+        output_path=str(output_path),
+        min_sentences_to_export=25,
+    )
+
+    assert sentence_count == 0
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {"sentences": []}
+
+
+def test_export_to_file_preserves_payload_at_minimum_threshold(tmp_path: Path) -> None:
+    output_path = tmp_path / "wireword_sentences.json"
+    exporter = _build_exporter_with_data(sentence_count=25)
+
+    sentence_count = exporter.export_to_file(
+        output_path=str(output_path),
+        min_sentences_to_export=25,
+    )
+
+    assert sentence_count == 25
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert len(payload["sentences"]) == 25

--- a/src/wireword/export_wireword_sentences.py
+++ b/src/wireword/export_wireword_sentences.py
@@ -347,6 +347,7 @@ class WirewordSentenceExporter:
         output_path: str,
         include_all_languages: bool = False,
         exclude_conversation_sentences: bool = True,
+        min_sentences_to_export: int = 0,
     ) -> int:
         """Export sentences to a JSON file.
 
@@ -355,6 +356,9 @@ class WirewordSentenceExporter:
             include_all_languages: Include all translations
             exclude_conversation_sentences: Exclude sentences that are part of conversations
                 (default: True). These are exported separately in wireword_conversations.jsonl.
+            min_sentences_to_export: Minimum sentence count required to export sentence data.
+                When the exported sentence count is below this threshold, an empty payload is
+                written instead. Defaults to 0 (no minimum threshold).
 
         Returns:
             Number of sentences exported
@@ -367,11 +371,22 @@ class WirewordSentenceExporter:
         # Create output directory if needed
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 
+        sentence_count = len(data["sentences"])
+        if sentence_count < min_sentences_to_export:
+            logger.warning(
+                "Sentence export count (%s) is below minimum threshold (%s); "
+                "writing empty sentence export to %s",
+                sentence_count,
+                min_sentences_to_export,
+                output_path,
+            )
+            data = {"sentences": []}
+            sentence_count = 0
+
         # Write to file
         with open(output_path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
 
-        sentence_count = len(data["sentences"])
         logger.info(f"Exported {sentence_count} sentences to {output_path}")
 
         return sentence_count


### PR DESCRIPTION
### Motivation
- Prevent generating small/insufficient WireWord sentence JSONs by enforcing a minimum exported sentence count before writing full payloads.

### Description
- Introduced `MIN_WIREWORD_SENTENCE_EXPORT_COUNT` and threaded it into `UngurysAgent.export_wireword_sentences` so the agent passes a minimum threshold to the exporter.
- Added a `min_sentences_to_export` parameter to `WirewordSentenceExporter.export_to_file` and implemented logic to write an empty payload and return `0` when the actual sentence count is below the threshold, with a warning log.
- Updated `WirewordSentenceExporter.export_to_file` to compute sentence count prior to writing and to respect the minimum threshold behavior.
- Added unit tests for both the agent and exporter: `src/tests/agents/test_ungurys_agent.py` and `src/tests/wireword/test_export_wireword_sentences.py` to verify threshold passing and empty-payload behavior.

### Testing
- Ran the new exporter unit tests: `src/tests/wireword/test_export_wireword_sentences.py`, which verify that counts below the threshold produce an empty payload and that payloads at the threshold are preserved; tests passed.
- Ran the new agent unit tests: `src/tests/agents/test_ungurys_agent.py`, which verify the agent forwards the threshold to the exporter and returns the exporter count; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd6166eb08327885966d05a10ddcf)