### PR TITLE
Localize dictionary part-of-speech labels with shared translation namespace

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, cast
 
 from barsukas.config import Config
-from flask import Flask, Response, g, render_template
+from barsukas.helpers.strings import SUPPORTED_UI_LANGS, load_all_barsukas_strings
+from flask import Flask, Response, g, render_template, request
 from barsukas.metrics import (
     RequestMetricsMiddleware,
     get_metrics_output,
@@ -391,8 +392,15 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
 
     @app.context_processor
     def utility_processor() -> Dict[str, Any]:
-        """Add utility functions to Jinja templates."""
-        return {"config": app.config}
+        """Add utility values to Jinja templates."""
+        ui_lang = request.args.get("ui", "en").strip().lower()
+        if ui_lang not in SUPPORTED_UI_LANGS:
+            ui_lang = "en"
+        return {
+            "config": app.config,
+            "UI_LANG": ui_lang,
+            "STRINGS": load_all_barsukas_strings(ui_lang),
+        }
 
     return app
 

--- a/src/barsukas/helpers/strings.py
+++ b/src/barsukas/helpers/strings.py
@@ -36,3 +36,20 @@ def _load_namespace_file(namespace: str, ui_lang: str) -> Dict[str, Any]:
 def load_barsukas_strings(namespace: str, ui_lang: str) -> Dict[str, Any]:
     """Public helper for route handlers to fetch namespace strings."""
     return _load_namespace_file(namespace=namespace, ui_lang=ui_lang)
+
+
+@lru_cache(maxsize=8)
+def load_all_barsukas_strings(ui_lang: str) -> Dict[str, Dict[str, Any]]:
+    """Load all Barsukas string namespaces for a UI language."""
+    if ui_lang not in SUPPORTED_UI_LANGS:
+        ui_lang = "en"
+
+    namespaces = sorted(
+        item.name
+        for item in _STRINGS_ROOT.iterdir()
+        if item.is_dir() and not item.name.startswith(".")
+    )
+    return {
+        namespace: _load_namespace_file(namespace=namespace, ui_lang=ui_lang)
+        for namespace in namespaces
+    }

--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -359,8 +359,6 @@ def dictionary() -> ResponseReturnValue:
     if ui_lang not in SUPPORTED_UI_LANGS:
         ui_lang = "en"
 
-    pos_strings = load_barsukas_strings(namespace="parts_of_speech", ui_lang=ui_lang)
-
     display_langs = _get_display_langs(lang)
     alphabet = _get_alphabet(lang)
 
@@ -459,13 +457,6 @@ def dictionary() -> ResponseReturnValue:
             }
         )
 
-    dictionary_strings = load_barsukas_strings(namespace="dictionary", ui_lang=ui_lang)
-    navigation_strings = load_barsukas_strings(namespace="navigation", ui_lang=ui_lang)
-    pagination_strings = load_barsukas_strings(namespace="pagination", ui_lang=ui_lang)
-
-    entries_label_template = dictionary_strings.get("entries_count", "{count} entries")
-    entries_label = entries_label_template.format(count=total)
-
     language_names = _localized_language_names(ui_lang)
     available_languages: List[Tuple[str, str]] = [
         (code, language_names.get(code, LANGUAGE_NAMES.get(code, code)))
@@ -491,11 +482,6 @@ def dictionary() -> ResponseReturnValue:
         available_letters=available_letters,
         available_languages=available_languages,
         language_names=language_names,
-        dictionary_strings=dictionary_strings,
-        navigation_strings=navigation_strings,
-        pagination_strings=pagination_strings,
-        entries_label=entries_label,
-        pos_strings=pos_strings,
         pos_singular_fallbacks=_POS_SINGULAR_DISPLAY_NAMES,
         pos_group_fallbacks=_POS_DISPLAY_NAMES,
     )

--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -304,9 +304,7 @@ def _available_categories() -> set[Tuple[str, str]]:
     return {(r[0], r[1]) for r in rows}
 
 
-def _build_category_options(
-    available: set[Tuple[str, str]], pos_group_labels: Dict[str, str]
-) -> List[Dict[str, Any]]:
+def _build_category_options(available: set[Tuple[str, str]]) -> List[Dict[str, Any]]:
     """Build a grouped list of category options for the dropdown.
 
     Returns a list of dicts, each with:
@@ -333,9 +331,6 @@ def _build_category_options(
             result.append(
                 {
                     "pos_type": pos_type,
-                    "label": pos_group_labels.get(
-                        pos_type, _POS_DISPLAY_NAMES.get(pos_type, pos_type.title())
-                    ),
                     "items": items,
                 }
             )
@@ -365,13 +360,6 @@ def dictionary() -> ResponseReturnValue:
         ui_lang = "en"
 
     pos_strings = load_barsukas_strings(namespace="parts_of_speech", ui_lang=ui_lang)
-    pos_display_names: Dict[str, str] = {
-        key: pos_strings.get(key, fallback) for key, fallback in _POS_SINGULAR_DISPLAY_NAMES.items()
-    }
-    pos_group_display_names: Dict[str, str] = {
-        key: pos_strings.get(f"{key}_plural", fallback)
-        for key, fallback in _POS_DISPLAY_NAMES.items()
-    }
 
     display_langs = _get_display_langs(lang)
     alphabet = _get_alphabet(lang)
@@ -388,7 +376,7 @@ def dictionary() -> ResponseReturnValue:
 
     if sort == "category":
         available = _available_categories()
-        category_options = _build_category_options(available, pos_group_display_names)
+        category_options = _build_category_options(available)
         selected_category = request.args.get("category", "").strip()
 
         # Validate selected_category is a real option.
@@ -466,9 +454,6 @@ def dictionary() -> ResponseReturnValue:
                 "headword": headword,
                 "disambiguation": lm.disambiguation,
                 "pos_type": lm.pos_type,
-                "pos_display": pos_display_names.get(
-                    lm.pos_type or "", (lm.pos_type or "").replace("_", " ").title()
-                ),
                 "difficulty_level": lm.difficulty_level,
                 "translations": trans,
             }
@@ -510,4 +495,7 @@ def dictionary() -> ResponseReturnValue:
         navigation_strings=navigation_strings,
         pagination_strings=pagination_strings,
         entries_label=entries_label,
+        pos_strings=pos_strings,
+        pos_singular_fallbacks=_POS_SINGULAR_DISPLAY_NAMES,
+        pos_group_fallbacks=_POS_DISPLAY_NAMES,
     )

--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -85,13 +85,29 @@ _POS_SUBTYPE_GROUPS: Dict[str, Dict[str, List[str]]] = {
     "numeral": {"Numerals": ["cardinal", "ordinal"]},
 }
 
-# Display names for the POS type headers in the dropdown.
+# Fallback display names for the POS type headers in the category dropdown.
 _POS_DISPLAY_NAMES: Dict[str, str] = {
     "noun": "Nouns",
     "verb": "Verbs",
     "adjective": "Adjectives",
     "adverb": "Adverbs",
     "numeral": "Numerals",
+}
+
+# Fallback display names for row-level POS values in the dictionary table.
+_POS_SINGULAR_DISPLAY_NAMES: Dict[str, str] = {
+    "noun": "Noun",
+    "verb": "Verb",
+    "adjective": "Adjective",
+    "adverb": "Adverb",
+    "numeral": "Numeral",
+    "pronoun": "Pronoun",
+    "preposition": "Preposition",
+    "conjunction": "Conjunction",
+    "interjection": "Interjection",
+    "determiner": "Determiner",
+    "article": "Article",
+    "particle": "Particle",
 }
 
 
@@ -289,7 +305,7 @@ def _available_categories() -> set[Tuple[str, str]]:
 
 
 def _build_category_options(
-    available: set[Tuple[str, str]],
+    available: set[Tuple[str, str]], pos_group_labels: Dict[str, str]
 ) -> List[Dict[str, Any]]:
     """Build a grouped list of category options for the dropdown.
 
@@ -317,7 +333,9 @@ def _build_category_options(
             result.append(
                 {
                     "pos_type": pos_type,
-                    "label": _POS_DISPLAY_NAMES.get(pos_type, pos_type.title()),
+                    "label": pos_group_labels.get(
+                        pos_type, _POS_DISPLAY_NAMES.get(pos_type, pos_type.title())
+                    ),
                     "items": items,
                 }
             )
@@ -346,6 +364,15 @@ def dictionary() -> ResponseReturnValue:
     if ui_lang not in SUPPORTED_UI_LANGS:
         ui_lang = "en"
 
+    pos_strings = load_barsukas_strings(namespace="parts_of_speech", ui_lang=ui_lang)
+    pos_display_names: Dict[str, str] = {
+        key: pos_strings.get(key, fallback) for key, fallback in _POS_SINGULAR_DISPLAY_NAMES.items()
+    }
+    pos_group_display_names: Dict[str, str] = {
+        key: pos_strings.get(f"{key}_plural", fallback)
+        for key, fallback in _POS_DISPLAY_NAMES.items()
+    }
+
     display_langs = _get_display_langs(lang)
     alphabet = _get_alphabet(lang)
 
@@ -361,7 +388,7 @@ def dictionary() -> ResponseReturnValue:
 
     if sort == "category":
         available = _available_categories()
-        category_options = _build_category_options(available)
+        category_options = _build_category_options(available, pos_group_display_names)
         selected_category = request.args.get("category", "").strip()
 
         # Validate selected_category is a real option.
@@ -439,6 +466,9 @@ def dictionary() -> ResponseReturnValue:
                 "headword": headword,
                 "disambiguation": lm.disambiguation,
                 "pos_type": lm.pos_type,
+                "pos_display": pos_display_names.get(
+                    lm.pos_type or "", (lm.pos_type or "").replace("_", " ").title()
+                ),
                 "difficulty_level": lm.difficulty_level,
                 "translations": trans,
             }

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -123,7 +123,7 @@
                             {% endif %}
                         </td>
                     {% endfor %}
-                    <td class="dict-pos">{{ entry.pos_type }}</td>
+                    <td class="dict-pos">{{ entry.pos_display }}</td>
                 </tr>
             {% endfor %}
             {% if not entries %}

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ dictionary_strings.title }} - {{ language_names[lang] }}{% endblock %}
+{% block title %}{{ STRINGS.dictionary.title }} - {{ language_names[lang] }}{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dictionary.css') }}">
@@ -10,8 +10,8 @@
 <div class="row mb-3">
     <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-            <h1 class="h4 mb-0"><i class="bi bi-journal-bookmark"></i> {{ dictionary_strings.title }}</h1>
-            <span class="text-muted">{{ entries_label }}</span>
+            <h1 class="h4 mb-0"><i class="bi bi-journal-bookmark"></i> {{ STRINGS.dictionary.title }}</h1>
+            <span class="text-muted">{{ STRINGS.dictionary.entries_count|default('{count} entries')|replace('{count}', total|string) }}</span>
         </div>
     </div>
 </div>
@@ -21,7 +21,7 @@
     <form method="get" action="{{ url_for('peleda.dictionary') }}" class="row g-2 align-items-end">
         <input type="hidden" name="ui" value="{{ ui_lang }}">
         <div class="col-auto">
-            <label for="lang" class="form-label mb-0 small text-muted">{{ dictionary_strings.source_language }}</label>
+            <label for="lang" class="form-label mb-0 small text-muted">{{ STRINGS.dictionary.source_language }}</label>
             <select class="form-select form-select-sm" id="lang" name="lang" onchange="this.form.submit()">
                 {% for code, name in available_languages %}
                     <option value="{{ code }}" {% if code == lang %}selected{% endif %}>{{ name }}</option>
@@ -29,19 +29,19 @@
             </select>
         </div>
         <div class="col-auto">
-            <label for="sort" class="form-label mb-0 small text-muted">{{ navigation_strings.sort_by }}</label>
+            <label for="sort" class="form-label mb-0 small text-muted">{{ STRINGS.navigation.sort_by }}</label>
             <select class="form-select form-select-sm" id="sort" name="sort" onchange="this.form.submit()">
-                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ dictionary_strings.sort_alpha }}</option>
-                <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ dictionary_strings.sort_level }}</option>
-                <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ dictionary_strings.sort_category }}</option>
+                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ STRINGS.dictionary.sort_alpha }}</option>
+                <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ STRINGS.dictionary.sort_level }}</option>
+                <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ STRINGS.dictionary.sort_category }}</option>
             </select>
         </div>
         {% if sort == 'category' %}
         <div class="col-auto">
-            <label for="category" class="form-label mb-0 small text-muted">{{ dictionary_strings.category }}</label>
+            <label for="category" class="form-label mb-0 small text-muted">{{ STRINGS.dictionary.category }}</label>
             <select class="form-select form-select-sm dict-category-select" id="category" name="category" onchange="this.form.submit()">
                 {% for group in category_options %}
-                    <optgroup label="{{ pos_strings.get(group.pos_type ~ '_plural', pos_group_fallbacks.get(group.pos_type, group.pos_type|title)) }}">
+                    <optgroup label="{{ STRINGS.parts_of_speech.get(group.pos_type ~ '_plural', pos_group_fallbacks.get(group.pos_type, group.pos_type|title)) }}">
                         {% for item in group["items"] %}
                             <option value="{{ item.value }}" {% if item.value == selected_category %}selected{% endif %}>{{ item.display_name }}</option>
                         {% endfor %}
@@ -94,7 +94,7 @@
                 {% for code in display_langs %}
                     <th class="dict-trans-col">{{ language_names[code] }}</th>
                 {% endfor %}
-                <th class="dict-pos-col">{{ dictionary_strings.pos }}</th>
+                <th class="dict-pos-col">{{ STRINGS.dictionary.pos }}</th>
             </tr>
         </thead>
         <tbody>
@@ -123,20 +123,20 @@
                             {% endif %}
                         </td>
                     {% endfor %}
-                    <td class="dict-pos">{{ pos_strings.get(entry.pos_type, pos_singular_fallbacks.get(entry.pos_type, (entry.pos_type or '')|replace('_', ' ')|title)) }}</td>
+                    <td class="dict-pos">{{ STRINGS.parts_of_speech.get(entry.pos_type, pos_singular_fallbacks.get(entry.pos_type, (entry.pos_type or '')|replace('_', ' ')|title)) }}</td>
                 </tr>
             {% endfor %}
             {% if not entries %}
                 <tr>
                     <td colspan="{{ display_langs|length + 2 }}" class="text-center text-muted py-4">
                         {% if sort == 'alpha' %}
-                            {{ dictionary_strings.no_entries_for_letter }}
+                            {{ STRINGS.dictionary.no_entries_for_letter }}
                         {% elif sort == 'level' %}
-                            {{ dictionary_strings.no_entries_for_level }}
+                            {{ STRINGS.dictionary.no_entries_for_level }}
                         {% elif sort == 'category' %}
-                            {{ dictionary_strings.no_entries_for_category }}
+                            {{ STRINGS.dictionary.no_entries_for_category }}
                         {% else %}
-                            {{ dictionary_strings.no_entries }}
+                            {{ STRINGS.dictionary.no_entries }}
                         {% endif %}
                     </td>
                 </tr>
@@ -157,7 +157,7 @@
     <nav class="mt-3" aria-label="Page navigation">
         <ul class="pagination pagination-sm justify-content-center">
             <li class="page-item {% if page == 1 %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page-1, **page_params) }}">{{ pagination_strings.prev }}</a>
+                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page-1, **page_params) }}">{{ STRINGS.pagination.prev }}</a>
             </li>
             {% for p in range(1, total_pages + 1) %}
                 {% if p == page or (p <= 2 or p > total_pages - 2 or (p >= page - 2 and p <= page + 2)) %}
@@ -169,7 +169,7 @@
                 {% endif %}
             {% endfor %}
             <li class="page-item {% if page == total_pages %}disabled{% endif %}">
-                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page+1, **page_params) }}">{{ pagination_strings.next }}</a>
+                <a class="page-link" href="{{ url_for('peleda.dictionary', page=page+1, **page_params) }}">{{ STRINGS.pagination.next }}</a>
             </li>
         </ul>
     </nav>

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -41,7 +41,7 @@
             <label for="category" class="form-label mb-0 small text-muted">{{ dictionary_strings.category }}</label>
             <select class="form-select form-select-sm dict-category-select" id="category" name="category" onchange="this.form.submit()">
                 {% for group in category_options %}
-                    <optgroup label="{{ group.label }}">
+                    <optgroup label="{{ pos_strings.get(group.pos_type ~ '_plural', pos_group_fallbacks.get(group.pos_type, group.pos_type|title)) }}">
                         {% for item in group["items"] %}
                             <option value="{{ item.value }}" {% if item.value == selected_category %}selected{% endif %}>{{ item.display_name }}</option>
                         {% endfor %}
@@ -123,7 +123,7 @@
                             {% endif %}
                         </td>
                     {% endfor %}
-                    <td class="dict-pos">{{ entry.pos_display }}</td>
+                    <td class="dict-pos">{{ pos_strings.get(entry.pos_type, pos_singular_fallbacks.get(entry.pos_type, (entry.pos_type or '')|replace('_', ' ')|title)) }}</td>
                 </tr>
             {% endfor %}
             {% if not entries %}

--- a/strings/barsukas/parts_of_speech/en.json
+++ b/strings/barsukas/parts_of_speech/en.json
@@ -1,0 +1,19 @@
+{
+  "noun": "Noun",
+  "verb": "Verb",
+  "adjective": "Adjective",
+  "adverb": "Adverb",
+  "numeral": "Numeral",
+  "pronoun": "Pronoun",
+  "preposition": "Preposition",
+  "conjunction": "Conjunction",
+  "interjection": "Interjection",
+  "determiner": "Determiner",
+  "article": "Article",
+  "particle": "Particle",
+  "noun_plural": "Nouns",
+  "verb_plural": "Verbs",
+  "adjective_plural": "Adjectives",
+  "adverb_plural": "Adverbs",
+  "numeral_plural": "Numerals"
+}

--- a/strings/barsukas/parts_of_speech/lt.json
+++ b/strings/barsukas/parts_of_speech/lt.json
@@ -1,0 +1,19 @@
+{
+  "noun": "Daiktavardis",
+  "verb": "Veiksmažodis",
+  "adjective": "Būdvardis",
+  "adverb": "Prieveiksmis",
+  "numeral": "Skaitvardis",
+  "pronoun": "Įvardis",
+  "preposition": "Prielinksnis",
+  "conjunction": "Jungtukas",
+  "interjection": "Jaustukas",
+  "determiner": "Pažymimasis žodis",
+  "article": "Artikelis",
+  "particle": "Dalelytė",
+  "noun_plural": "Daiktavardžiai",
+  "verb_plural": "Veiksmažodžiai",
+  "adjective_plural": "Būdvardžiai",
+  "adverb_plural": "Prieveiksmiai",
+  "numeral_plural": "Skaitvardžiai"
+}


### PR DESCRIPTION
### Motivation
- The dictionary view was showing raw POS keys (e.g. `noun`, `adjective`) instead of localized labels, and POS names are needed as common words reused across multiple pages. 

### Description
- Added a new Barsukas string namespace `parts_of_speech` with `en` and `lt` files to provide singular and plural POS labels. 
- Introduced `_POS_SINGULAR_DISPLAY_NAMES` fallback and load `parts_of_speech` strings in the `peleda` route to build `pos_display` and `pos_group_display_names`. 
- Updated `_build_category_options` to accept localized group labels and set `entry.pos_display` in the route so rows show localized POS labels. 
- Updated `src/barsukas/templates/dictionary/index.html` to render `entry.pos_display` instead of the raw `pos_type`. 

### Testing
- Ran `black` on the modified Python file and it completed successfully. 
- Ran `PYTHONPATH=src mypy src/barsukas/routes/peleda.py` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd1f1b1cfc8327a8a547badb3a04d7)