### PR TITLE
barsukas: global UI language selector with cookie persistence and header fallback

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -17,7 +17,12 @@ from typing import Any, Callable, Dict, Optional, cast
 
 from barsukas.config import Config
 from barsukas.helpers.strings import SUPPORTED_UI_LANGS, load_all_barsukas_strings
-from flask import Flask, Response, g, render_template, request
+from barsukas.helpers.ui_language import (
+    UI_LANGUAGE_COOKIE,
+    normalize_ui_language,
+    resolve_ui_language,
+)
+from flask import Flask, Response, g, redirect, render_template, request, url_for
 from barsukas.metrics import (
     RequestMetricsMiddleware,
     get_metrics_output,
@@ -334,6 +339,7 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
     def before_request() -> None:
         """Set up database session and start request timing for metrics."""
         g.db = app.db_session_factory()
+        g.ui_lang = resolve_ui_language(request)
         RequestMetricsMiddleware.before_request()
 
     @app.teardown_appcontext
@@ -350,7 +356,25 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
     @app.after_request
     def after_request(response: Response) -> Response:
         """Record request metrics after response is generated."""
+        selected_ui_lang = getattr(g, "set_ui_lang_cookie", None)
+        if selected_ui_lang:
+            response.set_cookie(
+                UI_LANGUAGE_COOKIE,
+                selected_ui_lang,
+                max_age=60 * 60 * 24 * 365,
+                samesite="Lax",
+            )
         return cast(Response, RequestMetricsMiddleware.after_request(response))
+
+    @app.post("/ui-language")
+    def set_ui_language() -> Any:
+        """Persist UI language selection in a cookie, then return to the target page."""
+        selected_ui_lang = normalize_ui_language(request.form.get("ui_lang")) or "en"
+        g.set_ui_lang_cookie = selected_ui_lang
+        next_url = request.form.get("next_url", "").strip()
+        if not next_url.startswith("/"):
+            next_url = url_for("index")
+        return redirect(next_url)
 
     @app.route("/metrics")
     def metrics() -> Response:
@@ -393,12 +417,11 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
     @app.context_processor
     def utility_processor() -> Dict[str, Any]:
         """Add utility values to Jinja templates."""
-        ui_lang = request.args.get("ui", "en").strip().lower()
-        if ui_lang not in SUPPORTED_UI_LANGS:
-            ui_lang = "en"
+        ui_lang = getattr(g, "ui_lang", "en")
         return {
             "config": app.config,
             "UI_LANG": ui_lang,
+            "SUPPORTED_UI_LANGS": sorted(SUPPORTED_UI_LANGS),
             "STRINGS": load_all_barsukas_strings(ui_lang),
         }
 

--- a/src/barsukas/helpers/ui_language.py
+++ b/src/barsukas/helpers/ui_language.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+"""Barsukas UI language resolution helpers."""
+
+from typing import Optional
+
+from flask import Request
+
+from barsukas.helpers.strings import SUPPORTED_UI_LANGS
+
+UI_LANGUAGE_COOKIE = "barsukas_ui_lang"
+
+
+def normalize_ui_language(lang: Optional[str]) -> Optional[str]:
+    """Return a normalized UI language code if supported."""
+    if not lang:
+        return None
+    normalized = lang.strip().lower()
+    if normalized in SUPPORTED_UI_LANGS:
+        return normalized
+    return None
+
+
+def resolve_ui_language(request: Request) -> str:
+    """Resolve UI language from cookie -> Accept-Language -> English fallback."""
+    cookie_lang = normalize_ui_language(request.cookies.get(UI_LANGUAGE_COOKIE))
+    if cookie_lang:
+        return cookie_lang
+
+    best_header_match = request.accept_languages.best_match(list(SUPPORTED_UI_LANGS))
+    header_lang = normalize_ui_language(best_header_match)
+    if header_lang:
+        return header_lang
+
+    return "en"

--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -14,7 +14,7 @@ from flask.typing import ResponseReturnValue
 from sqlalchemy import func
 from sqlalchemy.orm import Query
 
-from barsukas.helpers.strings import SUPPORTED_UI_LANGS, load_barsukas_strings
+from barsukas.helpers.strings import load_barsukas_strings
 from barsukas.routes.categories import (
     ADJECTIVE_GROUPS,
     ADVERB_GROUPS,
@@ -347,7 +347,7 @@ def dictionary() -> ResponseReturnValue:
     """Dictionary browse view."""
     lang = request.args.get("lang", "en").strip().lower()
     sort = request.args.get("sort", "alpha").strip().lower()
-    ui_lang = request.args.get("ui", "en").strip().lower()
+    ui_lang = getattr(g, "ui_lang", "en")
     page = request.args.get("page", 1, type=int)
 
     # Validate inputs.
@@ -356,9 +356,6 @@ def dictionary() -> ResponseReturnValue:
         lang = "en"
     if sort not in ("alpha", "level", "category"):
         sort = "alpha"
-    if ui_lang not in SUPPORTED_UI_LANGS:
-        ui_lang = "en"
-
     display_langs = _get_display_langs(lang)
     alphabet = _get_alphabet(lang)
 

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -164,6 +164,25 @@
                     {% endif %}
                 </ul>
                 <ul class="navbar-nav ms-auto">
+                    <li class="nav-item me-2">
+                        <form method="post" action="{{ url_for('set_ui_language') }}" class="d-flex align-items-center">
+                            <input type="hidden" name="next_url" value="{{ request.full_path if request.query_string else request.path }}">
+                            <label for="ui-lang-selector" class="visually-hidden">{{ STRINGS.navigation.get('ui_language', 'UI language') }}</label>
+                            <select
+                                id="ui-lang-selector"
+                                name="ui_lang"
+                                class="form-select form-select-sm"
+                                onchange="this.form.submit()"
+                                aria-label="{{ STRINGS.navigation.get('ui_language', 'UI language') }}"
+                            >
+                                {% for code in SUPPORTED_UI_LANGS %}
+                                    <option value="{{ code }}" {% if code == UI_LANG %}selected{% endif %}>
+                                        {{ STRINGS.languages.get(code, code|upper) }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </form>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link text-white-50" href="{{ url_for('settings.index') }}">
                             <small><i class="bi bi-database"></i> linguistics.sqlite</small>

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -19,7 +19,6 @@
 <!-- Language selector and sort control -->
 <div class="dict-controls mb-3">
     <form method="get" action="{{ url_for('peleda.dictionary') }}" class="row g-2 align-items-end">
-        <input type="hidden" name="ui" value="{{ ui_lang }}">
         <div class="col-auto">
             <label for="lang" class="form-label mb-0 small text-muted">{{ STRINGS.dictionary.source_language }}</label>
             <select class="form-select form-select-sm" id="lang" name="lang" onchange="this.form.submit()">
@@ -64,7 +63,7 @@
         {% if l == letter %}
             <span class="dict-letter dict-letter-active">{{ l }}</span>
         {% elif l in available_letters %}
-            <a href="{{ url_for('peleda.dictionary', lang=lang, letter=l, sort='alpha', ui=ui_lang) }}"
+            <a href="{{ url_for('peleda.dictionary', lang=lang, letter=l, sort='alpha') }}"
                class="dict-letter">{{ l }}</a>
         {% else %}
             <span class="dict-letter dict-letter-disabled">{{ l }}</span>
@@ -78,7 +77,7 @@
         {% if lv == selected_level %}
             <span class="dict-letter dict-letter-active">{{ lv }}</span>
         {% else %}
-            <a href="{{ url_for('peleda.dictionary', lang=lang, sort='level', level=lv, ui=ui_lang) }}"
+            <a href="{{ url_for('peleda.dictionary', lang=lang, sort='level', level=lv) }}"
                class="dict-letter">{{ lv }}</a>
         {% endif %}
     {% endfor %}
@@ -148,11 +147,11 @@
 <!-- Pagination -->
 {% if total_pages > 1 %}
     {% if sort == 'category' %}
-        {% set page_params = {'lang': lang, 'sort': 'category', 'category': selected_category, 'ui': ui_lang} %}
+        {% set page_params = {'lang': lang, 'sort': 'category', 'category': selected_category} %}
     {% elif sort == 'level' %}
-        {% set page_params = {'lang': lang, 'sort': 'level', 'level': selected_level, 'ui': ui_lang} %}
+        {% set page_params = {'lang': lang, 'sort': 'level', 'level': selected_level} %}
     {% else %}
-        {% set page_params = {'lang': lang, 'sort': 'alpha', 'letter': letter, 'ui': ui_lang} %}
+        {% set page_params = {'lang': lang, 'sort': 'alpha', 'letter': letter} %}
     {% endif %}
     <nav class="mt-3" aria-label="Page navigation">
         <ul class="pagination pagination-sm justify-content-center">

--- a/strings/barsukas/navigation/en.json
+++ b/strings/barsukas/navigation/en.json
@@ -1,3 +1,4 @@
 {
-  "sort_by": "Sort by"
+  "sort_by": "Sort by",
+  "ui_language": "UI language"
 }

--- a/strings/barsukas/navigation/lt.json
+++ b/strings/barsukas/navigation/lt.json
@@ -1,3 +1,4 @@
 {
-  "sort_by": "Rikiuoti pagal"
+  "sort_by": "Rikiuoti pagal",
+  "ui_language": "Sąsajos kalba"
 }


### PR DESCRIPTION
### Motivation
- Provide a single, consistent UI language choice across all Barsukas pages instead of per-page `ui` URL parameters.
- Respect an explicit user choice while giving first-time visitors a reasonable default via `Accept-Language` and ultimately falling back to English.

### Description
- Add `src/barsukas/helpers/ui_language.py` with `normalize_ui_language` and `resolve_ui_language` to centralize cookie -> header -> fallback resolution and define the cookie name `barsukas_ui_lang`.
- Wire the resolver into app request handling by setting `g.ui_lang` in `before_request`, exposing `UI_LANG` and `SUPPORTED_UI_LANGS` in the Jinja context, and setting a cookie in `after_request` when the user selects a language.
- Add a `POST /ui-language` endpoint (`set_ui_language`) that persists the selected language into a cookie and redirects back to the provided `next_url`.
- Replace dictionary-specific `ui` query-parameter usage so the dictionary and pagination use the global `UI_LANG` instead of `?ui=...` and stop propagating `ui` in links.
- Add a top-bar language selector form in `src/barsukas/templates/base.html` that uses an ordinary form POST to `/ui-language` (no AJAX), and add localized labels in `strings/barsukas/navigation/{en,lt}.json`.

### Testing
- Ran `PYTHONPATH=src black src/barsukas/app.py src/barsukas/routes/peleda.py src/barsukas/helpers/ui_language.py` and formatting completed successfully.
- Ran `PYTHONPATH=src mypy src/barsukas/app.py src/barsukas/routes/peleda.py src/barsukas/helpers/ui_language.py` and there were no type issues.
- Ran `PYTHONPATH=src python -m compileall src/barsukas/app.py src/barsukas/routes/peleda.py src/barsukas/helpers/ui_language.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2ba746b08327b1c07e84469f1ad6)