### PR TITLE
Add Bebras bulk IPA/phonetic checker and benchmark 0141

### DIFF
--- a/src/agents/bebras/verification.py
+++ b/src/agents/bebras/verification.py
@@ -7,7 +7,7 @@ It does NOT regenerate content - it only validates and returns "correct"/"incorr
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict
 
 from clients.batch_queue import (
     BatchQueueManager,
@@ -59,6 +59,61 @@ LANGUAGE_DIALECT_NAMES: Dict[str, str] = {
     "pt": "Portuguese (Brazilian)",
     "sv": "Swedish",
 }
+
+
+IncorrectPronunciationAction = Literal["log", "remove", "regenerate"]
+
+
+class PronunciationCheckItem(TypedDict):
+    """Single pronunciation entry used by bulk IPA/phonetic validation."""
+
+    word: str
+    chinese_hint: str
+    ipa: str
+    phonetic: str
+
+
+def build_bulk_pronunciation_verification_context() -> str:
+    """Build context for bulk IPA/phonetic verification."""
+    return (
+        "You are a strict pronunciation QA checker.\n"
+        "You receive 10-50 English words with Chinese disambiguation hints, "
+        "IPA, and plain-English phonetic spellings.\n"
+        "Return only entries where the pronunciation data is wrong or mismatched."
+    )
+
+
+def build_bulk_pronunciation_verification_prompt(items: List[PronunciationCheckItem]) -> str:
+    """Build a compact prompt with a short preamble and a numbered list."""
+    prompt_lines: List[str] = [
+        "Check this list and identify pronunciation problems.",
+        "A problem means incorrect IPA, incorrect phonetic spelling, "
+        "or IPA/phonetic mismatch for the intended English sense.",
+        "List only wrong words.",
+        "",
+    ]
+    for index, item in enumerate(items, start=1):
+        prompt_lines.append(
+            f'{index}. English: "{item["word"]}" | Chinese: "{item["chinese_hint"]}" '
+            f'| IPA: "{item["ipa"]}" | Phonetic: "{item["phonetic"]}"'
+        )
+    return "\n".join(prompt_lines)
+
+
+def build_bulk_pronunciation_verification_schema() -> Dict[str, Any]:
+    """Build JSON schema that only permits listing incorrect words."""
+    return {
+        "type": "object",
+        "properties": {
+            "wrong_words": {
+                "type": "array",
+                "description": "Only the English words with IPA/phonetic problems.",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["wrong_words"],
+        "additionalProperties": False,
+    }
 
 
 def get_supported_languages(model: str) -> List[str]:
@@ -629,6 +684,92 @@ IMPORTANT:
             description="Verification results for sentence translations",
             properties=properties,
         )
+
+    def verify_bulk_pronunciations(
+        self,
+        items: List[PronunciationCheckItem],
+        incorrect_action: IncorrectPronunciationAction = "log",
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Verify 10-50 word pronunciation entries and return only wrong words."""
+        if len(items) < 10 or len(items) > 50:
+            raise ValueError("Bulk pronunciation checker requires between 10 and 50 items.")
+
+        context = build_bulk_pronunciation_verification_context()
+        prompt = build_bulk_pronunciation_verification_prompt(items)
+        schema = build_bulk_pronunciation_verification_schema()
+
+        response = self.llm_client.generate_chat(
+            prompt=prompt,
+            context=context,
+            json_schema=schema,
+            timeout=90,
+        )
+        structured_data = response.structured_data or {}
+        raw_wrong_words = structured_data.get("wrong_words", [])
+        wrong_words = [word for word in raw_wrong_words if isinstance(word, str) and word.strip()]
+
+        wrong_word_set = set(wrong_words)
+        wrong_items = [item for item in items if item["word"] in wrong_word_set]
+
+        self._hook_log_correct_pronunciation_verifications(items, wrong_word_set)
+        action_summary = self._handle_incorrect_pronunciation_words(
+            wrong_items=wrong_items,
+            action=incorrect_action,
+            dry_run=dry_run,
+        )
+
+        return {
+            "wrong_words": wrong_words,
+            "checked_count": len(items),
+            "wrong_count": len(wrong_words),
+            "incorrect_action": incorrect_action,
+            "action_summary": action_summary,
+        }
+
+    def _hook_log_correct_pronunciation_verifications(
+        self, items: List[PronunciationCheckItem], wrong_word_set: set[str]
+    ) -> None:
+        """Hook for future metadata logging of correct pronunciation validations."""
+        correct_count = sum(1 for item in items if item["word"] not in wrong_word_set)
+        logger.debug(
+            "Pronunciation verification hook: %s correct words (metadata logging not enabled yet).",
+            correct_count,
+        )
+
+    def _handle_incorrect_pronunciation_words(
+        self,
+        wrong_items: List[PronunciationCheckItem],
+        action: IncorrectPronunciationAction,
+        dry_run: bool,
+    ) -> Dict[str, Any]:
+        """Handle incorrect words via log/remove/regenerate strategy hooks."""
+        if action == "log":
+            logger.info("Pronunciation issues found: %s words", len(wrong_items))
+            return {"action": "log", "affected_count": len(wrong_items), "executed": True}
+        if action == "remove":
+            logger.info(
+                "Pronunciation remove hook requested for %s words (dry_run=%s).",
+                len(wrong_items),
+                dry_run,
+            )
+            return {
+                "action": "remove",
+                "affected_count": len(wrong_items),
+                "executed": False,
+                "hook_only": True,
+            }
+        logger.info(
+            "Pronunciation regenerate hook requested for %s words (dry_run=%s).",
+            len(wrong_items),
+            dry_run,
+        )
+        return {
+            "action": "regenerate",
+            "affected_count": len(wrong_items),
+            "executed": False,
+            "hook_only": True,
+        }
 
     def batch_verify_words(
         self,

--- a/src/agents/bebras/verification_cli.py
+++ b/src/agents/bebras/verification_cli.py
@@ -27,6 +27,8 @@ from storage.models.schema import Lemma, Sentence
 from .verification import (
     DEFAULT_VERIFY_LANGUAGES,
     MODEL_LANGUAGE_SUPPORT,
+    IncorrectPronunciationAction,
+    PronunciationCheckItem,
     VerificationAgent,
     filter_languages_for_model,
     get_dialect_display_name,
@@ -113,6 +115,25 @@ Examples:
         action="store_true",
         default=True,
         help="Also verify linked lemmas (default: True)",
+    )
+
+    pronunciation_parser = subparsers.add_parser(
+        "pronunciations",
+        help="Bulk verify IPA/phonetic entries (10-50 items) and return wrong words only",
+    )
+    add_common_args(pronunciation_parser)
+    add_llm_args(pronunciation_parser, default_model="gpt-5.4-mini")
+    add_backend_args(pronunciation_parser)
+    pronunciation_parser.add_argument(
+        "--input-json",
+        required=True,
+        help="Path to JSON list with items: word, chinese_hint, ipa, phonetic",
+    )
+    pronunciation_parser.add_argument(
+        "--incorrect-action",
+        choices=["log", "remove", "regenerate"],
+        default="log",
+        help="How Bebras should handle incorrect words",
     )
 
     return parser
@@ -493,6 +514,43 @@ def submit_batch_sentences(args: argparse.Namespace) -> int:
     return 0
 
 
+def verify_pronunciations(args: argparse.Namespace) -> int:
+    """Bulk verify IPA/phonetic pronunciations from a JSON list."""
+    config = get_data_source_config(args)
+    agent = VerificationAgent(config)
+
+    with open(args.input_json, "r", encoding="utf-8") as input_file:
+        payload = json.load(input_file)
+
+    if not isinstance(payload, list):
+        logger.error("Input JSON must be a list of pronunciation items.")
+        return 1
+
+    items: List[PronunciationCheckItem] = []
+    required_fields = ("word", "chinese_hint", "ipa", "phonetic")
+    for item in payload:
+        if not isinstance(item, dict) or any(field not in item for field in required_fields):
+            logger.error("Each item must include: word, chinese_hint, ipa, phonetic.")
+            return 1
+        items.append(
+            {
+                "word": str(item["word"]),
+                "chinese_hint": str(item["chinese_hint"]),
+                "ipa": str(item["ipa"]),
+                "phonetic": str(item["phonetic"]),
+            }
+        )
+
+    incorrect_action: IncorrectPronunciationAction = args.incorrect_action
+    result = agent.verify_bulk_pronunciations(
+        items=items,
+        incorrect_action=incorrect_action,
+        dry_run=args.dry_run,
+    )
+    print(json.dumps({"wrong_words": result["wrong_words"]}, ensure_ascii=False, indent=2))
+    return 0
+
+
 def main() -> Optional[int]:
     """Main entry point for the verification CLI."""
     parser = get_argument_parser()
@@ -511,6 +569,8 @@ def main() -> Optional[int]:
         return submit_batch_words(args)
     elif args.verify_type == "submit-batch-sentences":
         return submit_batch_sentences(args)
+    elif args.verify_type == "pronunciations":
+        return verify_pronunciations(args)
     else:
         parser.print_help()
         return 1

--- a/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
+++ b/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
@@ -1,0 +1,650 @@
+[
+  {
+    "case_id": "case_01_perfect",
+    "entries": [
+      {
+        "word": "record",
+        "chinese_hint": "记录（动词）",
+        "ipa": "rɪˈkɔrd",
+        "phonetic": "rih-KORD"
+      },
+      {
+        "word": "record",
+        "chinese_hint": "唱片；记录（名词）",
+        "ipa": "ˈrɛkərd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "赠送；呈现（动词）",
+        "ipa": "prɪˈzɛnt",
+        "phonetic": "prih-ZENT"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "礼物；现在（名词/形容词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "PREZ-ent"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "带领（动词）",
+        "ipa": "lid",
+        "phonetic": "leed"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "铅（金属）",
+        "ipa": "lɛd",
+        "phonetic": "led"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "风（名词）",
+        "ipa": "wɪnd",
+        "phonetic": "wind"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "缠绕（动词）",
+        "ipa": "waɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音；鲈鱼（鱼）",
+        "ipa": "bæs",
+        "phonetic": "bass"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音（音乐）",
+        "ipa": "beɪs",
+        "phonetic": "base"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "关闭（动词）",
+        "ipa": "kloʊz",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "接近的（形容词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohs"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "弓（武器）",
+        "ipa": "boʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "鞠躬（动词）",
+        "ipa": "baʊ",
+        "phonetic": "bau"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "眼泪（名词）",
+        "ipa": "tɪr",
+        "phonetic": "teer"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "撕裂（动词）",
+        "ipa": "tɛr",
+        "phonetic": "tare"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（现在时）",
+        "ipa": "rid",
+        "phonetic": "reed"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（过去时）",
+        "ipa": "rɛd",
+        "phonetic": "red"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "分钟（名词）",
+        "ipa": "ˈmɪnɪt",
+        "phonetic": "MIN-it"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "极小的（形容词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "my-NYOOT"
+      }
+    ],
+    "wrong_words": []
+  },
+  {
+    "case_id": "case_02_two_wrong",
+    "entries": [
+      {
+        "word": "record",
+        "chinese_hint": "记录（动词）",
+        "ipa": "rɪˈkɔrd",
+        "phonetic": "rih-KORD"
+      },
+      {
+        "word": "record",
+        "chinese_hint": "唱片；记录（名词）",
+        "ipa": "ˈrɛkərd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "赠送；呈现（动词）",
+        "ipa": "prɪˈzɛnt",
+        "phonetic": "prih-ZENT"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "礼物；现在（名词/形容词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "PREZ-ent"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "带领（动词）",
+        "ipa": "lɛd",
+        "phonetic": "leed"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "铅（金属）",
+        "ipa": "lɛd",
+        "phonetic": "led"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "风（名词）",
+        "ipa": "wɪnd",
+        "phonetic": "wind"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "缠绕（动词）",
+        "ipa": "waɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音；鲈鱼（鱼）",
+        "ipa": "bæs",
+        "phonetic": "bass"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音（音乐）",
+        "ipa": "beɪs",
+        "phonetic": "base"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "关闭（动词）",
+        "ipa": "kloʊz",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "接近的（形容词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "弓（武器）",
+        "ipa": "boʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "鞠躬（动词）",
+        "ipa": "baʊ",
+        "phonetic": "bau"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "眼泪（名词）",
+        "ipa": "tɪr",
+        "phonetic": "teer"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "撕裂（动词）",
+        "ipa": "tɛr",
+        "phonetic": "tare"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（现在时）",
+        "ipa": "rid",
+        "phonetic": "reed"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（过去时）",
+        "ipa": "rɛd",
+        "phonetic": "red"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "分钟（名词）",
+        "ipa": "ˈmɪnɪt",
+        "phonetic": "MIN-it"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "极小的（形容词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "my-NYOOT"
+      }
+    ],
+    "wrong_words": [
+      "lead",
+      "close"
+    ]
+  },
+  {
+    "case_id": "case_03_three_wrong",
+    "entries": [
+      {
+        "word": "record",
+        "chinese_hint": "记录（动词）",
+        "ipa": "rɪˈkɔrd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "record",
+        "chinese_hint": "唱片；记录（名词）",
+        "ipa": "ˈrɛkərd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "赠送；呈现（动词）",
+        "ipa": "prɪˈzɛnt",
+        "phonetic": "prih-ZENT"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "礼物；现在（名词/形容词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "PREZ-ent"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "带领（动词）",
+        "ipa": "lid",
+        "phonetic": "leed"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "铅（金属）",
+        "ipa": "lɛd",
+        "phonetic": "led"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "风（名词）",
+        "ipa": "wɪnd",
+        "phonetic": "wind"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "缠绕（动词）",
+        "ipa": "wɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音；鲈鱼（鱼）",
+        "ipa": "bæs",
+        "phonetic": "bass"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音（音乐）",
+        "ipa": "beɪs",
+        "phonetic": "base"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "关闭（动词）",
+        "ipa": "kloʊz",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "接近的（形容词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohs"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "弓（武器）",
+        "ipa": "boʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "鞠躬（动词）",
+        "ipa": "baʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "眼泪（名词）",
+        "ipa": "tɪr",
+        "phonetic": "teer"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "撕裂（动词）",
+        "ipa": "tɛr",
+        "phonetic": "tare"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（现在时）",
+        "ipa": "rid",
+        "phonetic": "reed"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（过去时）",
+        "ipa": "rɛd",
+        "phonetic": "red"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "分钟（名词）",
+        "ipa": "ˈmɪnɪt",
+        "phonetic": "MIN-it"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "极小的（形容词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "my-NYOOT"
+      }
+    ],
+    "wrong_words": [
+      "record",
+      "wind",
+      "bow"
+    ]
+  },
+  {
+    "case_id": "case_04_four_wrong",
+    "entries": [
+      {
+        "word": "record",
+        "chinese_hint": "记录（动词）",
+        "ipa": "rɪˈkɔrd",
+        "phonetic": "rih-KORD"
+      },
+      {
+        "word": "record",
+        "chinese_hint": "唱片；记录（名词）",
+        "ipa": "ˈrɛkərd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "赠送；呈现（动词）",
+        "ipa": "prɪˈzɛnt",
+        "phonetic": "prih-ZENT"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "礼物；现在（名词/形容词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "PREZ-ent"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "带领（动词）",
+        "ipa": "lid",
+        "phonetic": "leed"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "铅（金属）",
+        "ipa": "lɛd",
+        "phonetic": "leed"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "风（名词）",
+        "ipa": "wɪnd",
+        "phonetic": "wind"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "缠绕（动词）",
+        "ipa": "waɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音；鲈鱼（鱼）",
+        "ipa": "bæs",
+        "phonetic": "bass"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音（音乐）",
+        "ipa": "bæs",
+        "phonetic": "base"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "关闭（动词）",
+        "ipa": "kloʊz",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "接近的（形容词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohs"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "弓（武器）",
+        "ipa": "boʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "鞠躬（动词）",
+        "ipa": "baʊ",
+        "phonetic": "bau"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "眼泪（名词）",
+        "ipa": "tɪr",
+        "phonetic": "teer"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "撕裂（动词）",
+        "ipa": "tɪr",
+        "phonetic": "tare"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（现在时）",
+        "ipa": "rid",
+        "phonetic": "reed"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（过去时）",
+        "ipa": "rɛd",
+        "phonetic": "red"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "分钟（名词）",
+        "ipa": "ˈmɪnɪt",
+        "phonetic": "MIN-it"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "极小的（形容词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "MIN-it"
+      }
+    ],
+    "wrong_words": [
+      "lead",
+      "bass",
+      "tear",
+      "minute"
+    ]
+  },
+  {
+    "case_id": "case_05_five_wrong",
+    "entries": [
+      {
+        "word": "record",
+        "chinese_hint": "记录（动词）",
+        "ipa": "rɪˈkɔrd",
+        "phonetic": "rih-KORD"
+      },
+      {
+        "word": "record",
+        "chinese_hint": "唱片；记录（名词）",
+        "ipa": "ˈrɛkərd",
+        "phonetic": "REK-erd"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "赠送；呈现（动词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "prih-ZENT"
+      },
+      {
+        "word": "present",
+        "chinese_hint": "礼物；现在（名词/形容词）",
+        "ipa": "ˈprɛzənt",
+        "phonetic": "PREZ-ent"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "带领（动词）",
+        "ipa": "lid",
+        "phonetic": "leed"
+      },
+      {
+        "word": "lead",
+        "chinese_hint": "铅（金属）",
+        "ipa": "lɛd",
+        "phonetic": "led"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "风（名词）",
+        "ipa": "wɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "wind",
+        "chinese_hint": "缠绕（动词）",
+        "ipa": "waɪnd",
+        "phonetic": "wynd"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音；鲈鱼（鱼）",
+        "ipa": "bæs",
+        "phonetic": "bass"
+      },
+      {
+        "word": "bass",
+        "chinese_hint": "低音（音乐）",
+        "ipa": "beɪs",
+        "phonetic": "base"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "关闭（动词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohz"
+      },
+      {
+        "word": "close",
+        "chinese_hint": "接近的（形容词）",
+        "ipa": "kloʊs",
+        "phonetic": "klohs"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "弓（武器）",
+        "ipa": "boʊ",
+        "phonetic": "boh"
+      },
+      {
+        "word": "bow",
+        "chinese_hint": "鞠躬（动词）",
+        "ipa": "baʊ",
+        "phonetic": "bau"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "眼泪（名词）",
+        "ipa": "tɪr",
+        "phonetic": "teer"
+      },
+      {
+        "word": "tear",
+        "chinese_hint": "撕裂（动词）",
+        "ipa": "tɛr",
+        "phonetic": "tare"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（现在时）",
+        "ipa": "rid",
+        "phonetic": "red"
+      },
+      {
+        "word": "read",
+        "chinese_hint": "阅读（过去时）",
+        "ipa": "rɛd",
+        "phonetic": "red"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "分钟（名词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "MIN-it"
+      },
+      {
+        "word": "minute",
+        "chinese_hint": "极小的（形容词）",
+        "ipa": "maɪˈn(j)ut",
+        "phonetic": "my-NYOOT"
+      }
+    ],
+    "wrong_words": [
+      "present",
+      "wind",
+      "close",
+      "read",
+      "minute"
+    ]
+  }
+]

--- a/src/benchmarks/BENCHMARK_INDEX.md
+++ b/src/benchmarks/BENCHMARK_INDEX.md
@@ -55,6 +55,7 @@ This document captures the current benchmark lineup and numbering through `0299`
 | 0130 | `validate_lemma_form` | Validate Lemma Form (lokys) | agent regression | implemented |
 | 0131 | `validate_definition` | Validate Definition (lokys) | agent regression | implemented |
 | 0132 | `validate_translation` | Validate Translation (voras) | agent regression | implemented |
+| 0141 | `validate_pronunciation_bulk` | Validate Bulk IPA/Phonetic (bebras) | agent regression | implemented |
 | 0151 | `geography` | Geography Knowledge | general knowledge | implemented |
 | 0152 | `syllogism_validity` | Syllogism Validity | general knowledge | implemented |
 | 0153 | `book_author_match` | Book Author Match | general knowledge | implemented |

--- a/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
+++ b/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+"""Generator for Bebras bulk IPA/phonetic verification benchmark."""
+
+from typing import Any, Dict, Iterator, List
+
+from benchmarks.lib.utils.base_generator import BenchmarkGenerator
+from benchmarks.lib.utils.data_models import (
+    AnswerType,
+    BenchmarkMetadata,
+    BenchmarkQuestion,
+    Difficulty,
+    EvaluationCriteria,
+)
+
+BENCHMARK_CODE = "0141_validate_pronunciation_bulk"
+
+
+class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
+    """Generate batch pronunciation QA questions from curated sample lists."""
+
+    def __init__(self, metadata: BenchmarkMetadata, session: Any = None) -> None:
+        super().__init__(metadata, session)
+        self.can_load_from_file = True
+        self.can_generate_locally = False
+        self.can_generate_with_llm = False
+        self.questions_file_path = "samples.json"
+
+    def _generate_from_file(self, **kwargs: Any) -> Iterator[BenchmarkQuestion]:
+        samples: List[Dict[str, Any]] = self.load_json_file("samples.json")
+
+        for sample in samples:
+            case_id = sample["case_id"]
+            entries = sample["entries"]
+            wrong_words = sample["wrong_words"]
+
+            difficulty = Difficulty.EASY if not wrong_words else Difficulty.MEDIUM
+            if len(wrong_words) >= 4:
+                difficulty = Difficulty.HARD
+
+            yield BenchmarkQuestion(
+                question_text=f"Bulk pronunciation QA case: {case_id}",
+                answer_type=AnswerType.JSON,
+                correct_answer={
+                    "inputs": {"entries": entries},
+                    "expected": {"wrong_words": wrong_words},
+                },
+                category="agent_regression_pronunciation",
+                difficulty=difficulty,
+                tags=[
+                    "agent_benchmark",
+                    "bebras",
+                    "pronunciation",
+                    "ipa",
+                    f"case:{case_id}",
+                ],
+                evaluation_criteria=EvaluationCriteria(
+                    exact_match=True,
+                    case_sensitive=False,
+                    required_fields=["wrong_words"],
+                ),
+            )

--- a/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
+++ b/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python3
+
+"""Runner for Bebras bulk IPA/phonetic verification benchmark."""
+
+import json
+import time
+from typing import Any, Dict, Optional, Tuple
+
+from agents.bebras.verification import (
+    build_bulk_pronunciation_verification_context,
+    build_bulk_pronunciation_verification_prompt,
+    build_bulk_pronunciation_verification_schema,
+)
+from benchmarks.lib.utils.base_runner import BenchmarkRunner
+from benchmarks.lib.utils.data_models import BenchmarkMetadata, BenchmarkResult
+from clients import unified_client
+
+BENCHMARK_CODE = "0141_validate_pronunciation_bulk"
+
+
+class ValidatePronunciationBulkRunner(BenchmarkRunner):
+    """Run pronunciation-list validation and score wrong-word extraction accuracy."""
+
+    def prepare_prompt(
+        self, question_data: Dict[str, Any]
+    ) -> Tuple[str, Optional[Dict[str, Any]], Optional[str]]:
+        entries = question_data["correct_answer"]["inputs"]["entries"]
+        prompt = build_bulk_pronunciation_verification_prompt(entries)
+        schema = build_bulk_pronunciation_verification_schema()
+        context = build_bulk_pronunciation_verification_context()
+        return prompt, schema, context
+
+    def process_question(self, question: Dict[str, Any]) -> BenchmarkResult:
+        question_data = json.loads(question["question_info_json"])
+        question_id = question["question_id"]
+        expected = question_data["correct_answer"]["expected"]
+
+        prompt, schema, context = self.prepare_prompt(question_data)
+
+        try:
+            start_time = time.time()
+            response = unified_client.generate_chat(
+                prompt=prompt,
+                model=self.remote_model,
+                json_schema=schema,
+                context=context,
+            )
+            elapsed_msec = int((time.time() - start_time) * 1000)
+
+            structured_data = response.structured_data or {}
+            wrong_words = structured_data.get("wrong_words", [])
+            if not isinstance(wrong_words, list):
+                wrong_words = []
+
+            normalized_actual = sorted(str(word).strip().lower() for word in wrong_words)
+            normalized_expected = sorted(
+                str(word).strip().lower() for word in expected["wrong_words"]
+            )
+
+            is_correct = normalized_actual == normalized_expected
+            score = 100 if is_correct else 0
+
+            debug_info = {
+                "response": {"wrong_words": wrong_words},
+                "expected": expected,
+                "normalized_actual": normalized_actual,
+                "normalized_expected": normalized_expected,
+                "is_correct": is_correct,
+            }
+
+            return BenchmarkResult(
+                question_id=question_id,
+                score=score,
+                eval_msec=elapsed_msec,
+                debug_json=json.dumps(debug_info),
+            )
+
+        except Exception as error:
+            return BenchmarkResult(
+                question_id=question_id,
+                score=0,
+                eval_msec=0,
+                debug_json=json.dumps({"error": str(error)}),
+            )

--- a/src/benchmarks/lib/utils/registry.py
+++ b/src/benchmarks/lib/utils/registry.py
@@ -597,6 +597,12 @@ register_runner("0131_validate_definition", ValidateDefinitionRunner)
 
 from benchmarks.lib.generators.validate_translation_generator import ValidateTranslationGenerator
 from benchmarks.lib.runners.validate_translation_runner import ValidateTranslationRunner
+from benchmarks.lib.generators.validate_pronunciation_bulk_generator import (
+    ValidatePronunciationBulkGenerator,
+)
+from benchmarks.lib.runners.validate_pronunciation_bulk_runner import (
+    ValidatePronunciationBulkRunner,
+)
 
 
 @benchmark(
@@ -617,3 +623,23 @@ class ValidateTranslationBenchmark:
 
 register_generator("0132_validate_translation", ValidateTranslationGenerator)
 register_runner("0132_validate_translation", ValidateTranslationRunner)
+
+
+@benchmark(
+    code="0141_validate_pronunciation_bulk",
+    name="Validate Bulk IPA/Phonetic (bebras)",
+    description="""
+           A regression benchmark for Bebras bulk pronunciation verification.
+           Tests whether the model returns only words with wrong IPA/phonetic
+           mappings from 20-word lists with English + Chinese disambiguation.""",
+    category="agent regression",
+    default_num_questions=5,
+)
+class ValidatePronunciationBulkBenchmark:
+    """Module container for bulk pronunciation verification benchmark."""
+
+    pass
+
+
+register_generator("0141_validate_pronunciation_bulk", ValidatePronunciationBulkGenerator)
+register_runner("0141_validate_pronunciation_bulk", ValidatePronunciationBulkRunner)


### PR DESCRIPTION
### Motivation
- Provide a bulk QA tool to validate IPA/phonetic pronunciations for 10–50 items at once and return only problematic words in a machine-friendly JSON format.
- Integrate the flow into the Bebras verification agent and the benchmarks system so lists can be checked by LLMs and later recorded/acted on via configurable hooks (`log|remove|regenerate`).

### Description
- Added reusable builders in `src/agents/bebras/verification.py`: `build_bulk_pronunciation_verification_context`, `build_bulk_pronunciation_verification_prompt`, and `build_bulk_pronunciation_verification_schema`, plus `PronunciationCheckItem` and `IncorrectPronunciationAction` types.
- Implemented `VerificationAgent.verify_bulk_pronunciations()` with hook points `_hook_log_correct_pronunciation_verifications()` and `_handle_incorrect_pronunciation_words()` to support `log`, `remove`, and `regenerate` behaviors (non-destructive placeholders for now).
- Extended the Bebras CLI in `src/agents/bebras/verification_cli.py` with a `pronunciations` subcommand that accepts `--input-json` and `--incorrect-action` and prints JSON containing only `wrong_words`.
- Added benchmark `0141_validate_pronunciation_bulk` with a generator and runner in `src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py` and `src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py`, registered the benchmark in the registry, updated `BENCHMARK_INDEX.md`, and added 5 curated test cases (`src/benchmarks/0141_validate_pronunciation_bulk/samples.json`) (one perfect case, others contain 2–5 wrong items).

### Testing
- Ran `black` on modified files and formatting checks completed successfully.
- Ran `mypy` against modified files and type checks passed with no issues reported.
- Performed a smoke import to wire the benchmark generator/runner, which failed due to a missing environment dependency (`pydantic`) unrelated to the new code; this prevented an end-to-end registry import smoke test from completing in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3e8e6b6c8327a7dfcc0ef6c10d1c)