### PR TITLE
Bulk pronunciation checker: add entry IDs and structured wrong_entries with issue_type

### DIFF
--- a/src/agents/bebras/verification.py
+++ b/src/agents/bebras/verification.py
@@ -7,7 +7,7 @@ It does NOT regenerate content - it only validates and returns "correct"/"incorr
 """
 
 import logging
-from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict
+from typing import Any, Dict, List, Literal, Optional, Tuple, TypedDict, cast
 
 from clients.batch_queue import (
     BatchQueueManager,
@@ -64,9 +64,10 @@ LANGUAGE_DIALECT_NAMES: Dict[str, str] = {
 IncorrectPronunciationAction = Literal["log", "remove", "regenerate"]
 
 
-class PronunciationCheckItem(TypedDict):
+class PronunciationCheckItem(TypedDict, total=False):
     """Single pronunciation entry used by bulk IPA/phonetic validation."""
 
+    entry_id: str
     word: str
     chinese_hint: str
     ipa: str
@@ -89,29 +90,39 @@ def build_bulk_pronunciation_verification_prompt(items: List[PronunciationCheckI
         "Check this list and identify pronunciation problems.",
         "A problem means incorrect IPA, incorrect phonetic spelling, "
         "or IPA/phonetic mismatch for the intended English sense.",
-        "List only wrong words.",
+        "List only wrong entries by entry_id, with issue_type set to ipa, phonetic, or both.",
         "",
     ]
     for index, item in enumerate(items, start=1):
+        entry_id = str(item.get("entry_id", f"item_{index:02d}"))
         prompt_lines.append(
-            f'{index}. English: "{item["word"]}" | Chinese: "{item["chinese_hint"]}" '
+            f'{index}. ID: "{entry_id}" | English: "{item["word"]}" | Chinese: "{item["chinese_hint"]}" '
             f'| IPA: "{item["ipa"]}" | Phonetic: "{item["phonetic"]}"'
         )
     return "\n".join(prompt_lines)
 
 
 def build_bulk_pronunciation_verification_schema() -> Dict[str, Any]:
-    """Build JSON schema that only permits listing incorrect words."""
+    """Build JSON schema that only permits listing incorrect entries."""
     return {
         "type": "object",
         "properties": {
-            "wrong_words": {
+            "wrong_entries": {
                 "type": "array",
-                "description": "Only the English words with IPA/phonetic problems.",
-                "items": {"type": "string"},
+                "description": "Only entries with pronunciation problems.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "entry_id": {"type": "string"},
+                        "word": {"type": "string"},
+                        "issue_type": {"type": "string", "enum": ["ipa", "phonetic", "both"]},
+                    },
+                    "required": ["entry_id", "word", "issue_type"],
+                    "additionalProperties": False,
+                },
             }
         },
-        "required": ["wrong_words"],
+        "required": ["wrong_entries"],
         "additionalProperties": False,
     }
 
@@ -706,13 +717,36 @@ IMPORTANT:
             timeout=90,
         )
         structured_data = response.structured_data or {}
-        raw_wrong_words = structured_data.get("wrong_words", [])
-        wrong_words = [word for word in raw_wrong_words if isinstance(word, str) and word.strip()]
+        raw_wrong_entries = structured_data.get("wrong_entries", [])
+        normalized_items: List[PronunciationCheckItem] = []
+        for index, item in enumerate(items, start=1):
+            normalized_item = dict(item)
+            normalized_item["entry_id"] = str(item.get("entry_id", f"item_{index:02d}"))
+            normalized_items.append(cast(PronunciationCheckItem, normalized_item))
 
-        wrong_word_set = set(wrong_words)
-        wrong_items = [item for item in items if item["word"] in wrong_word_set]
+        valid_issue_types = {"ipa", "phonetic", "both"}
+        wrong_entries: List[Dict[str, str]] = []
+        for entry in raw_wrong_entries if isinstance(raw_wrong_entries, list) else []:
+            if not isinstance(entry, dict):
+                continue
+            entry_id = str(entry.get("entry_id", "")).strip()
+            word = str(entry.get("word", "")).strip()
+            issue_type = str(entry.get("issue_type", "")).strip().lower()
+            if not entry_id or not word or issue_type not in valid_issue_types:
+                continue
+            wrong_entries.append(
+                {
+                    "entry_id": entry_id,
+                    "word": word,
+                    "issue_type": issue_type,
+                }
+            )
 
-        self._hook_log_correct_pronunciation_verifications(items, wrong_word_set)
+        wrong_id_set = {entry["entry_id"] for entry in wrong_entries}
+        wrong_word_set = {entry["word"] for entry in wrong_entries}
+        wrong_items = [item for item in normalized_items if item["entry_id"] in wrong_id_set]
+
+        self._hook_log_correct_pronunciation_verifications(normalized_items, wrong_word_set)
         action_summary = self._handle_incorrect_pronunciation_words(
             wrong_items=wrong_items,
             action=incorrect_action,
@@ -720,9 +754,10 @@ IMPORTANT:
         )
 
         return {
-            "wrong_words": wrong_words,
-            "checked_count": len(items),
-            "wrong_count": len(wrong_words),
+            "wrong_entries": wrong_entries,
+            "wrong_words": sorted(wrong_word_set),
+            "checked_count": len(normalized_items),
+            "wrong_count": len(wrong_entries),
             "incorrect_action": incorrect_action,
             "action_summary": action_summary,
         }

--- a/src/agents/bebras/verification_cli.py
+++ b/src/agents/bebras/verification_cli.py
@@ -528,12 +528,13 @@ def verify_pronunciations(args: argparse.Namespace) -> int:
 
     items: List[PronunciationCheckItem] = []
     required_fields = ("word", "chinese_hint", "ipa", "phonetic")
-    for item in payload:
+    for index, item in enumerate(payload, start=1):
         if not isinstance(item, dict) or any(field not in item for field in required_fields):
             logger.error("Each item must include: word, chinese_hint, ipa, phonetic.")
             return 1
         items.append(
             {
+                "entry_id": str(item.get("entry_id", f"item_{index:02d}")),
                 "word": str(item["word"]),
                 "chinese_hint": str(item["chinese_hint"]),
                 "ipa": str(item["ipa"]),
@@ -547,7 +548,16 @@ def verify_pronunciations(args: argparse.Namespace) -> int:
         incorrect_action=incorrect_action,
         dry_run=args.dry_run,
     )
-    print(json.dumps({"wrong_words": result["wrong_words"]}, ensure_ascii=False, indent=2))
+    print(
+        json.dumps(
+            {
+                "wrong_entries": result["wrong_entries"],
+                "wrong_words": result["wrong_words"],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
     return 0
 
 

--- a/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
+++ b/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
@@ -6,124 +6,145 @@
         "word": "record",
         "chinese_hint": "记录（动词）",
         "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD"
+        "phonetic": "rih-KORD",
+        "entry_id": "case_01_perfect_item_01"
       },
       {
         "word": "record",
         "chinese_hint": "唱片；记录（名词）",
         "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_01_perfect_item_02"
       },
       {
         "word": "present",
         "chinese_hint": "赠送；呈现（动词）",
         "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT"
+        "phonetic": "prih-ZENT",
+        "entry_id": "case_01_perfect_item_03"
       },
       {
         "word": "present",
         "chinese_hint": "礼物；现在（名词/形容词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent"
+        "phonetic": "PREZ-ent",
+        "entry_id": "case_01_perfect_item_04"
       },
       {
         "word": "lead",
         "chinese_hint": "带领（动词）",
         "ipa": "lid",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_01_perfect_item_05"
       },
       {
         "word": "lead",
         "chinese_hint": "铅（金属）",
         "ipa": "lɛd",
-        "phonetic": "led"
+        "phonetic": "led",
+        "entry_id": "case_01_perfect_item_06"
       },
       {
         "word": "wind",
         "chinese_hint": "风（名词）",
         "ipa": "wɪnd",
-        "phonetic": "wind"
+        "phonetic": "wind",
+        "entry_id": "case_01_perfect_item_07"
       },
       {
         "word": "wind",
         "chinese_hint": "缠绕（动词）",
         "ipa": "waɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_01_perfect_item_08"
       },
       {
         "word": "bass",
         "chinese_hint": "低音；鲈鱼（鱼）",
         "ipa": "bæs",
-        "phonetic": "bass"
+        "phonetic": "bass",
+        "entry_id": "case_01_perfect_item_09"
       },
       {
         "word": "bass",
         "chinese_hint": "低音（音乐）",
         "ipa": "beɪs",
-        "phonetic": "base"
+        "phonetic": "base",
+        "entry_id": "case_01_perfect_item_10"
       },
       {
         "word": "close",
         "chinese_hint": "关闭（动词）",
         "ipa": "kloʊz",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_01_perfect_item_11"
       },
       {
         "word": "close",
         "chinese_hint": "接近的（形容词）",
         "ipa": "kloʊs",
-        "phonetic": "klohs"
+        "phonetic": "klohs",
+        "entry_id": "case_01_perfect_item_12"
       },
       {
         "word": "bow",
         "chinese_hint": "弓（武器）",
         "ipa": "boʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_01_perfect_item_13"
       },
       {
         "word": "bow",
         "chinese_hint": "鞠躬（动词）",
         "ipa": "baʊ",
-        "phonetic": "bau"
+        "phonetic": "bau",
+        "entry_id": "case_01_perfect_item_14"
       },
       {
         "word": "tear",
         "chinese_hint": "眼泪（名词）",
         "ipa": "tɪr",
-        "phonetic": "teer"
+        "phonetic": "teer",
+        "entry_id": "case_01_perfect_item_15"
       },
       {
         "word": "tear",
         "chinese_hint": "撕裂（动词）",
         "ipa": "tɛr",
-        "phonetic": "tare"
+        "phonetic": "tare",
+        "entry_id": "case_01_perfect_item_16"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（现在时）",
         "ipa": "rid",
-        "phonetic": "reed"
+        "phonetic": "reed",
+        "entry_id": "case_01_perfect_item_17"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（过去时）",
         "ipa": "rɛd",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_01_perfect_item_18"
       },
       {
         "word": "minute",
         "chinese_hint": "分钟（名词）",
         "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_01_perfect_item_19"
       },
       {
         "word": "minute",
         "chinese_hint": "极小的（形容词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT"
+        "phonetic": "my-NYOOT",
+        "entry_id": "case_01_perfect_item_20"
       }
     ],
-    "wrong_words": []
+    "wrong_words": [],
+    "wrong_entries": []
   },
   {
     "case_id": "case_02_two_wrong",
@@ -132,126 +153,158 @@
         "word": "record",
         "chinese_hint": "记录（动词）",
         "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD"
+        "phonetic": "rih-KORD",
+        "entry_id": "case_02_two_wrong_item_01"
       },
       {
         "word": "record",
         "chinese_hint": "唱片；记录（名词）",
         "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_02_two_wrong_item_02"
       },
       {
         "word": "present",
         "chinese_hint": "赠送；呈现（动词）",
         "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT"
+        "phonetic": "prih-ZENT",
+        "entry_id": "case_02_two_wrong_item_03"
       },
       {
         "word": "present",
         "chinese_hint": "礼物；现在（名词/形容词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent"
+        "phonetic": "PREZ-ent",
+        "entry_id": "case_02_two_wrong_item_04"
       },
       {
         "word": "lead",
         "chinese_hint": "带领（动词）",
         "ipa": "lɛd",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_02_two_wrong_item_05"
       },
       {
         "word": "lead",
         "chinese_hint": "铅（金属）",
         "ipa": "lɛd",
-        "phonetic": "led"
+        "phonetic": "led",
+        "entry_id": "case_02_two_wrong_item_06"
       },
       {
         "word": "wind",
         "chinese_hint": "风（名词）",
         "ipa": "wɪnd",
-        "phonetic": "wind"
+        "phonetic": "wind",
+        "entry_id": "case_02_two_wrong_item_07"
       },
       {
         "word": "wind",
         "chinese_hint": "缠绕（动词）",
         "ipa": "waɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_02_two_wrong_item_08"
       },
       {
         "word": "bass",
         "chinese_hint": "低音；鲈鱼（鱼）",
         "ipa": "bæs",
-        "phonetic": "bass"
+        "phonetic": "bass",
+        "entry_id": "case_02_two_wrong_item_09"
       },
       {
         "word": "bass",
         "chinese_hint": "低音（音乐）",
         "ipa": "beɪs",
-        "phonetic": "base"
+        "phonetic": "base",
+        "entry_id": "case_02_two_wrong_item_10"
       },
       {
         "word": "close",
         "chinese_hint": "关闭（动词）",
         "ipa": "kloʊz",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_02_two_wrong_item_11"
       },
       {
         "word": "close",
         "chinese_hint": "接近的（形容词）",
         "ipa": "kloʊs",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_02_two_wrong_item_12"
       },
       {
         "word": "bow",
         "chinese_hint": "弓（武器）",
         "ipa": "boʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_02_two_wrong_item_13"
       },
       {
         "word": "bow",
         "chinese_hint": "鞠躬（动词）",
         "ipa": "baʊ",
-        "phonetic": "bau"
+        "phonetic": "bau",
+        "entry_id": "case_02_two_wrong_item_14"
       },
       {
         "word": "tear",
         "chinese_hint": "眼泪（名词）",
         "ipa": "tɪr",
-        "phonetic": "teer"
+        "phonetic": "teer",
+        "entry_id": "case_02_two_wrong_item_15"
       },
       {
         "word": "tear",
         "chinese_hint": "撕裂（动词）",
         "ipa": "tɛr",
-        "phonetic": "tare"
+        "phonetic": "tare",
+        "entry_id": "case_02_two_wrong_item_16"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（现在时）",
         "ipa": "rid",
-        "phonetic": "reed"
+        "phonetic": "reed",
+        "entry_id": "case_02_two_wrong_item_17"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（过去时）",
         "ipa": "rɛd",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_02_two_wrong_item_18"
       },
       {
         "word": "minute",
         "chinese_hint": "分钟（名词）",
         "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_02_two_wrong_item_19"
       },
       {
         "word": "minute",
         "chinese_hint": "极小的（形容词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT"
+        "phonetic": "my-NYOOT",
+        "entry_id": "case_02_two_wrong_item_20"
       }
     ],
     "wrong_words": [
       "lead",
       "close"
+    ],
+    "wrong_entries": [
+      {
+        "entry_id": "case_02_two_wrong_item_05",
+        "word": "lead",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_02_two_wrong_item_12",
+        "word": "close",
+        "issue_type": "phonetic"
+      }
     ]
   },
   {
@@ -261,127 +314,164 @@
         "word": "record",
         "chinese_hint": "记录（动词）",
         "ipa": "rɪˈkɔrd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_03_three_wrong_item_01"
       },
       {
         "word": "record",
         "chinese_hint": "唱片；记录（名词）",
         "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_03_three_wrong_item_02"
       },
       {
         "word": "present",
         "chinese_hint": "赠送；呈现（动词）",
         "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT"
+        "phonetic": "prih-ZENT",
+        "entry_id": "case_03_three_wrong_item_03"
       },
       {
         "word": "present",
         "chinese_hint": "礼物；现在（名词/形容词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent"
+        "phonetic": "PREZ-ent",
+        "entry_id": "case_03_three_wrong_item_04"
       },
       {
         "word": "lead",
         "chinese_hint": "带领（动词）",
         "ipa": "lid",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_03_three_wrong_item_05"
       },
       {
         "word": "lead",
         "chinese_hint": "铅（金属）",
         "ipa": "lɛd",
-        "phonetic": "led"
+        "phonetic": "led",
+        "entry_id": "case_03_three_wrong_item_06"
       },
       {
         "word": "wind",
         "chinese_hint": "风（名词）",
         "ipa": "wɪnd",
-        "phonetic": "wind"
+        "phonetic": "wind",
+        "entry_id": "case_03_three_wrong_item_07"
       },
       {
         "word": "wind",
         "chinese_hint": "缠绕（动词）",
         "ipa": "wɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_03_three_wrong_item_08"
       },
       {
         "word": "bass",
         "chinese_hint": "低音；鲈鱼（鱼）",
         "ipa": "bæs",
-        "phonetic": "bass"
+        "phonetic": "bass",
+        "entry_id": "case_03_three_wrong_item_09"
       },
       {
         "word": "bass",
         "chinese_hint": "低音（音乐）",
         "ipa": "beɪs",
-        "phonetic": "base"
+        "phonetic": "base",
+        "entry_id": "case_03_three_wrong_item_10"
       },
       {
         "word": "close",
         "chinese_hint": "关闭（动词）",
         "ipa": "kloʊz",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_03_three_wrong_item_11"
       },
       {
         "word": "close",
         "chinese_hint": "接近的（形容词）",
         "ipa": "kloʊs",
-        "phonetic": "klohs"
+        "phonetic": "klohs",
+        "entry_id": "case_03_three_wrong_item_12"
       },
       {
         "word": "bow",
         "chinese_hint": "弓（武器）",
         "ipa": "boʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_03_three_wrong_item_13"
       },
       {
         "word": "bow",
         "chinese_hint": "鞠躬（动词）",
         "ipa": "baʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_03_three_wrong_item_14"
       },
       {
         "word": "tear",
         "chinese_hint": "眼泪（名词）",
         "ipa": "tɪr",
-        "phonetic": "teer"
+        "phonetic": "teer",
+        "entry_id": "case_03_three_wrong_item_15"
       },
       {
         "word": "tear",
         "chinese_hint": "撕裂（动词）",
         "ipa": "tɛr",
-        "phonetic": "tare"
+        "phonetic": "tare",
+        "entry_id": "case_03_three_wrong_item_16"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（现在时）",
         "ipa": "rid",
-        "phonetic": "reed"
+        "phonetic": "reed",
+        "entry_id": "case_03_three_wrong_item_17"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（过去时）",
         "ipa": "rɛd",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_03_three_wrong_item_18"
       },
       {
         "word": "minute",
         "chinese_hint": "分钟（名词）",
         "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_03_three_wrong_item_19"
       },
       {
         "word": "minute",
         "chinese_hint": "极小的（形容词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT"
+        "phonetic": "my-NYOOT",
+        "entry_id": "case_03_three_wrong_item_20"
       }
     ],
     "wrong_words": [
       "record",
       "wind",
       "bow"
+    ],
+    "wrong_entries": [
+      {
+        "entry_id": "case_03_three_wrong_item_01",
+        "word": "record",
+        "issue_type": "phonetic"
+      },
+      {
+        "entry_id": "case_03_three_wrong_item_08",
+        "word": "wind",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_03_three_wrong_item_14",
+        "word": "bow",
+        "issue_type": "phonetic"
+      }
     ]
   },
   {
@@ -391,121 +481,141 @@
         "word": "record",
         "chinese_hint": "记录（动词）",
         "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD"
+        "phonetic": "rih-KORD",
+        "entry_id": "case_04_four_wrong_item_01"
       },
       {
         "word": "record",
         "chinese_hint": "唱片；记录（名词）",
         "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_04_four_wrong_item_02"
       },
       {
         "word": "present",
         "chinese_hint": "赠送；呈现（动词）",
         "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT"
+        "phonetic": "prih-ZENT",
+        "entry_id": "case_04_four_wrong_item_03"
       },
       {
         "word": "present",
         "chinese_hint": "礼物；现在（名词/形容词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent"
+        "phonetic": "PREZ-ent",
+        "entry_id": "case_04_four_wrong_item_04"
       },
       {
         "word": "lead",
         "chinese_hint": "带领（动词）",
         "ipa": "lid",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_04_four_wrong_item_05"
       },
       {
         "word": "lead",
         "chinese_hint": "铅（金属）",
         "ipa": "lɛd",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_04_four_wrong_item_06"
       },
       {
         "word": "wind",
         "chinese_hint": "风（名词）",
         "ipa": "wɪnd",
-        "phonetic": "wind"
+        "phonetic": "wind",
+        "entry_id": "case_04_four_wrong_item_07"
       },
       {
         "word": "wind",
         "chinese_hint": "缠绕（动词）",
         "ipa": "waɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_04_four_wrong_item_08"
       },
       {
         "word": "bass",
         "chinese_hint": "低音；鲈鱼（鱼）",
         "ipa": "bæs",
-        "phonetic": "bass"
+        "phonetic": "bass",
+        "entry_id": "case_04_four_wrong_item_09"
       },
       {
         "word": "bass",
         "chinese_hint": "低音（音乐）",
         "ipa": "bæs",
-        "phonetic": "base"
+        "phonetic": "base",
+        "entry_id": "case_04_four_wrong_item_10"
       },
       {
         "word": "close",
         "chinese_hint": "关闭（动词）",
         "ipa": "kloʊz",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_04_four_wrong_item_11"
       },
       {
         "word": "close",
         "chinese_hint": "接近的（形容词）",
         "ipa": "kloʊs",
-        "phonetic": "klohs"
+        "phonetic": "klohs",
+        "entry_id": "case_04_four_wrong_item_12"
       },
       {
         "word": "bow",
         "chinese_hint": "弓（武器）",
         "ipa": "boʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_04_four_wrong_item_13"
       },
       {
         "word": "bow",
         "chinese_hint": "鞠躬（动词）",
         "ipa": "baʊ",
-        "phonetic": "bau"
+        "phonetic": "bau",
+        "entry_id": "case_04_four_wrong_item_14"
       },
       {
         "word": "tear",
         "chinese_hint": "眼泪（名词）",
         "ipa": "tɪr",
-        "phonetic": "teer"
+        "phonetic": "teer",
+        "entry_id": "case_04_four_wrong_item_15"
       },
       {
         "word": "tear",
         "chinese_hint": "撕裂（动词）",
         "ipa": "tɪr",
-        "phonetic": "tare"
+        "phonetic": "tare",
+        "entry_id": "case_04_four_wrong_item_16"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（现在时）",
         "ipa": "rid",
-        "phonetic": "reed"
+        "phonetic": "reed",
+        "entry_id": "case_04_four_wrong_item_17"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（过去时）",
         "ipa": "rɛd",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_04_four_wrong_item_18"
       },
       {
         "word": "minute",
         "chinese_hint": "分钟（名词）",
         "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_04_four_wrong_item_19"
       },
       {
         "word": "minute",
         "chinese_hint": "极小的（形容词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_04_four_wrong_item_20"
       }
     ],
     "wrong_words": [
@@ -513,6 +623,28 @@
       "bass",
       "tear",
       "minute"
+    ],
+    "wrong_entries": [
+      {
+        "entry_id": "case_04_four_wrong_item_06",
+        "word": "lead",
+        "issue_type": "phonetic"
+      },
+      {
+        "entry_id": "case_04_four_wrong_item_10",
+        "word": "bass",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_04_four_wrong_item_16",
+        "word": "tear",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_04_four_wrong_item_20",
+        "word": "minute",
+        "issue_type": "phonetic"
+      }
     ]
   },
   {
@@ -522,121 +654,141 @@
         "word": "record",
         "chinese_hint": "记录（动词）",
         "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD"
+        "phonetic": "rih-KORD",
+        "entry_id": "case_05_five_wrong_item_01"
       },
       {
         "word": "record",
         "chinese_hint": "唱片；记录（名词）",
         "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd"
+        "phonetic": "REK-erd",
+        "entry_id": "case_05_five_wrong_item_02"
       },
       {
         "word": "present",
         "chinese_hint": "赠送；呈现（动词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "prih-ZENT"
+        "phonetic": "prih-ZENT",
+        "entry_id": "case_05_five_wrong_item_03"
       },
       {
         "word": "present",
         "chinese_hint": "礼物；现在（名词/形容词）",
         "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent"
+        "phonetic": "PREZ-ent",
+        "entry_id": "case_05_five_wrong_item_04"
       },
       {
         "word": "lead",
         "chinese_hint": "带领（动词）",
         "ipa": "lid",
-        "phonetic": "leed"
+        "phonetic": "leed",
+        "entry_id": "case_05_five_wrong_item_05"
       },
       {
         "word": "lead",
         "chinese_hint": "铅（金属）",
         "ipa": "lɛd",
-        "phonetic": "led"
+        "phonetic": "led",
+        "entry_id": "case_05_five_wrong_item_06"
       },
       {
         "word": "wind",
         "chinese_hint": "风（名词）",
         "ipa": "wɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_05_five_wrong_item_07"
       },
       {
         "word": "wind",
         "chinese_hint": "缠绕（动词）",
         "ipa": "waɪnd",
-        "phonetic": "wynd"
+        "phonetic": "wynd",
+        "entry_id": "case_05_five_wrong_item_08"
       },
       {
         "word": "bass",
         "chinese_hint": "低音；鲈鱼（鱼）",
         "ipa": "bæs",
-        "phonetic": "bass"
+        "phonetic": "bass",
+        "entry_id": "case_05_five_wrong_item_09"
       },
       {
         "word": "bass",
         "chinese_hint": "低音（音乐）",
         "ipa": "beɪs",
-        "phonetic": "base"
+        "phonetic": "base",
+        "entry_id": "case_05_five_wrong_item_10"
       },
       {
         "word": "close",
         "chinese_hint": "关闭（动词）",
         "ipa": "kloʊs",
-        "phonetic": "klohz"
+        "phonetic": "klohz",
+        "entry_id": "case_05_five_wrong_item_11"
       },
       {
         "word": "close",
         "chinese_hint": "接近的（形容词）",
         "ipa": "kloʊs",
-        "phonetic": "klohs"
+        "phonetic": "klohs",
+        "entry_id": "case_05_five_wrong_item_12"
       },
       {
         "word": "bow",
         "chinese_hint": "弓（武器）",
         "ipa": "boʊ",
-        "phonetic": "boh"
+        "phonetic": "boh",
+        "entry_id": "case_05_five_wrong_item_13"
       },
       {
         "word": "bow",
         "chinese_hint": "鞠躬（动词）",
         "ipa": "baʊ",
-        "phonetic": "bau"
+        "phonetic": "bau",
+        "entry_id": "case_05_five_wrong_item_14"
       },
       {
         "word": "tear",
         "chinese_hint": "眼泪（名词）",
         "ipa": "tɪr",
-        "phonetic": "teer"
+        "phonetic": "teer",
+        "entry_id": "case_05_five_wrong_item_15"
       },
       {
         "word": "tear",
         "chinese_hint": "撕裂（动词）",
         "ipa": "tɛr",
-        "phonetic": "tare"
+        "phonetic": "tare",
+        "entry_id": "case_05_five_wrong_item_16"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（现在时）",
         "ipa": "rid",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_05_five_wrong_item_17"
       },
       {
         "word": "read",
         "chinese_hint": "阅读（过去时）",
         "ipa": "rɛd",
-        "phonetic": "red"
+        "phonetic": "red",
+        "entry_id": "case_05_five_wrong_item_18"
       },
       {
         "word": "minute",
         "chinese_hint": "分钟（名词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "MIN-it"
+        "phonetic": "MIN-it",
+        "entry_id": "case_05_five_wrong_item_19"
       },
       {
         "word": "minute",
         "chinese_hint": "极小的（形容词）",
         "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT"
+        "phonetic": "my-NYOOT",
+        "entry_id": "case_05_five_wrong_item_20"
       }
     ],
     "wrong_words": [
@@ -645,6 +797,33 @@
       "close",
       "read",
       "minute"
+    ],
+    "wrong_entries": [
+      {
+        "entry_id": "case_05_five_wrong_item_03",
+        "word": "present",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_05_five_wrong_item_07",
+        "word": "wind",
+        "issue_type": "phonetic"
+      },
+      {
+        "entry_id": "case_05_five_wrong_item_11",
+        "word": "close",
+        "issue_type": "ipa"
+      },
+      {
+        "entry_id": "case_05_five_wrong_item_17",
+        "word": "read",
+        "issue_type": "phonetic"
+      },
+      {
+        "entry_id": "case_05_five_wrong_item_19",
+        "word": "minute",
+        "issue_type": "ipa"
+      }
     ]
   }
 ]

--- a/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
+++ b/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
@@ -32,10 +32,10 @@ class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
         for sample in samples:
             case_id = sample["case_id"]
             entries = sample["entries"]
-            wrong_words = sample["wrong_words"]
+            wrong_entries = sample["wrong_entries"]
 
-            difficulty = Difficulty.EASY if not wrong_words else Difficulty.MEDIUM
-            if len(wrong_words) >= 4:
+            difficulty = Difficulty.EASY if not wrong_entries else Difficulty.MEDIUM
+            if len(wrong_entries) >= 4:
                 difficulty = Difficulty.HARD
 
             yield BenchmarkQuestion(
@@ -43,7 +43,7 @@ class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
                 answer_type=AnswerType.JSON,
                 correct_answer={
                     "inputs": {"entries": entries},
-                    "expected": {"wrong_words": wrong_words},
+                    "expected": {"wrong_entries": wrong_entries},
                 },
                 category="agent_regression_pronunciation",
                 difficulty=difficulty,
@@ -57,6 +57,6 @@ class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
                 evaluation_criteria=EvaluationCriteria(
                     exact_match=True,
                     case_sensitive=False,
-                    required_fields=["wrong_words"],
+                    required_fields=["wrong_entries"],
                 ),
             )

--- a/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
+++ b/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
@@ -48,20 +48,34 @@ class ValidatePronunciationBulkRunner(BenchmarkRunner):
             elapsed_msec = int((time.time() - start_time) * 1000)
 
             structured_data = response.structured_data or {}
-            wrong_words = structured_data.get("wrong_words", [])
-            if not isinstance(wrong_words, list):
-                wrong_words = []
+            wrong_entries = structured_data.get("wrong_entries", [])
+            if not isinstance(wrong_entries, list):
+                wrong_entries = []
 
-            normalized_actual = sorted(str(word).strip().lower() for word in wrong_words)
+            normalized_actual = sorted(
+                (
+                    str(entry.get("entry_id", "")).strip().lower(),
+                    str(entry.get("word", "")).strip().lower(),
+                    str(entry.get("issue_type", "")).strip().lower(),
+                )
+                for entry in wrong_entries
+                if isinstance(entry, dict)
+            )
             normalized_expected = sorted(
-                str(word).strip().lower() for word in expected["wrong_words"]
+                (
+                    str(entry.get("entry_id", "")).strip().lower(),
+                    str(entry.get("word", "")).strip().lower(),
+                    str(entry.get("issue_type", "")).strip().lower(),
+                )
+                for entry in expected["wrong_entries"]
+                if isinstance(entry, dict)
             )
 
             is_correct = normalized_actual == normalized_expected
             score = 100 if is_correct else 0
 
             debug_info = {
-                "response": {"wrong_words": wrong_words},
+                "response": {"wrong_entries": wrong_entries},
                 "expected": expected,
                 "normalized_actual": normalized_actual,
                 "normalized_expected": normalized_expected,


### PR DESCRIPTION
### Motivation
- The bulk IPA/phonetic verification could not distinguish repeated words and did not indicate whether the IPA or phonetic form (or both) was wrong.
- The benchmark and CLI needed to surface per-entry detail so evaluators and downstream tooling can act on specific issues.

### Description
- Added an optional `entry_id` to the `PronunciationCheckItem` and updated the prompt to include an `ID` so each input row is addressable and duplicates are distinguishable, with a default ephemeral `item_XX` when absent (`src/agents/bebras/verification.py`).
- Replaced the simple `wrong_words` schema with structured `wrong_entries` objects containing `entry_id`, `word`, and `issue_type` (enum: `ipa`, `phonetic`, `both`), and updated the LLM response handling to validate/normalize those entries and still derive a compatibility `wrong_words` list (`src/agents/bebras/verification.py`).
- Updated the pronunciations CLI to auto-assign default `entry_id`s when missing and to print both `wrong_entries` and `wrong_words` in the output (`src/agents/bebras/verification_cli.py`).
- Updated benchmark `0141` generator and runner to use `wrong_entries` (including `issue_type`) for evaluation, and extended the `0141` sample fixtures with explicit `entry_id` on each entry and `wrong_entries` expectations per case (`src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py`, `src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py`, `src/benchmarks/0141_validate_pronunciation_bulk/samples.json`).

### Testing
- Ran `black` on modified files (`src/agents/bebras/verification.py`, `src/agents/bebras/verification_cli.py`, `src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py`, `src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py`) and it succeeded.
- Ran `mypy` over the modified files and it reported no issues after adding `cast` where needed.
- Performed a quick Python sanity check that built a prompt and asserted `ID:` appears and that sample `wrong_entries` `issue_type` values are one of `ipa`, `phonetic`, or `both`, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd432483548327903df80d866ad92f)