### PR TITLE
Introduce UI string bundles and localize templates and rhyme language labels

### DIFF
--- a/src/barsukas/routes/rhymes.py
+++ b/src/barsukas/routes/rhymes.py
@@ -18,6 +18,7 @@ from flask import Blueprint, g, render_template, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import func
 
+from barsukas.helpers.strings import load_barsukas_strings
 from langtools.rhyme_keys import (
     RHYME_KEY_LANGUAGES,
     rhyme_key_final_sound,
@@ -47,9 +48,14 @@ def _validated_language_code(raw_language: Optional[str]) -> str:
 def _rhyme_language_options() -> List[Tuple[str, str]]:
     """Return sorted (language_code, language_name) options for rhyme browsing."""
     language_names = get_supported_languages()
+    ui_lang = getattr(g, "ui_lang", "en")
+    localized_names = load_barsukas_strings(namespace="languages", ui_lang=ui_lang)
     options: List[Tuple[str, str]] = []
     for language_code in sorted(RHYME_KEY_LANGUAGES):
-        options.append((language_code, language_names.get(language_code, language_code)))
+        localized_name = localized_names.get(
+            language_code, language_names.get(language_code, language_code)
+        )
+        options.append((language_code, localized_name))
     return options
 
 

--- a/src/barsukas/templates/lemmas/list.html
+++ b/src/barsukas/templates/lemmas/list.html
@@ -1,20 +1,20 @@
 {% extends "base.html" %}
 
-{% block title %}Browse Lemmas{% endblock %}
+{% block title %}{{ STRINGS.lemmas.browse_title }}{% endblock %}
 
 {% block content %}
 <div class="row mb-4">
     <div class="col">
         <div class="d-flex justify-content-between align-items-center">
             <div>
-                <h1><i class="bi bi-list"></i> Browse Lemmas</h1>
-                <p class="text-muted">{{ total }} lemma{{ 's' if total != 1 else '' }} found</p>
+                <h1><i class="bi bi-list"></i> {{ STRINGS.lemmas.browse_title }}</h1>
+                <p class="text-muted">{{ STRINGS.lemmas.found_count }}: {{ total }}</p>
             </div>
             <div>
                 <a href="{{ url_for('lemmas.add_lemma') }}"
                    class="btn btn-primary {% if config.get('READONLY', False) %}disabled{% endif %}"
                    {% if config.get('READONLY', False) %}aria-disabled="true" tabindex="-1"{% endif %}>
-                    <i class="bi bi-plus-circle"></i> Add New Lemma
+                    <i class="bi bi-plus-circle"></i> {{ STRINGS.lemmas.add_new }}
                 </a>
             </div>
         </div>
@@ -26,14 +26,14 @@
     <form method="get" action="{{ url_for('lemmas.list_lemmas') }}">
         <div class="row g-3">
             <div class="col-md-5">
-                <label for="search" class="form-label">Search</label>
+                <label for="search" class="form-label">{{ STRINGS.common.search }}</label>
                 <input type="text" class="form-control" id="search" name="search"
-                       value="{{ search }}" placeholder="Lemma text or definition...">
+                       value="{{ search }}" placeholder="{{ STRINGS.lemmas.search_placeholder }}">
             </div>
             <div class="col-md-2">
-                <label for="pos_type" class="form-label">POS Type</label>
+                <label for="pos_type" class="form-label">{{ STRINGS.lemmas.pos_type }}</label>
                 <select class="form-select" id="pos_type" name="pos_type">
-                    <option value="">All</option>
+                    <option value="">{{ STRINGS.common.all }}</option>
                     {% for pt in pos_types %}
                         <option value="{{ pt }}" {% if pt == pos_type %}selected{% endif %}>
                             {{ pt }}
@@ -42,9 +42,9 @@
                 </select>
             </div>
             <div class="col-md-2">
-                <label for="pos_subtype" class="form-label">Subcategory</label>
+                <label for="pos_subtype" class="form-label">{{ STRINGS.lemmas.subcategory }}</label>
                 <select class="form-select" id="pos_subtype" name="pos_subtype">
-                    <option value="">All</option>
+                    <option value="">{{ STRINGS.common.all }}</option>
                     {% for pst in pos_subtypes %}
                         <option value="{{ pst }}" {% if pst == pos_subtype %}selected{% endif %}>
                             {{ pst }}
@@ -53,14 +53,14 @@
                 </select>
             </div>
             <div class="col-md-3">
-                <label for="difficulty" class="form-label">Difficulty</label>
+                <label for="difficulty" class="form-label">{{ STRINGS.lemmas.difficulty }}</label>
                 <select class="form-select" id="difficulty" name="difficulty">
-                    <option value="">All</option>
-                    <option value="null" {% if difficulty == 'null' %}selected{% endif %}>No level set</option>
-                    <option value="-1" {% if difficulty == '-1' %}selected{% endif %}>Excluded (-1)</option>
+                    <option value="">{{ STRINGS.common.all }}</option>
+                    <option value="null" {% if difficulty == 'null' %}selected{% endif %}>{{ STRINGS.lemmas.no_level_set }}</option>
+                    <option value="-1" {% if difficulty == '-1' %}selected{% endif %}>{{ STRINGS.lemmas.excluded }}</option>
                     {% for i in range(1, config.MAX_DIFFICULTY_LEVEL + 1) %}
                         <option value="{{ i }}" {% if difficulty == i|string %}selected{% endif %}>
-                            Level {{ i }}
+                            {{ STRINGS.lemmas.level }} {{ i }}
                         </option>
                     {% endfor %}
                 </select>
@@ -69,10 +69,10 @@
         <div class="row mt-3">
             <div class="col">
                 <button type="submit" class="btn btn-primary">
-                    <i class="bi bi-search"></i> Search
+                    <i class="bi bi-search"></i> {{ STRINGS.common.search }}
                 </button>
                 <a href="{{ url_for('lemmas.list_lemmas') }}" class="btn btn-outline-secondary">
-                    <i class="bi bi-x-circle"></i> Clear
+                    <i class="bi bi-x-circle"></i> {{ STRINGS.common.clear }}
                 </a>
             </div>
         </div>
@@ -109,9 +109,9 @@
                                     {% endif %}
                                     {% if lemma.difficulty_level is not none %}
                                         {% if lemma.difficulty_level == -1 %}
-                                            <span class="badge bg-warning difficulty-badge">Excluded</span>
+                                            <span class="badge bg-warning difficulty-badge">{{ STRINGS.lemmas.excluded_short }}</span>
                                         {% else %}
-                                            <span class="badge bg-info difficulty-badge">Level {{ lemma.difficulty_level }}</span>
+                                            <span class="badge bg-info difficulty-badge">{{ STRINGS.lemmas.level }} {{ lemma.difficulty_level }}</span>
                                         {% endif %}
                                     {% endif %}
                                 </div>
@@ -119,12 +119,12 @@
                             <div class="col-md-4 text-end">
                                 <a href="{{ url_for('lemmas.view_lemma', lemma_id=lemma.id) }}"
                                    class="btn btn-sm btn-outline-primary">
-                                    <i class="bi bi-eye"></i> View
+                                    <i class="bi bi-eye"></i> {{ STRINGS.common.view }}
                                 </a>
                                 <a href="{{ url_for('lemmas.edit_lemma', lemma_id=lemma.id) }}"
                                    class="btn btn-sm btn-outline-secondary {% if config.get('READONLY', False) %}disabled{% endif %}"
                                    {% if config.get('READONLY', False) %}aria-disabled="true" tabindex="-1"{% endif %}>
-                                    <i class="bi bi-pencil"></i> Edit
+                                    <i class="bi bi-pencil"></i> {{ STRINGS.common.edit }}
                                 </a>
                             </div>
                         </div>
@@ -138,7 +138,7 @@
                     <ul class="pagination justify-content-center">
                         <li class="page-item {% if page == 1 %}disabled{% endif %}">
                             <a class="page-link" href="{{ url_for('lemmas.list_lemmas', page=page-1, search=search, pos_type=pos_type, pos_subtype=pos_subtype, difficulty=difficulty) }}">
-                                Previous
+                                {{ STRINGS.pagination.prev }}
                             </a>
                         </li>
 
@@ -158,7 +158,7 @@
 
                         <li class="page-item {% if page == total_pages %}disabled{% endif %}">
                             <a class="page-link" href="{{ url_for('lemmas.list_lemmas', page=page+1, search=search, pos_type=pos_type, pos_subtype=pos_subtype, difficulty=difficulty) }}">
-                                Next
+                                {{ STRINGS.pagination.next }}
                             </a>
                         </li>
                     </ul>
@@ -166,7 +166,7 @@
             {% endif %}
         {% else %}
             <div class="alert alert-info">
-                <i class="bi bi-info-circle"></i> No lemmas found matching your criteria.
+                <i class="bi bi-info-circle"></i> {{ STRINGS.lemmas.no_results }}
             </div>
         {% endif %}
     </div>

--- a/src/barsukas/templates/rhymes/family.html
+++ b/src/barsukas/templates/rhymes/family.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Rhyme Family: -{{ rhyme_key or '?' }}{% endblock %}
+{% block title %}{{ STRINGS.rhymes.family_title }}: -{{ rhyme_key or '?' }}{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/rhymes.css') }}">
@@ -10,7 +10,7 @@
 <div class="row mb-3">
     <div class="col">
         <a href="{{ url_for('rhymes.index', sound=final_sound, language=selected_language) }}" class="text-muted small">
-            <i class="bi bi-arrow-left"></i> Back to rhyme index
+            <i class="bi bi-arrow-left"></i> {{ STRINGS.rhymes.back_to_index }}
         </a>
     </div>
 </div>
@@ -18,7 +18,7 @@
 <form method="get" class="row g-2 align-items-end mb-3">
     <input type="hidden" name="key" value="{{ rhyme_key or '' }}">
     <div class="col-auto">
-        <label for="language" class="form-label mb-1">Language</label>
+        <label for="language" class="form-label mb-1">{{ STRINGS.common.language }}</label>
         <select class="form-select form-select-sm" id="language" name="language">
             {% for lang_code, lang_name in language_options %}
                 <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
@@ -28,7 +28,7 @@
         </select>
     </div>
     <div class="col-auto">
-        <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ STRINGS.common.apply }}</button>
     </div>
 </form>
 
@@ -38,9 +38,9 @@
         <div class="d-flex justify-content-between align-items-center">
             <h1 class="h4 mb-0">
                 <i class="bi bi-music-note-list"></i>
-                Words rhyming with <span class="rhyme-key-display">-{{ rhyme_key }}</span>
+                {{ STRINGS.rhymes.words_rhyming_with }} <span class="rhyme-key-display">-{{ rhyme_key }}</span>
             </h1>
-            <span class="text-muted">{{ words|length }} words</span>
+            <span class="text-muted">{{ STRINGS.rhymes.words_count }}: {{ words|length }}</span>
         </div>
     </div>
 </div>
@@ -51,11 +51,11 @@
         <table class="table table-sm table-hover">
             <thead>
                 <tr>
-                    <th>Word</th>
-                    <th>IPA</th>
-                    <th>Form</th>
-                    <th>POS</th>
-                    <th>Level</th>
+                    <th>{{ STRINGS.linguistics.word }}</th>
+                    <th>{{ STRINGS.linguistics.ipa }}</th>
+                    <th>{{ STRINGS.linguistics.form }}</th>
+                    <th>{{ STRINGS.linguistics.pos }}</th>
+                    <th>{{ STRINGS.linguistics.level }}</th>
                 </tr>
             </thead>
             <tbody>
@@ -88,7 +88,7 @@
                 {% if not words %}
                     <tr>
                         <td colspan="5" class="text-center text-muted py-4">
-                            No words found for this rhyme key.
+                            {{ STRINGS.rhymes.no_words_for_key }}
                         </td>
                     </tr>
                 {% endif %}
@@ -101,7 +101,7 @@
     <div class="col-md-3">
         <div class="card">
             <div class="card-header">
-                <h6 class="mb-0">Related rhymes (-{{ final_sound }})</h6>
+                <h6 class="mb-0">{{ STRINGS.rhymes.related_rhymes }} (-{{ final_sound }})</h6>
             </div>
             <div class="list-group list-group-flush rhyme-related-list">
                 {% for rel in related_families %}
@@ -121,7 +121,7 @@
 <div class="row">
     <div class="col">
         <div class="alert alert-info">
-            No rhyme key specified. <a href="{{ url_for('rhymes.index', language=selected_language) }}">Browse rhyme families</a>.
+            {{ STRINGS.rhymes.no_key_specified }} <a href="{{ url_for('rhymes.index', language=selected_language) }}">{{ STRINGS.rhymes.browse_families }}</a>.
         </div>
     </div>
 </div>

--- a/src/barsukas/templates/rhymes/index.html
+++ b/src/barsukas/templates/rhymes/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Rhyming Dictionary{% endblock %}
+{% block title %}{{ STRINGS.rhymes.title }}{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/rhymes.css') }}">
@@ -10,15 +10,15 @@
 <div class="row mb-3">
     <div class="col">
         <div class="d-flex justify-content-between align-items-center">
-            <h1 class="h4 mb-0"><i class="bi bi-music-note-list"></i> Rhyming Dictionary</h1>
-            <span class="text-muted">{{ total_families }} rhyme families</span>
+            <h1 class="h4 mb-0"><i class="bi bi-music-note-list"></i> {{ STRINGS.rhymes.title }}</h1>
+            <span class="text-muted">{{ STRINGS.rhymes.families_count }}: {{ total_families }}</span>
         </div>
     </div>
 </div>
 
 <form method="get" class="row g-2 align-items-end mb-3">
     <div class="col-auto">
-        <label for="language" class="form-label mb-1">Language</label>
+        <label for="language" class="form-label mb-1">{{ STRINGS.common.language }}</label>
         <select class="form-select form-select-sm" id="language" name="language">
             {% for lang_code, lang_name in language_options %}
                 <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
@@ -34,14 +34,14 @@
         <input type="hidden" name="pen" value="{{ selected_penultimate }}">
     {% endif %}
     <div class="col-auto">
-        <button type="submit" class="btn btn-sm btn-outline-secondary">Apply</button>
+        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ STRINGS.common.apply }}</button>
     </div>
 </form>
 
 <!-- Tier 1: Final sound navigation -->
 {% if final_sounds %}
 <nav class="rhyme-nav mb-3" aria-label="Final sound navigation">
-    <span class="rhyme-nav-label text-muted small me-2">Ending sound:</span>
+    <span class="rhyme-nav-label text-muted small me-2">{{ STRINGS.rhymes.ending_sound }}:</span>
     {% for sound, count in final_sounds %}
         {% if sound == selected_sound %}
             <span class="rhyme-sound rhyme-sound-active" title="{{ count }} families">{{ sound }}</span>
@@ -56,9 +56,9 @@
 <!-- Tier 2: Penultimate sound sub-navigation -->
 {% if penultimate_sounds|length > 1 %}
 <nav class="rhyme-nav rhyme-nav-tier2 mb-3" aria-label="Vowel sound navigation">
-    <span class="rhyme-nav-label text-muted small me-2">Vowel:</span>
+    <span class="rhyme-nav-label text-muted small me-2">{{ STRINGS.rhymes.vowel }}:</span>
     <a href="{{ url_for('rhymes.index', sound=selected_sound, language=selected_language) }}"
-       class="rhyme-sound rhyme-sound-sm {% if not selected_penultimate %}rhyme-sound-active{% endif %}">All</a>
+       class="rhyme-sound rhyme-sound-sm {% if not selected_penultimate %}rhyme-sound-active{% endif %}">{{ STRINGS.common.all }}</a>
     {% for pen in penultimate_sounds %}
         {% if pen == selected_penultimate %}
             <span class="rhyme-sound rhyme-sound-sm rhyme-sound-active">{{ pen }}</span>
@@ -75,9 +75,9 @@
     <table class="table table-sm table-hover">
         <thead>
             <tr>
-                <th>Rhyme Key</th>
-                <th>Example</th>
-                <th class="text-end">Words</th>
+                <th>{{ STRINGS.rhymes.rhyme_key }}</th>
+                <th>{{ STRINGS.rhymes.example }}</th>
+                <th class="text-end">{{ STRINGS.rhymes.words }}</th>
             </tr>
         </thead>
         <tbody>
@@ -94,8 +94,8 @@
             {% if not families %}
                 <tr>
                     <td colspan="3" class="text-center text-muted py-4">
-                        No rhyme families found.
-                        {% if selected_sound %}Try a different ending sound.{% endif %}
+                        {{ STRINGS.rhymes.no_families }}
+                        {% if selected_sound %}{{ STRINGS.rhymes.try_other_ending }}{% endif %}
                     </td>
                 </tr>
             {% endif %}

--- a/strings/README.md
+++ b/strings/README.md
@@ -1,0 +1,39 @@
+# Strings layout
+
+This repository stores UI translation strings in JSON files under namespaced folders.
+
+## Directory structure
+
+- `strings/barsukas/<namespace>/en.json`
+- `strings/barsukas/<namespace>/lt.json`
+
+Each `<namespace>` groups related keys (for example: `navigation`, `pagination`, `dictionary`, `lemmas`, `rhymes`, `languages`, `common`, `linguistics`).
+
+## File format
+
+- Files are UTF-8 JSON objects.
+- Keys are stable identifiers used in templates.
+- Values are localized strings.
+- Prefer static labels for counts, and render the number separately in templates to avoid plural grammar issues.
+
+Example:
+
+```json
+{
+  "entries_count": "Entries"
+}
+```
+
+## Template usage
+
+Barsukas loads all namespaces into a global `STRINGS` object for templates.
+
+- Access a namespace with dot syntax: `STRINGS.dictionary.title`
+- Access dynamic keys with `.get(...)` when needed.
+- For counts, keep text and number as separate template blocks:
+  - `{{ STRINGS.dictionary.entries_count }}: {{ total }}`
+
+## Fallback behavior
+
+- UI language is selected from supported languages (`en`, `lt`).
+- If a namespace file is missing for the selected UI language, Barsukas falls back to `en.json` for that namespace.

--- a/strings/README.md
+++ b/strings/README.md
@@ -9,6 +9,39 @@ This repository stores UI translation strings in JSON files under namespaced fol
 
 Each `<namespace>` groups related keys (for example: `navigation`, `pagination`, `dictionary`, `lemmas`, `rhymes`, `languages`, `common`, `linguistics`).
 
+## Namespace scope (shared vs module-specific)
+
+Use shared namespaces across multiple pages/modules, and keep module-specific
+namespaces isolated to their own views.
+
+### Shared namespaces (cross-module)
+
+- `strings/barsukas/common/en.json`
+- `strings/barsukas/common/lt.json`
+- `strings/barsukas/linguistics/en.json`
+- `strings/barsukas/linguistics/lt.json`
+- `strings/barsukas/navigation/en.json`
+- `strings/barsukas/navigation/lt.json`
+- `strings/barsukas/pagination/en.json`
+- `strings/barsukas/pagination/lt.json`
+- `strings/barsukas/languages/en.json`
+- `strings/barsukas/languages/lt.json`
+- `strings/barsukas/parts_of_speech/en.json`
+- `strings/barsukas/parts_of_speech/lt.json`
+
+### Module-specific namespaces
+
+- `strings/barsukas/lemmas/en.json`
+- `strings/barsukas/lemmas/lt.json`
+- `strings/barsukas/rhymes/en.json`
+- `strings/barsukas/rhymes/lt.json`
+- `strings/barsukas/dictionary/en.json`
+- `strings/barsukas/dictionary/lt.json`
+
+Rule of thumb: pages should use shared namespaces for generic labels, but avoid
+importing another module's namespace (for example, `lemmas` should not use
+`rhymes` keys).
+
 ## File format
 
 - Files are UTF-8 JSON objects.

--- a/strings/barsukas/common/en.json
+++ b/strings/barsukas/common/en.json
@@ -1,0 +1,9 @@
+{
+  "all": "All",
+  "apply": "Apply",
+  "clear": "Clear",
+  "edit": "Edit",
+  "language": "Language",
+  "search": "Search",
+  "view": "View"
+}

--- a/strings/barsukas/common/lt.json
+++ b/strings/barsukas/common/lt.json
@@ -1,0 +1,9 @@
+{
+  "all": "Visi",
+  "apply": "Taikyti",
+  "clear": "Išvalyti",
+  "edit": "Redaguoti",
+  "language": "Kalba",
+  "search": "Paieška",
+  "view": "Peržiūrėti"
+}

--- a/strings/barsukas/lemmas/en.json
+++ b/strings/barsukas/lemmas/en.json
@@ -1,0 +1,14 @@
+{
+  "browse_title": "Browse Lemmas",
+  "found_count": "Lemmas found",
+  "add_new": "Add New Lemma",
+  "search_placeholder": "Lemma text or definition...",
+  "pos_type": "POS Type",
+  "subcategory": "Subcategory",
+  "difficulty": "Difficulty",
+  "no_level_set": "No level set",
+  "excluded": "Excluded",
+  "excluded_short": "Excluded",
+  "level": "Level",
+  "no_results": "No lemmas found matching your criteria."
+}

--- a/strings/barsukas/lemmas/lt.json
+++ b/strings/barsukas/lemmas/lt.json
@@ -1,0 +1,14 @@
+{
+  "browse_title": "Lemų naršymas",
+  "found_count": "Rasta lemų",
+  "add_new": "Pridėti naują lemą",
+  "search_placeholder": "Lemos tekstas arba apibrėžimas...",
+  "pos_type": "Kalbos dalis",
+  "subcategory": "Subkategorija",
+  "difficulty": "Sunkumas",
+  "no_level_set": "Lygis nenustatytas",
+  "excluded": "Neįtrauktas",
+  "excluded_short": "Neįtrauktas",
+  "level": "Lygis",
+  "no_results": "Pagal jūsų kriterijus lemų nerasta."
+}

--- a/strings/barsukas/linguistics/en.json
+++ b/strings/barsukas/linguistics/en.json
@@ -1,0 +1,7 @@
+{
+  "form": "Form",
+  "ipa": "IPA",
+  "level": "Level",
+  "pos": "POS",
+  "word": "Word"
+}

--- a/strings/barsukas/linguistics/lt.json
+++ b/strings/barsukas/linguistics/lt.json
@@ -1,0 +1,7 @@
+{
+  "form": "Forma",
+  "ipa": "IPA",
+  "level": "Lygis",
+  "pos": "Kalbos dalis",
+  "word": "Žodis"
+}

--- a/strings/barsukas/rhymes/en.json
+++ b/strings/barsukas/rhymes/en.json
@@ -1,0 +1,19 @@
+{
+  "title": "Rhyming Dictionary",
+  "families_count": "Rhyme families",
+  "family_title": "Rhyme Family",
+  "ending_sound": "Ending sound",
+  "vowel": "Vowel",
+  "rhyme_key": "Rhyme Key",
+  "example": "Example",
+  "words": "Words",
+  "no_families": "No rhyme families found.",
+  "try_other_ending": "Try a different ending sound.",
+  "back_to_index": "Back to rhyme index",
+  "words_rhyming_with": "Words rhyming with",
+  "words_count": "Words",
+  "no_words_for_key": "No words found for this rhyme key.",
+  "related_rhymes": "Related rhymes",
+  "no_key_specified": "No rhyme key specified.",
+  "browse_families": "Browse rhyme families"
+}

--- a/strings/barsukas/rhymes/lt.json
+++ b/strings/barsukas/rhymes/lt.json
@@ -1,0 +1,19 @@
+{
+  "title": "Rimų žodynas",
+  "families_count": "Rimų šeimų",
+  "family_title": "Rimų šeima",
+  "ending_sound": "Galinis garsas",
+  "vowel": "Balsis",
+  "rhyme_key": "Rimo raktas",
+  "example": "Pavyzdys",
+  "words": "Žodžiai",
+  "no_families": "Rimų šeimų nerasta.",
+  "try_other_ending": "Pabandykite kitą galinį garsą.",
+  "back_to_index": "Atgal į rimų sąrašą",
+  "words_rhyming_with": "Žodžiai, rimuojantys su",
+  "words_count": "Žodžiai",
+  "no_words_for_key": "Šiam rimo raktui žodžių nerasta.",
+  "related_rhymes": "Susiję rimai",
+  "no_key_specified": "Nenurodytas rimo raktas.",
+  "browse_families": "Naršyti rimų šeimas"
+}


### PR DESCRIPTION
### Motivation

- Replace hard-coded UI labels in lemma and rhyme pages with a centralized translation system to support multiple UI languages.
- Provide localized language names in the rhyme browsing UI so options are shown in the current `ui_lang` when available.

### Description

- Replaced hard-coded strings in `lemmas/list.html`, `rhymes/index.html`, and `rhymes/family.html` with lookups into the global `STRINGS` object used by templates. 
- Added a set of JSON string bundles under `strings/barsukas/` for the `common`, `lemmas`, `linguistics`, and `rhymes` namespaces with `en.json` and `lt.json` translations and a `strings/README.md` describing the format and fallback rules. 
- Updated `src/barsukas/routes/rhymes.py` to import and use `load_barsukas_strings` and `g.ui_lang` to produce localized language options for rhyme browsing.

### Testing

- Ran the project test suite with `pytest` and the tests completed successfully. 
- Performed template render smoke checks for the modified pages to ensure the `STRINGS` lookups render without template errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd43daac5c8327948ebf032ce566c1)