### PR TITLE
Fix missing cost/token fields in 0141 pronunciation bulk runner

### DIFF
--- a/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
+++ b/src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py
@@ -132,6 +132,10 @@ class ValidatePronunciationBulkRunner(BenchmarkRunner):
                 score=score,
                 eval_msec=elapsed_msec,
                 debug_json=json.dumps(debug_info),
+                cost_usd=response.usage.cost if response.usage else None,
+                tokens_used=response.usage.total_tokens if response.usage else None,
+                tokens_in=response.usage.tokens_in if response.usage else None,
+                tokens_out=response.usage.tokens_out if response.usage else None,
             )
 
         except Exception as error:


### PR DESCRIPTION
### Motivation
- The 0141 benchmark runner (`ValidatePronunciationBulkRunner`) returned `BenchmarkResult` without copying usage telemetry from the LLM response, causing `run_detail.cost_usd` and token columns to remain null for that benchmark's runs.

### Description
- Populate `cost_usd`, `tokens_used`, `tokens_in`, and `tokens_out` on the `BenchmarkResult` returned by `src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py` so run details persist usage and cost like the base runner.

### Testing
- Ran formatter: `black src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py` which completed successfully. 
- Ran type check: `PYTHONPATH=src mypy src/benchmarks/lib/runners/validate_pronunciation_bulk_runner.py` which passed with no issues. 
- Attempted unit test run `PYTHONPATH=src python -m unittest src/benchmarks/lib/runners/test_validate_pronunciation_bulk_scoring.py` but the test run failed in this environment due to a missing `pydantic` dependency (external to this change) and not because of the code modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4b998c80832785935999ba40b5fa)