### PR TITLE
Fix clear button label lookup in lemmas list template and add smoke test

### DIFF
--- a/src/barsukas/templates/lemmas/list.html
+++ b/src/barsukas/templates/lemmas/list.html
@@ -72,7 +72,7 @@
                     <i class="bi bi-search"></i> {{ STRINGS.common.search }}
                 </button>
                 <a href="{{ url_for('lemmas.list_lemmas') }}" class="btn btn-outline-secondary">
-                    <i class="bi bi-x-circle"></i> {{ STRINGS.common.clear }}
+                    <i class="bi bi-x-circle"></i> {{ STRINGS.common["clear"] }}
                 </a>
             </div>
         </div>

--- a/src/tests/barsukas/test_routes_smoke.py
+++ b/src/tests/barsukas/test_routes_smoke.py
@@ -31,6 +31,12 @@ class TestLemmaRoutes:
         response = client.get("/lemmas/?pos_type=verb")
         assert response.status_code == 200
 
+    def test_lemma_list_clear_button_uses_string_value(self, client: FlaskClient) -> None:
+        response = client.get("/lemmas/")
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "built-in method" not in html
+
     def test_view_lemma_returns_200(self, client: FlaskClient) -> None:
         response = client.get("/lemmas/1")
         assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Prevent the template from rendering a Python/method representation for the "clear" label by ensuring the string is fetched correctly from the `STRINGS` mapping.

### Description
- Changed the lemmas list template to use bracket lookup for the `clear` key: replaced `{{ STRINGS.common.clear }}` with `{{ STRINGS.common["clear"] }}` in `src/barsukas/templates/lemmas/list.html`.
- Added a smoke test `test_lemma_list_clear_button_uses_string_value` in `src/tests/barsukas/test_routes_smoke.py` that asserts the page does not contain the text `"built-in method"`.

### Testing
- Ran the smoke tests in `tests/barsukas/test_routes_smoke.py`, including the new `test_lemma_list_clear_button_uses_string_value`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4cb6be708327887ad789b4701fea)