### PR TITLE
Seed sentence translations and parametrize route smoke tests to cover pages and rendering issues

### DIFF
--- a/src/tests/barsukas/conftest.py
+++ b/src/tests/barsukas/conftest.py
@@ -21,6 +21,7 @@ from storage.models.schema import (
     LemmaDifficultyOverride,
     LemmaTranslation,
     Sentence,
+    SentenceTranslation,
 )
 
 
@@ -118,6 +119,29 @@ def _seed_database(session: Session) -> None:
         ),
     ]
     session.add_all(forms)
+
+    sentence1 = Sentence(
+        id=1,
+        guid="S_00001",
+        pattern_type="SVO",
+        minimum_level=1,
+        verified=False,
+        rejected=False,
+    )
+    session.add(sentence1)
+    session.flush()
+
+    sentence_translation_en = SentenceTranslation(
+        sentence_id=1,
+        language_code="en",
+        translation_text="I eat",
+    )
+    sentence_translation_lt = SentenceTranslation(
+        sentence_id=1,
+        language_code="lt",
+        translation_text="Aš valgau",
+    )
+    session.add_all([sentence_translation_en, sentence_translation_lt])
 
     session.commit()
 

--- a/src/tests/barsukas/test_routes_smoke.py
+++ b/src/tests/barsukas/test_routes_smoke.py
@@ -1,25 +1,62 @@
 """Smoke tests for Barsukas GET routes.
 
 These tests use the Flask test client with a temporary SQLite database
-to verify that key pages render without errors.  They do NOT test
+to verify that key pages render without errors. They do NOT test
 business logic — only that templates render and return 200.
 """
+
+from dataclasses import dataclass
 
 import pytest
 from flask.testing import FlaskClient
 
 
-class TestLemmaRoutes:
-    """Smoke tests for /lemmas routes."""
+@dataclass(frozen=True)
+class RouteSmokeCase:
+    """Single smoke-test case for a route."""
 
-    def test_lemma_list_returns_200(self, client: FlaskClient) -> None:
-        response = client.get("/lemmas/")
+    name: str
+    path: str
+    expected_text: str
+
+
+ROUTE_SMOKE_CASES: tuple[RouteSmokeCase, ...] = (
+    RouteSmokeCase(name="lemmas", path="/lemmas/", expected_text="eat"),
+    RouteSmokeCase(name="sentences", path="/sentences/", expected_text="I eat"),
+    RouteSmokeCase(name="dictionary", path="/dictionary/?letter=E", expected_text="eat"),
+    RouteSmokeCase(name="sync", path="/sync/", expected_text="sync"),
+)
+
+
+class TestRouteSmoke:
+    """Reusable smoke checks for top-level Barsukas sections."""
+
+    @pytest.mark.parametrize("case", ROUTE_SMOKE_CASES, ids=lambda case: case.name)
+    def test_section_page_returns_200(self, client: FlaskClient, case: RouteSmokeCase) -> None:
+        response = client.get(case.path)
         assert response.status_code == 200
 
-    def test_lemma_list_contains_seed_lemma(self, client: FlaskClient) -> None:
-        response = client.get("/lemmas/")
+    @pytest.mark.parametrize("case", ROUTE_SMOKE_CASES, ids=lambda case: case.name)
+    def test_section_page_contains_expected_text(
+        self, client: FlaskClient, case: RouteSmokeCase
+    ) -> None:
+        response = client.get(case.path)
+        assert response.status_code == 200
+        html = response.data.decode().lower()
+        assert case.expected_text.lower() in html
+
+    @pytest.mark.parametrize("case", ROUTE_SMOKE_CASES, ids=lambda case: case.name)
+    def test_section_page_does_not_render_builtin_method_text(
+        self, client: FlaskClient, case: RouteSmokeCase
+    ) -> None:
+        response = client.get(case.path)
+        assert response.status_code == 200
         html = response.data.decode()
-        assert "eat" in html
+        assert "built-in method" not in html
+
+
+class TestLemmaRoutes:
+    """Smoke tests for /lemmas routes."""
 
     def test_lemma_list_search(self, client: FlaskClient) -> None:
         response = client.get("/lemmas/?search=house")
@@ -30,12 +67,6 @@ class TestLemmaRoutes:
     def test_lemma_list_filter_by_pos_type(self, client: FlaskClient) -> None:
         response = client.get("/lemmas/?pos_type=verb")
         assert response.status_code == 200
-
-    def test_lemma_list_clear_button_uses_string_value(self, client: FlaskClient) -> None:
-        response = client.get("/lemmas/")
-        assert response.status_code == 200
-        html = response.data.decode()
-        assert "built-in method" not in html
 
     def test_view_lemma_returns_200(self, client: FlaskClient) -> None:
         response = client.get("/lemmas/1")


### PR DESCRIPTION
### Motivation

- Ensure sentence-related pages have seed data so `/sentences/` and related routes render in smoke tests. 
- Consolidate and parametrize route smoke tests to avoid duplication and verify expected content across top-level pages. 
- Prevent templates from rendering accidental Python text like "built-in method" by asserting it is not present in responses.

### Description

- Import `SentenceTranslation` and add a seeded `Sentence` plus English and Lithuanian `SentenceTranslation` rows in the test DB seed (`_seed_database`).
- Introduce a frozen dataclass `RouteSmokeCase` and a `ROUTE_SMOKE_CASES` tuple to declare route name, path, and `expected_text` for parameterized tests.
- Replace duplicated single-route smoke tests with three parameterized tests: `test_section_page_returns_200`, `test_section_page_contains_expected_text`, and `test_section_page_does_not_render_builtin_method_text` that run across the declared cases.
- Keep lemma-specific route tests and remove the now-duplicated check for the builtin-method text in the lemma list.

### Testing

- Ran the Barsukas smoke tests via `pytest src/tests/barsukas -q` and the test collection executed the new parameterized cases for `lemmas`, `sentences`, `dictionary`, and `sync`.
- All executed tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4e9983408327ac0ab4fecf77cd29)