### PR TITLE
Refactor pronunciation bulk generator and split sample/wrong datasets

### DIFF
--- a/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
+++ b/src/benchmarks/0141_validate_pronunciation_bulk/samples.json
@@ -1,815 +1,144 @@
-[
-  {
-    "case_id": "case_01_perfect",
-    "entries": [
-      {
-        "word": "record",
-        "chinese_hint": "记录（动词）",
-        "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD",
-        "entry_id": "C1_001"
-      },
-      {
-        "word": "record",
-        "chinese_hint": "唱片；记录（名词）",
-        "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd",
-        "entry_id": "C1_002"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "赠送；呈现（动词）",
-        "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT",
-        "entry_id": "C1_003"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "礼物；现在（名词/形容词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent",
-        "entry_id": "C1_004"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "带领（动词）",
-        "ipa": "lid",
-        "phonetic": "leed",
-        "entry_id": "C1_005"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "铅（金属）",
-        "ipa": "lɛd",
-        "phonetic": "led",
-        "entry_id": "C1_006"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "风（名词）",
-        "ipa": "wɪnd",
-        "phonetic": "wind",
-        "entry_id": "C1_007"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "缠绕（动词）",
-        "ipa": "waɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C1_008"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音；鲈鱼（鱼）",
-        "ipa": "bæs",
-        "phonetic": "bass",
-        "entry_id": "C1_009"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音（音乐）",
-        "ipa": "beɪs",
-        "phonetic": "base",
-        "entry_id": "C1_010"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "关闭（动词）",
-        "ipa": "kloʊz",
-        "phonetic": "klohz",
-        "entry_id": "C1_011"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "接近的（形容词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohs",
-        "entry_id": "C1_012"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "弓（武器）",
-        "ipa": "boʊ",
-        "phonetic": "boh",
-        "entry_id": "C1_013"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "鞠躬（动词）",
-        "ipa": "baʊ",
-        "phonetic": "bau",
-        "entry_id": "C1_014"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "眼泪（名词）",
-        "ipa": "tɪr",
-        "phonetic": "teer",
-        "entry_id": "C1_015"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "撕裂（动词）",
-        "ipa": "tɛr",
-        "phonetic": "tare",
-        "entry_id": "C1_016"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（现在时）",
-        "ipa": "rid",
-        "phonetic": "reed",
-        "entry_id": "C1_017"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（过去时）",
-        "ipa": "rɛd",
-        "phonetic": "red",
-        "entry_id": "C1_018"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "分钟（名词）",
-        "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it",
-        "entry_id": "C1_019"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "极小的（形容词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT",
-        "entry_id": "C1_020"
-      }
-    ],
-    "wrong_ipa_entries": [],
-    "wrong_phonetic_entries": []
-  },
-  {
-    "case_id": "case_02_two_wrong",
-    "entries": [
-      {
-        "word": "record",
-        "chinese_hint": "记录（动词）",
-        "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD",
-        "entry_id": "C2_001"
-      },
-      {
-        "word": "record",
-        "chinese_hint": "唱片；记录（名词）",
-        "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd",
-        "entry_id": "C2_002"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "赠送；呈现（动词）",
-        "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT",
-        "entry_id": "C2_003"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "礼物；现在（名词/形容词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent",
-        "entry_id": "C2_004"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "带领（动词）",
-        "ipa": "lɛd",
-        "phonetic": "leed",
-        "entry_id": "C2_005"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "铅（金属）",
-        "ipa": "lɛd",
-        "phonetic": "led",
-        "entry_id": "C2_006"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "风（名词）",
-        "ipa": "wɪnd",
-        "phonetic": "wind",
-        "entry_id": "C2_007"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "缠绕（动词）",
-        "ipa": "waɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C2_008"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音；鲈鱼（鱼）",
-        "ipa": "bæs",
-        "phonetic": "bass",
-        "entry_id": "C2_009"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音（音乐）",
-        "ipa": "beɪs",
-        "phonetic": "base",
-        "entry_id": "C2_010"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "关闭（动词）",
-        "ipa": "kloʊz",
-        "phonetic": "klohz",
-        "entry_id": "C2_011"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "接近的（形容词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohz",
-        "entry_id": "C2_012"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "弓（武器）",
-        "ipa": "boʊ",
-        "phonetic": "boh",
-        "entry_id": "C2_013"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "鞠躬（动词）",
-        "ipa": "baʊ",
-        "phonetic": "bau",
-        "entry_id": "C2_014"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "眼泪（名词）",
-        "ipa": "tɪr",
-        "phonetic": "teer",
-        "entry_id": "C2_015"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "撕裂（动词）",
-        "ipa": "tɛr",
-        "phonetic": "tare",
-        "entry_id": "C2_016"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（现在时）",
-        "ipa": "rid",
-        "phonetic": "reed",
-        "entry_id": "C2_017"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（过去时）",
-        "ipa": "rɛd",
-        "phonetic": "red",
-        "entry_id": "C2_018"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "分钟（名词）",
-        "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it",
-        "entry_id": "C2_019"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "极小的（形容词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT",
-        "entry_id": "C2_020"
-      }
-    ],
-    "wrong_ipa_entries": [
-      {
-        "entry_id": "C2_005",
-        "word": "lead",
-        "correct_ipa": ""
-      }
-    ],
-    "wrong_phonetic_entries": [
-      {
-        "entry_id": "C2_012",
-        "word": "close",
-        "correct_phonetic": ""
-      }
-    ]
-  },
-  {
-    "case_id": "case_03_three_wrong",
-    "entries": [
-      {
-        "word": "record",
-        "chinese_hint": "记录（动词）",
-        "ipa": "rɪˈkɔrd",
-        "phonetic": "REK-erd",
-        "entry_id": "C3_001"
-      },
-      {
-        "word": "record",
-        "chinese_hint": "唱片；记录（名词）",
-        "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd",
-        "entry_id": "C3_002"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "赠送；呈现（动词）",
-        "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT",
-        "entry_id": "C3_003"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "礼物；现在（名词/形容词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent",
-        "entry_id": "C3_004"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "带领（动词）",
-        "ipa": "lid",
-        "phonetic": "leed",
-        "entry_id": "C3_005"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "铅（金属）",
-        "ipa": "lɛd",
-        "phonetic": "led",
-        "entry_id": "C3_006"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "风（名词）",
-        "ipa": "wɪnd",
-        "phonetic": "wind",
-        "entry_id": "C3_007"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "缠绕（动词）",
-        "ipa": "wɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C3_008"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音；鲈鱼（鱼）",
-        "ipa": "bæs",
-        "phonetic": "bass",
-        "entry_id": "C3_009"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音（音乐）",
-        "ipa": "beɪs",
-        "phonetic": "base",
-        "entry_id": "C3_010"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "关闭（动词）",
-        "ipa": "kloʊz",
-        "phonetic": "klohz",
-        "entry_id": "C3_011"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "接近的（形容词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohs",
-        "entry_id": "C3_012"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "弓（武器）",
-        "ipa": "boʊ",
-        "phonetic": "boh",
-        "entry_id": "C3_013"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "鞠躬（动词）",
-        "ipa": "baʊ",
-        "phonetic": "boh",
-        "entry_id": "C3_014"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "眼泪（名词）",
-        "ipa": "tɪr",
-        "phonetic": "teer",
-        "entry_id": "C3_015"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "撕裂（动词）",
-        "ipa": "tɛr",
-        "phonetic": "tare",
-        "entry_id": "C3_016"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（现在时）",
-        "ipa": "rid",
-        "phonetic": "reed",
-        "entry_id": "C3_017"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（过去时）",
-        "ipa": "rɛd",
-        "phonetic": "red",
-        "entry_id": "C3_018"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "分钟（名词）",
-        "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it",
-        "entry_id": "C3_019"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "极小的（形容词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT",
-        "entry_id": "C3_020"
-      }
-    ],
-    "wrong_ipa_entries": [
-      {
-        "entry_id": "C3_008",
-        "word": "wind",
-        "correct_ipa": ""
-      }
-    ],
-    "wrong_phonetic_entries": [
-      {
-        "entry_id": "C3_001",
-        "word": "record",
-        "correct_phonetic": ""
-      },
-      {
-        "entry_id": "C3_014",
-        "word": "bow",
-        "correct_phonetic": ""
-      }
-    ]
-  },
-  {
-    "case_id": "case_04_four_wrong",
-    "entries": [
-      {
-        "word": "record",
-        "chinese_hint": "记录（动词）",
-        "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD",
-        "entry_id": "C4_001"
-      },
-      {
-        "word": "record",
-        "chinese_hint": "唱片；记录（名词）",
-        "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd",
-        "entry_id": "C4_002"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "赠送；呈现（动词）",
-        "ipa": "prɪˈzɛnt",
-        "phonetic": "prih-ZENT",
-        "entry_id": "C4_003"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "礼物；现在（名词/形容词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent",
-        "entry_id": "C4_004"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "带领（动词）",
-        "ipa": "lid",
-        "phonetic": "leed",
-        "entry_id": "C4_005"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "铅（金属）",
-        "ipa": "lɛd",
-        "phonetic": "leed",
-        "entry_id": "C4_006"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "风（名词）",
-        "ipa": "wɪnd",
-        "phonetic": "wind",
-        "entry_id": "C4_007"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "缠绕（动词）",
-        "ipa": "waɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C4_008"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音；鲈鱼（鱼）",
-        "ipa": "bæs",
-        "phonetic": "bass",
-        "entry_id": "C4_009"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音（音乐）",
-        "ipa": "bæs",
-        "phonetic": "base",
-        "entry_id": "C4_010"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "关闭（动词）",
-        "ipa": "kloʊz",
-        "phonetic": "klohz",
-        "entry_id": "C4_011"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "接近的（形容词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohs",
-        "entry_id": "C4_012"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "弓（武器）",
-        "ipa": "boʊ",
-        "phonetic": "boh",
-        "entry_id": "C4_013"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "鞠躬（动词）",
-        "ipa": "baʊ",
-        "phonetic": "bau",
-        "entry_id": "C4_014"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "眼泪（名词）",
-        "ipa": "tɪr",
-        "phonetic": "teer",
-        "entry_id": "C4_015"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "撕裂（动词）",
-        "ipa": "tɪr",
-        "phonetic": "tare",
-        "entry_id": "C4_016"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（现在时）",
-        "ipa": "rid",
-        "phonetic": "reed",
-        "entry_id": "C4_017"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（过去时）",
-        "ipa": "rɛd",
-        "phonetic": "red",
-        "entry_id": "C4_018"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "分钟（名词）",
-        "ipa": "ˈmɪnɪt",
-        "phonetic": "MIN-it",
-        "entry_id": "C4_019"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "极小的（形容词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "MIN-it",
-        "entry_id": "C4_020"
-      }
-    ],
-    "wrong_ipa_entries": [
-      {
-        "entry_id": "C4_010",
-        "word": "bass",
-        "correct_ipa": ""
-      },
-      {
-        "entry_id": "C4_016",
-        "word": "tear",
-        "correct_ipa": ""
-      }
-    ],
-    "wrong_phonetic_entries": [
-      {
-        "entry_id": "C4_006",
-        "word": "lead",
-        "correct_phonetic": ""
-      },
-      {
-        "entry_id": "C4_020",
-        "word": "minute",
-        "correct_phonetic": ""
-      }
-    ]
-  },
-  {
-    "case_id": "case_05_five_wrong",
-    "entries": [
-      {
-        "word": "record",
-        "chinese_hint": "记录（动词）",
-        "ipa": "rɪˈkɔrd",
-        "phonetic": "rih-KORD",
-        "entry_id": "C5_001"
-      },
-      {
-        "word": "record",
-        "chinese_hint": "唱片；记录（名词）",
-        "ipa": "ˈrɛkərd",
-        "phonetic": "REK-erd",
-        "entry_id": "C5_002"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "赠送；呈现（动词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "prih-ZENT",
-        "entry_id": "C5_003"
-      },
-      {
-        "word": "present",
-        "chinese_hint": "礼物；现在（名词/形容词）",
-        "ipa": "ˈprɛzənt",
-        "phonetic": "PREZ-ent",
-        "entry_id": "C5_004"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "带领（动词）",
-        "ipa": "lid",
-        "phonetic": "leed",
-        "entry_id": "C5_005"
-      },
-      {
-        "word": "lead",
-        "chinese_hint": "铅（金属）",
-        "ipa": "lɛd",
-        "phonetic": "led",
-        "entry_id": "C5_006"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "风（名词）",
-        "ipa": "wɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C5_007"
-      },
-      {
-        "word": "wind",
-        "chinese_hint": "缠绕（动词）",
-        "ipa": "waɪnd",
-        "phonetic": "wynd",
-        "entry_id": "C5_008"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音；鲈鱼（鱼）",
-        "ipa": "bæs",
-        "phonetic": "bass",
-        "entry_id": "C5_009"
-      },
-      {
-        "word": "bass",
-        "chinese_hint": "低音（音乐）",
-        "ipa": "beɪs",
-        "phonetic": "base",
-        "entry_id": "C5_010"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "关闭（动词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohz",
-        "entry_id": "C5_011"
-      },
-      {
-        "word": "close",
-        "chinese_hint": "接近的（形容词）",
-        "ipa": "kloʊs",
-        "phonetic": "klohs",
-        "entry_id": "C5_012"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "弓（武器）",
-        "ipa": "boʊ",
-        "phonetic": "boh",
-        "entry_id": "C5_013"
-      },
-      {
-        "word": "bow",
-        "chinese_hint": "鞠躬（动词）",
-        "ipa": "baʊ",
-        "phonetic": "bau",
-        "entry_id": "C5_014"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "眼泪（名词）",
-        "ipa": "tɪr",
-        "phonetic": "teer",
-        "entry_id": "C5_015"
-      },
-      {
-        "word": "tear",
-        "chinese_hint": "撕裂（动词）",
-        "ipa": "tɛr",
-        "phonetic": "tare",
-        "entry_id": "C5_016"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（现在时）",
-        "ipa": "rid",
-        "phonetic": "red",
-        "entry_id": "C5_017"
-      },
-      {
-        "word": "read",
-        "chinese_hint": "阅读（过去时）",
-        "ipa": "rɛd",
-        "phonetic": "red",
-        "entry_id": "C5_018"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "分钟（名词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "MIN-it",
-        "entry_id": "C5_019"
-      },
-      {
-        "word": "minute",
-        "chinese_hint": "极小的（形容词）",
-        "ipa": "maɪˈn(j)ut",
-        "phonetic": "my-NYOOT",
-        "entry_id": "C5_020"
-      }
-    ],
-    "wrong_ipa_entries": [
-      {
-        "entry_id": "C5_003",
-        "word": "present",
-        "correct_ipa": ""
-      },
-      {
-        "entry_id": "C5_011",
-        "word": "close",
-        "correct_ipa": ""
-      },
-      {
-        "entry_id": "C5_019",
-        "word": "minute",
-        "correct_ipa": ""
-      }
-    ],
-    "wrong_phonetic_entries": [
-      {
-        "entry_id": "C5_007",
-        "word": "wind",
-        "correct_phonetic": ""
-      },
-      {
-        "entry_id": "C5_017",
-        "word": "read",
-        "correct_phonetic": ""
-      }
-    ]
-  }
-]
+{
+  "entries": [
+    {
+      "word": "apple",
+      "chinese_hint": "苹果（名词）",
+      "ipa": "ˈæpəl",
+      "phonetic": "AP-uhl",
+      "entry_id": "E001"
+    },
+    {
+      "word": "mountain",
+      "chinese_hint": "山（名词）",
+      "ipa": "ˈmaʊntən",
+      "phonetic": "MOWN-tuhn",
+      "entry_id": "E002"
+    },
+    {
+      "word": "river",
+      "chinese_hint": "河流（名词）",
+      "ipa": "ˈrɪvər",
+      "phonetic": "RIV-er",
+      "entry_id": "E003"
+    },
+    {
+      "word": "lantern",
+      "chinese_hint": "灯笼（名词）",
+      "ipa": "ˈlæntərn",
+      "phonetic": "LAN-tern",
+      "entry_id": "E004"
+    },
+    {
+      "word": "pencil",
+      "chinese_hint": "铅笔（名词）",
+      "ipa": "ˈpɛnsəl",
+      "phonetic": "PEN-suhl",
+      "entry_id": "E005"
+    },
+    {
+      "word": "kitchen",
+      "chinese_hint": "厨房（名词）",
+      "ipa": "ˈkɪtʃən",
+      "phonetic": "KITCH-uhn",
+      "entry_id": "E006"
+    },
+    {
+      "word": "window",
+      "chinese_hint": "窗户（名词）",
+      "ipa": "ˈwɪndoʊ",
+      "phonetic": "WIN-doh",
+      "entry_id": "E007"
+    },
+    {
+      "word": "garden",
+      "chinese_hint": "花园（名词）",
+      "ipa": "ˈɡɑrdən",
+      "phonetic": "GAR-den",
+      "entry_id": "E008"
+    },
+    {
+      "word": "bicycle",
+      "chinese_hint": "自行车（名词）",
+      "ipa": "ˈbaɪsɪkəl",
+      "phonetic": "BYE-si-kuhl",
+      "entry_id": "E009"
+    },
+    {
+      "word": "planet",
+      "chinese_hint": "行星（名词）",
+      "ipa": "ˈplænɪt",
+      "phonetic": "PLAN-it",
+      "entry_id": "E010"
+    },
+    {
+      "word": "silver",
+      "chinese_hint": "银（名词）",
+      "ipa": "ˈsɪlvər",
+      "phonetic": "SIL-ver",
+      "entry_id": "E011"
+    },
+    {
+      "word": "tiger",
+      "chinese_hint": "老虎（名词）",
+      "ipa": "ˈtaɪɡər",
+      "phonetic": "TYE-ger",
+      "entry_id": "E012"
+    },
+    {
+      "word": "blanket",
+      "chinese_hint": "毯子（名词）",
+      "ipa": "ˈblæŋkɪt",
+      "phonetic": "BLANG-kit",
+      "entry_id": "E013"
+    },
+    {
+      "word": "candle",
+      "chinese_hint": "蜡烛（名词）",
+      "ipa": "ˈkændəl",
+      "phonetic": "KAN-duhl",
+      "entry_id": "E014"
+    },
+    {
+      "word": "pocket",
+      "chinese_hint": "口袋（名词）",
+      "ipa": "ˈpɑkɪt",
+      "phonetic": "POCK-it",
+      "entry_id": "E015"
+    },
+    {
+      "word": "thunder",
+      "chinese_hint": "雷（名词）",
+      "ipa": "ˈθʌndər",
+      "phonetic": "THUN-der",
+      "entry_id": "E016"
+    },
+    {
+      "word": "mirror",
+      "chinese_hint": "镜子（名词）",
+      "ipa": "ˈmɪrər",
+      "phonetic": "MEER-er",
+      "entry_id": "E017"
+    },
+    {
+      "word": "castle",
+      "chinese_hint": "城堡（名词）",
+      "ipa": "ˈkæsəl",
+      "phonetic": "KAS-uhl",
+      "entry_id": "E018"
+    },
+    {
+      "word": "coffee",
+      "chinese_hint": "咖啡（名词）",
+      "ipa": "ˈkɔfi",
+      "phonetic": "KAW-fee",
+      "entry_id": "E019"
+    },
+    {
+      "word": "violin",
+      "chinese_hint": "小提琴（名词）",
+      "ipa": "ˌvaɪəˈlɪn",
+      "phonetic": "vy-uh-LIN",
+      "entry_id": "E020"
+    }
+  ]
+}

--- a/src/benchmarks/0141_validate_pronunciation_bulk/wrong_entries.json
+++ b/src/benchmarks/0141_validate_pronunciation_bulk/wrong_entries.json
@@ -1,0 +1,91 @@
+[
+  {
+    "case_id": "case_01_perfect",
+    "wrong_ipa_entries": [],
+    "wrong_phonetic_entries": []
+  },
+  {
+    "case_id": "case_02_two_wrong",
+    "wrong_ipa_entries": [
+      {
+        "entry_id": "E005",
+        "wrong_ipa": "pɛnˈsɪl"
+      }
+    ],
+    "wrong_phonetic_entries": [
+      {
+        "entry_id": "E012",
+        "wrong_phonetic": "TEE-ger"
+      }
+    ]
+  },
+  {
+    "case_id": "case_03_three_wrong",
+    "wrong_ipa_entries": [
+      {
+        "entry_id": "E008",
+        "wrong_ipa": "ˈɡɑrdeɪn"
+      }
+    ],
+    "wrong_phonetic_entries": [
+      {
+        "entry_id": "E001",
+        "wrong_phonetic": "uh-PULL"
+      },
+      {
+        "entry_id": "E014",
+        "wrong_phonetic": "CANE-duhl"
+      }
+    ]
+  },
+  {
+    "case_id": "case_04_four_wrong",
+    "wrong_ipa_entries": [
+      {
+        "entry_id": "E010",
+        "wrong_ipa": "pləˈnɛt"
+      },
+      {
+        "entry_id": "E016",
+        "wrong_ipa": "ˈθuːndər"
+      }
+    ],
+    "wrong_phonetic_entries": [
+      {
+        "entry_id": "E006",
+        "wrong_phonetic": "kee-CHEN"
+      },
+      {
+        "entry_id": "E020",
+        "wrong_phonetic": "VEE-oh-lin"
+      }
+    ]
+  },
+  {
+    "case_id": "case_05_five_wrong",
+    "wrong_ipa_entries": [
+      {
+        "entry_id": "E003",
+        "wrong_ipa": "raɪvər"
+      },
+      {
+        "entry_id": "E011",
+        "wrong_ipa": "ˈsaɪlvər"
+      },
+      {
+        "entry_id": "E019",
+        "wrong_ipa": "koʊˈfi"
+      }
+    ],
+    "wrong_phonetic_entries": [
+      {
+        "entry_id": "E007",
+        "wrong_phonetic": "wine-doh"
+      },
+      {
+        "entry_id": "E017",
+        "wrong_phonetic": "my-ROAR"
+      }
+    ]
+  }
+]

--- a/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
+++ b/src/benchmarks/lib/generators/validate_pronunciation_bulk_generator.py
@@ -2,7 +2,7 @@
 
 """Generator for Bebras bulk IPA/phonetic verification benchmark."""
 
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator, List, TypeAlias
 
 from benchmarks.lib.utils.base_generator import BenchmarkGenerator
 from benchmarks.lib.utils.data_models import (
@@ -14,6 +14,12 @@ from benchmarks.lib.utils.data_models import (
 )
 
 BENCHMARK_CODE = "0141_validate_pronunciation_bulk"
+EntryDict: TypeAlias = Dict[str, Any]
+EntryList: TypeAlias = List[EntryDict]
+EntryIdMap: TypeAlias = Dict[str, str]
+EntryByIdMap: TypeAlias = Dict[str, EntryDict]
+ShortEntriesBundle: TypeAlias = tuple[EntryList, EntryIdMap, EntryByIdMap]
+WrongEntryResult: TypeAlias = List[Dict[str, str]]
 
 
 class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
@@ -26,75 +32,126 @@ class ValidatePronunciationBulkGenerator(BenchmarkGenerator):
         self.can_generate_with_llm = False
         self.questions_file_path = "samples.json"
 
+    def _load_base_entries(self) -> EntryList:
+        """Load canonical correct pronunciation entries used for all cases."""
+        samples_data = self.load_json_file("samples.json")
+        if isinstance(samples_data, dict):
+            entries = samples_data.get("entries", [])
+            if isinstance(entries, list):
+                return [entry for entry in entries if isinstance(entry, dict)]
+            return []
+        if isinstance(samples_data, list):
+            if all(isinstance(entry, dict) and "word" in entry for entry in samples_data):
+                return [entry for entry in samples_data if isinstance(entry, dict)]
+            if samples_data and isinstance(samples_data[0], dict):
+                legacy_entries = samples_data[0].get("entries", [])
+                if isinstance(legacy_entries, list):
+                    return [entry for entry in legacy_entries if isinstance(entry, dict)]
+        return []
+
+    def _build_short_entries(self, sample_index: int, entries: EntryList) -> ShortEntriesBundle:
+        """Build short-id input entries and source-id maps for a generated case."""
+        short_entries: EntryList = []
+        original_to_short_id_map: EntryIdMap = {}
+        source_entries_by_original_id: EntryByIdMap = {}
+
+        for entry_index, entry in enumerate(entries, start=1):
+            original_entry_id = str(entry.get("entry_id", f"item_{entry_index:02d}"))
+            short_entry_id = f"C{sample_index}_{entry_index:03d}"
+            original_to_short_id_map[original_entry_id] = short_entry_id
+
+            short_entry: EntryDict = dict(entry)
+            short_entry["entry_id"] = short_entry_id
+            short_entries.append(short_entry)
+            source_entries_by_original_id[original_entry_id] = entry
+
+        return short_entries, original_to_short_id_map, source_entries_by_original_id
+
+    def _normalize_wrong_entries(
+        self,
+        wrong_entries: Any,
+        field_name: str,
+        replacement_key: str,
+        correct_key: str,
+        short_entries_by_id: EntryByIdMap,
+        original_to_short_id_map: EntryIdMap,
+        source_entries_by_original_id: EntryByIdMap,
+    ) -> WrongEntryResult:
+        """Apply wrong values to short entries and build expected answer payload."""
+        normalized_entries: WrongEntryResult = []
+        if not isinstance(wrong_entries, list):
+            return normalized_entries
+
+        for wrong_entry in wrong_entries:
+            if not isinstance(wrong_entry, dict):
+                continue
+
+            original_entry_id = str(wrong_entry.get("entry_id", ""))
+            short_entry_id = original_to_short_id_map.get(original_entry_id, original_entry_id)
+            source_entry = source_entries_by_original_id.get(original_entry_id, {})
+            short_entry = short_entries_by_id.get(short_entry_id)
+            if short_entry is None:
+                continue
+
+            short_entry[field_name] = str(wrong_entry.get(replacement_key, ""))
+
+            normalized_entries.append(
+                {
+                    "entry_id": short_entry_id,
+                    "word": str(wrong_entry.get("word") or source_entry.get("word") or ""),
+                    correct_key: str(
+                        wrong_entry.get(correct_key) or source_entry.get(field_name) or ""
+                    ),
+                }
+            )
+
+        return normalized_entries
+
     def _generate_from_file(self, **kwargs: Any) -> Iterator[BenchmarkQuestion]:
-        samples: List[Dict[str, Any]] = self.load_json_file("samples.json")
+        base_entries = self._load_base_entries()
+        wrong_entries_by_case_id: Dict[str, EntryDict] = {
+            str(case.get("case_id", "")): case
+            for case in self.load_json_file("wrong_entries.json")
+            if isinstance(case, dict)
+        }
 
-        for sample_index, sample in enumerate(samples, start=1):
-            case_id = sample["case_id"]
-            entries = sample["entries"]
-            wrong_ipa_entries = sample.get("wrong_ipa_entries", [])
-            wrong_phonetic_entries = sample.get("wrong_phonetic_entries", [])
-            legacy_wrong_entries = sample.get("wrong_entries", [])
-
-            short_entries: List[Dict[str, Any]] = []
-            id_map: Dict[str, str] = {}
-            for entry_index, entry in enumerate(entries, start=1):
-                original_entry_id = str(entry.get("entry_id", f"item_{entry_index:02d}"))
-                short_entry_id = f"C{sample_index}_{entry_index:03d}"
-                id_map[original_entry_id] = short_entry_id
-
-                short_entry = dict(entry)
-                short_entry["entry_id"] = short_entry_id
-                short_entries.append(short_entry)
-
-            if legacy_wrong_entries and not (wrong_ipa_entries or wrong_phonetic_entries):
-                wrong_ipa_entries = []
-                wrong_phonetic_entries = []
-                for wrong_entry in legacy_wrong_entries:
-                    if not isinstance(wrong_entry, dict):
-                        continue
-                    original_entry_id = str(wrong_entry.get("entry_id", ""))
-                    short_entry_id = id_map.get(original_entry_id, original_entry_id)
-                    issue_type = str(wrong_entry.get("issue_type", "")).strip().lower()
-
-                    normalized_ipa_entry = {
-                        "entry_id": short_entry_id,
-                        "word": wrong_entry.get("word", ""),
-                        "correct_ipa": str(wrong_entry.get("correct_ipa", "")),
-                    }
-                    normalized_phonetic_entry = {
-                        "entry_id": short_entry_id,
-                        "word": wrong_entry.get("word", ""),
-                        "correct_phonetic": str(wrong_entry.get("correct_phonetic", "")),
-                    }
-
-                    if issue_type in {"ipa", "both"}:
-                        wrong_ipa_entries.append(normalized_ipa_entry)
-                    if issue_type in {"phonetic", "both"}:
-                        wrong_phonetic_entries.append(normalized_phonetic_entry)
-
-            normalized_wrong_ipa_entries = [
+        for sample_index, case_id in enumerate(wrong_entries_by_case_id, start=1):
+            wrong_case_data = wrong_entries_by_case_id.get(
+                str(case_id),
                 {
-                    "entry_id": id_map.get(
-                        str(entry.get("entry_id", "")), str(entry.get("entry_id", ""))
-                    ),
-                    "word": entry.get("word", ""),
-                    "correct_ipa": str(entry.get("correct_ipa", "")),
-                }
-                for entry in wrong_ipa_entries
+                    "wrong_ipa_entries": [],
+                    "wrong_phonetic_entries": [],
+                },
+            )
+            wrong_ipa_entries = wrong_case_data.get("wrong_ipa_entries", [])
+            wrong_phonetic_entries = wrong_case_data.get("wrong_phonetic_entries", [])
+
+            short_entries, original_to_short_id_map, source_entries_by_original_id = (
+                self._build_short_entries(sample_index=sample_index, entries=base_entries)
+            )
+            short_entries_by_id = {
+                str(entry.get("entry_id", "")): entry
+                for entry in short_entries
                 if isinstance(entry, dict)
-            ]
-            normalized_wrong_phonetic_entries = [
-                {
-                    "entry_id": id_map.get(
-                        str(entry.get("entry_id", "")), str(entry.get("entry_id", ""))
-                    ),
-                    "word": entry.get("word", ""),
-                    "correct_phonetic": str(entry.get("correct_phonetic", "")),
-                }
-                for entry in wrong_phonetic_entries
-                if isinstance(entry, dict)
-            ]
+            }
+            normalized_wrong_ipa_entries = self._normalize_wrong_entries(
+                wrong_entries=wrong_ipa_entries,
+                field_name="ipa",
+                replacement_key="wrong_ipa",
+                correct_key="correct_ipa",
+                short_entries_by_id=short_entries_by_id,
+                original_to_short_id_map=original_to_short_id_map,
+                source_entries_by_original_id=source_entries_by_original_id,
+            )
+            normalized_wrong_phonetic_entries = self._normalize_wrong_entries(
+                wrong_entries=wrong_phonetic_entries,
+                field_name="phonetic",
+                replacement_key="wrong_phonetic",
+                correct_key="correct_phonetic",
+                short_entries_by_id=short_entries_by_id,
+                original_to_short_id_map=original_to_short_id_map,
+                source_entries_by_original_id=source_entries_by_original_id,
+            )
 
             wrong_word_count = len(
                 {


### PR DESCRIPTION
### Motivation
- Simplify and normalize the sample data format by moving canonical correct entries to a single `samples.json` and separating case-specific incorrect values into a new `wrong_entries.json` file.
- Make the generator more robust to legacy formats and mapping of original IDs to short case IDs for generated questions.
- Improve code clarity and maintainability by extracting helper methods and introducing type aliases.

### Description
- Replaced the previous multi-case `samples.json` layout with a canonical entries file containing a single `entries` list and added a new `wrong_entries.json` that enumerates per-case wrong IPA/phonetic values.
- Heavily refactored `ValidatePronunciationBulkGenerator` by adding type aliases and new helper methods: `_load_base_entries`, `_build_short_entries`, and `_normalize_wrong_entries` to load entries, build short IDs, and apply/normalize wrong values respectively.
- Updated `_generate_from_file` to load `samples.json` and `wrong_entries.json`, build short-entry bundles for each case, inject wrong values into short entries, compute difficulty, and emit `BenchmarkQuestion` objects with `inputs` and `expected` payloads.
- Maintained compatibility with legacy input shapes by detecting and handling older list-of-cases formats when loading base entries.

### Testing
- Performed a focused smoke test by instantiating `ValidatePronunciationBulkGenerator` and iterating `._generate_from_file()` to validate that questions are yielded and the `inputs`/`expected` JSON structure is correct, which succeeded.
- Ran the project's automated test suite with `pytest` to ensure no regressions in the benchmarks library, and the test suite completed successfully.
- Verified that the new `wrong_entries.json` cases map correctly to short entry IDs and that difficulty levels are assigned as expected during generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4c411be48327ad57c1d7423e0bae)