### PR TITLE
Fix sentence rapid review cursor ordering across level buckets

### DIFF
--- a/src/barsukas/routes/sentence_rapid_review.py
+++ b/src/barsukas/routes/sentence_rapid_review.py
@@ -17,7 +17,7 @@ from flask import (
     request,
 )
 from flask.typing import ResponseReturnValue
-from sqlalchemy import case
+from sqlalchemy import and_, case, or_
 from sqlalchemy.orm import Query
 
 from langtools.zh.pinyin_helper import generate_pinyin
@@ -240,14 +240,28 @@ def index() -> ResponseReturnValue:
 
 
 def get_next_sentence(
-    current_id: int,
+    current_sentence: Sentence,
     status_filter: str,
     level_filter: str,
     pattern_filter: str,
 ) -> Optional[Dict[str, Any]]:
-    """Get the next sentence after current_id matching filters."""
+    """Get the next sentence in review sort order matching filters."""
     query = build_sentence_query(status_filter, level_filter, pattern_filter)
-    query = query.filter(Sentence.id > current_id)
+
+    current_level_order = (
+        current_sentence.minimum_level if current_sentence.minimum_level is not None else 99
+    )
+    sentence_level_order = case(
+        (Sentence.minimum_level.is_(None), 99), else_=Sentence.minimum_level
+    )
+
+    # Match index ordering: (minimum_level with NULL as 99, id)
+    query = query.filter(
+        or_(
+            sentence_level_order > current_level_order,
+            and_(sentence_level_order == current_level_order, Sentence.id > current_sentence.id),
+        )
+    )
 
     sentences_with_translations = find_sentences_with_translations(query, limit=1)
 
@@ -294,7 +308,7 @@ def verify(sentence_id: int) -> ResponseReturnValue:
         g.db.commit()
 
         # Get next sentence
-        next_sentence = get_next_sentence(sentence_id, status_filter, level_filter, pattern_filter)
+        next_sentence = get_next_sentence(sentence, status_filter, level_filter, pattern_filter)
 
         if next_sentence:
             return jsonify(
@@ -333,7 +347,7 @@ def reject(sentence_id: int) -> ResponseReturnValue:
         g.db.commit()
 
         # Get next sentence
-        next_sentence = get_next_sentence(sentence_id, status_filter, level_filter, pattern_filter)
+        next_sentence = get_next_sentence(sentence, status_filter, level_filter, pattern_filter)
 
         if next_sentence:
             return jsonify(
@@ -368,7 +382,7 @@ def skip(sentence_id: int) -> ResponseReturnValue:
 
     try:
         # Get next sentence
-        next_sentence = get_next_sentence(sentence_id, status_filter, level_filter, pattern_filter)
+        next_sentence = get_next_sentence(sentence, status_filter, level_filter, pattern_filter)
 
         if next_sentence:
             return jsonify(


### PR DESCRIPTION
### Motivation
- The rapid sentence review sequence was terminating early because the next-item cursor only compared `id > current_id` while the index view is ordered by `(minimum_level, id)` with NULL `minimum_level` treated as a high value. 
- The intent is to advance through the same ordering used by the index so reviewers traverse all level buckets instead of stopping after the current ID range.

### Description
- Updated `get_next_sentence` in `src/barsukas/routes/sentence_rapid_review.py` to accept the current `Sentence` object and compute the current sort key rather than accepting just an `id` value. 
- Added computation of `current_level_order` and `sentence_level_order` (treating NULL `minimum_level` as `99`) and applied a compound filter using `or_`/`and_` to match the index ordering `(minimum_level, id)`. 
- Replaced calls in the `verify`, `reject`, and `skip` flows to pass the `Sentence` object into `get_next_sentence`, and added the required imports `and_` and `or_` from `sqlalchemy`.

### Testing
- Ran `black src/barsukas/routes/sentence_rapid_review.py` which reformatted the file successfully. 
- Ran `PYTHONPATH=src mypy src/barsukas/routes/sentence_rapid_review.py` which completed with no type issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd544ce3e48327a6320f7e58552a96)