### PR TITLE
Remove Python POS fallback dicts; rely on en.json strings fallback

### DIFF
--- a/src/barsukas/routes/peleda.py
+++ b/src/barsukas/routes/peleda.py
@@ -85,31 +85,6 @@ _POS_SUBTYPE_GROUPS: Dict[str, Dict[str, List[str]]] = {
     "numeral": {"Numerals": ["cardinal", "ordinal"]},
 }
 
-# Fallback display names for the POS type headers in the category dropdown.
-_POS_DISPLAY_NAMES: Dict[str, str] = {
-    "noun": "Nouns",
-    "verb": "Verbs",
-    "adjective": "Adjectives",
-    "adverb": "Adverbs",
-    "numeral": "Numerals",
-}
-
-# Fallback display names for row-level POS values in the dictionary table.
-_POS_SINGULAR_DISPLAY_NAMES: Dict[str, str] = {
-    "noun": "Noun",
-    "verb": "Verb",
-    "adjective": "Adjective",
-    "adverb": "Adverb",
-    "numeral": "Numeral",
-    "pronoun": "Pronoun",
-    "preposition": "Preposition",
-    "conjunction": "Conjunction",
-    "interjection": "Interjection",
-    "determiner": "Determiner",
-    "article": "Article",
-    "particle": "Particle",
-}
-
 
 def _get_display_langs(source_lang: str) -> List[str]:
     """Return the 3 translation columns to show for a given source language."""
@@ -479,6 +454,4 @@ def dictionary() -> ResponseReturnValue:
         available_letters=available_letters,
         available_languages=available_languages,
         language_names=language_names,
-        pos_singular_fallbacks=_POS_SINGULAR_DISPLAY_NAMES,
-        pos_group_fallbacks=_POS_DISPLAY_NAMES,
     )

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -40,7 +40,7 @@
             <label for="category" class="form-label mb-0 small text-muted">{{ STRINGS.dictionary.category }}</label>
             <select class="form-select form-select-sm dict-category-select" id="category" name="category" onchange="this.form.submit()">
                 {% for group in category_options %}
-                    <optgroup label="{{ STRINGS.parts_of_speech.get(group.pos_type ~ '_plural', pos_group_fallbacks.get(group.pos_type, group.pos_type|title)) }}">
+                    <optgroup label="{{ STRINGS.parts_of_speech.get(group.pos_type ~ '_plural', group.pos_type|title) }}">
                         {% for item in group["items"] %}
                             <option value="{{ item.value }}" {% if item.value == selected_category %}selected{% endif %}>{{ item.display_name }}</option>
                         {% endfor %}
@@ -122,7 +122,7 @@
                             {% endif %}
                         </td>
                     {% endfor %}
-                    <td class="dict-pos">{{ STRINGS.parts_of_speech.get(entry.pos_type, pos_singular_fallbacks.get(entry.pos_type, (entry.pos_type or '')|replace('_', ' ')|title)) }}</td>
+                    <td class="dict-pos">{{ STRINGS.parts_of_speech.get(entry.pos_type, (entry.pos_type or '')|replace('_', ' ')|title) }}</td>
                 </tr>
             {% endfor %}
             {% if not entries %}


### PR DESCRIPTION
The parts_of_speech en.json already serves as the English fallback via _load_namespace_file, so the duplicate _POS_DISPLAY_NAMES and _POS_SINGULAR_DISPLAY_NAMES dicts in peleda.py are unnecessary.