### PR TITLE
Localize /lemmas list headwords, definitions, and POS labels

### DIFF
--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -27,7 +27,7 @@ from storage.crud.derivative_form import delete_derivative_form
 from storage.crud.difficulty_override import get_all_overrides_for_lemma
 from storage.crud.lemma import handle_lemma_type_subtype_change
 from storage.crud.operation_log import log_translation_change
-from storage.models.schema import DerivativeForm, Lemma
+from storage.models.schema import DerivativeForm, Lemma, LemmaTranslation
 from storage.queries.lemma import build_lemma_search_query
 from storage.translation_helpers import (
     TIER_3_LANGUAGES,
@@ -197,6 +197,11 @@ def list_lemmas() -> ResponseReturnValue:
     pos_type = request.args.get("pos_type", "").strip()
     pos_subtype = request.args.get("pos_subtype", "").strip()
     difficulty = request.args.get("difficulty", "", type=str).strip()
+    supported_languages = get_supported_languages()
+    requested_display_lang = getattr(g, "ui_lang", "en")
+    display_language_code = (
+        requested_display_lang if requested_display_lang in supported_languages else "en"
+    )
 
     # Build filtered and ordered query
     query = build_lemma_search_query(
@@ -205,11 +210,61 @@ def list_lemmas() -> ResponseReturnValue:
         pos_type=pos_type or None,
         pos_subtype=pos_subtype or None,
         difficulty=difficulty or None,
+        display_language_code=display_language_code,
     )
 
     # Paginate
     total = query.count()
     lemmas = query.limit(Config.ITEMS_PER_PAGE).offset((page - 1) * Config.ITEMS_PER_PAGE).all()
+
+    lemma_ids = [lemma.id for lemma in lemmas]
+    translation_languages = {"en", display_language_code}
+    translations_by_lemma: dict[int, dict[str, LemmaTranslation]] = {}
+    if lemma_ids:
+        translation_rows = (
+            g.db.query(LemmaTranslation)
+            .filter(
+                LemmaTranslation.lemma_id.in_(lemma_ids),
+                LemmaTranslation.language_code.in_(list(translation_languages)),
+            )
+            .all()
+        )
+        for translation_row in translation_rows:
+            if translation_row.lemma_id not in translations_by_lemma:
+                translations_by_lemma[translation_row.lemma_id] = {}
+            translations_by_lemma[translation_row.lemma_id][
+                translation_row.language_code
+            ] = translation_row
+
+    lemma_cards: list[dict[str, Any]] = []
+    for lemma in lemmas:
+        lemma_translations = translations_by_lemma.get(lemma.id, {})
+        display_translation = lemma_translations.get(display_language_code)
+        display_lemma_text = (
+            display_translation.translation
+            if display_language_code != "en"
+            and display_translation
+            and display_translation.translation
+            else lemma.lemma_text
+        )
+        if display_language_code == "en":
+            display_definition = lemma.definition_text
+        elif display_translation and display_translation.definition_text:
+            display_definition = display_translation.definition_text
+        else:
+            display_definition = f"{lemma.lemma_text}: {lemma.definition_text}"
+
+        lemma_cards.append(
+            {
+                "id": lemma.id,
+                "display_lemma_text": display_lemma_text,
+                "display_definition": display_definition,
+                "pos_type": lemma.pos_type,
+                "pos_subtype": lemma.pos_subtype,
+                "difficulty_level": lemma.difficulty_level,
+                "verified": lemma.verified,
+            }
+        )
 
     # Get filter options in optimized queries (replaces 2 separate DISTINCT queries)
     from barsukas.helpers.db_optimization import get_lemma_list_filter_options
@@ -223,7 +278,7 @@ def list_lemmas() -> ResponseReturnValue:
 
     return render_template(
         "lemmas/list.html",
-        lemmas=lemmas,
+        lemmas=lemma_cards,
         page=page,
         total_pages=total_pages,
         total=total,
@@ -233,6 +288,7 @@ def list_lemmas() -> ResponseReturnValue:
         difficulty=difficulty,
         pos_types=pos_types,
         pos_subtypes=pos_subtypes,
+        display_language_code=display_language_code,
     )
 
 

--- a/src/barsukas/templates/lemmas/list.html
+++ b/src/barsukas/templates/lemmas/list.html
@@ -36,7 +36,7 @@
                     <option value="">{{ STRINGS.common.all }}</option>
                     {% for pt in pos_types %}
                         <option value="{{ pt }}" {% if pt == pos_type %}selected{% endif %}>
-                            {{ pt }}
+                            {{ STRINGS.parts_of_speech.get(pt, pt|replace('_', ' ')|title) }}
                         </option>
                     {% endfor %}
                 </select>
@@ -91,17 +91,17 @@
                                 <h5 class="card-title">
                                     <a href="{{ url_for('lemmas.view_lemma', lemma_id=lemma.id) }}"
                                        class="text-decoration-none">
-                                        {{ lemma.lemma_text }}
+                                        {{ lemma.display_lemma_text }}
                                     </a>
                                     {% if lemma.verified %}
                                         <i class="bi bi-check-circle-fill text-success" title="Verified"></i>
                                     {% endif %}
                                 </h5>
                                 <p class="card-text lemma-definition">
-                                    {{ lemma.definition_text[:150] }}{% if lemma.definition_text|length > 150 %}...{% endif %}
+                                    {{ lemma.display_definition[:150] }}{% if lemma.display_definition|length > 150 %}...{% endif %}
                                 </p>
                                 <div class="text-muted-small">
-                                    <span class="badge bg-secondary pos-badge me-2">{{ lemma.pos_type }}</span>
+                                    <span class="badge bg-secondary pos-badge me-2">{{ STRINGS.parts_of_speech.get(lemma.pos_type, (lemma.pos_type or '')|replace('_', ' ')|title) }}</span>
                                     {% if lemma.pos_subtype %}
                                         <a href="{{ url_for('lemmas.list_lemmas', pos_subtype=lemma.pos_subtype) }}" class="text-decoration-none">
                                             <span class="badge bg-light text-dark me-2">{{ lemma.pos_subtype }}</span>

--- a/src/storage/queries/lemma.py
+++ b/src/storage/queries/lemma.py
@@ -87,6 +87,7 @@ def build_lemma_search_query(
     pos_type: Optional[str] = None,
     pos_subtype: Optional[str] = None,
     difficulty: Optional[str] = None,
+    display_language_code: str = "en",
 ) -> Query[Lemma]:
     """
     Build a filtered and ordered lemma query for search/listing.
@@ -103,6 +104,16 @@ def build_lemma_search_query(
     """
     # Build base query
     query = session.query(Lemma)
+
+    # Join display language translation for sorting/relevance in non-English views
+    display_translation_joined = False
+    if display_language_code != "en":
+        query = query.outerjoin(
+            LemmaTranslation,
+            (LemmaTranslation.lemma_id == Lemma.id)
+            & (LemmaTranslation.language_code == display_language_code),
+        )
+        display_translation_joined = True
 
     # Apply search filter
     if search:
@@ -168,7 +179,15 @@ def build_lemma_search_query(
             (func.lower(Lemma.vietnamese_translation).contains(search_lower), 6),
             else_=7,
         )
-        query = query.order_by(relevance, func.lower(Lemma.lemma_text))
+        if display_translation_joined:
+            display_text_order = func.lower(
+                func.coalesce(
+                    LemmaTranslation.sort_key, LemmaTranslation.translation, Lemma.lemma_text
+                )
+            )
+            query = query.order_by(relevance, display_text_order)
+        else:
+            query = query.order_by(relevance, func.lower(Lemma.lemma_text))
     else:
         # No search: order by difficulty level first, then case-insensitive alphabetically
         # Put NULL levels at the end, then -1 (not applicable), then levels 1-9
@@ -177,6 +196,14 @@ def build_lemma_search_query(
             (Lemma.difficulty_level == -1, 98),  # -1 (not applicable) second to last
             else_=Lemma.difficulty_level,
         )
-        query = query.order_by(level_order, func.lower(Lemma.lemma_text))
+        if display_translation_joined:
+            display_text_order = func.lower(
+                func.coalesce(
+                    LemmaTranslation.sort_key, LemmaTranslation.translation, Lemma.lemma_text
+                )
+            )
+            query = query.order_by(level_order, display_text_order)
+        else:
+            query = query.order_by(level_order, func.lower(Lemma.lemma_text))
 
     return query


### PR DESCRIPTION
### Motivation
- Make the lemmas list show headwords and definitions in the currently selected UI/display language when translations are available, and fall back to English otherwise.
- Improve sorting so the list orders by the display-language translation/sort key (when present) while preserving current relevance and difficulty ordering semantics.
- Show part-of-speech labels in the UI language rather than raw POS keys.

### Description
- Add a `display_language_code` parameter to `build_lemma_search_query` and outer-join `LemmaTranslation` for the requested display language so ordering can use `sort_key`/`translation` before falling back to `lemma_text` (file: `src/storage/queries/lemma.py`).
- Use `g.ui_lang` (validated via `get_supported_languages()`) in the `/lemmas/` route to pick the display language, fetch `LemmaTranslation` rows for the page, and build per-card `display_lemma_text` and `display_definition` with the fallback format `"{english_lemma}: {english_definition}"` when a display-language definition is not available (file: `src/barsukas/routes/lemmas.py`).
- Render the template using the new card fields and localize POS type labels via `STRINGS.parts_of_speech` in `src/barsukas/templates/lemmas/list.html`.
- Keep existing subcategory behavior unchanged and include the resolved `display_language_code` in the template context.

### Testing
- Formatted changes with `black` via `black src/barsukas/routes/lemmas.py src/storage/queries/lemma.py` and the formatter ran successfully.
- Type-checked the modified files with `mypy src/barsukas/routes/lemmas.py src/storage/queries/lemma.py` and there were no errors.
- No automated unit tests were added or run for UI rendering; please verify the UI in a local browser for non-English `UI` language scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7aafa5848327b60e91dcf3c80169)