### PR TITLE
Fix trailing space in sentence pattern lemma link text

### DIFF
--- a/src/barsukas/templates/sentences/view.html
+++ b/src/barsukas/templates/sentences/view.html
@@ -188,9 +188,7 @@
                                 <td>{{ word.english_text }}</td>
                                 <td>
                                     {% if word.lemma %}
-                                        <a href="{{ url_for('lemmas.view_lemma', lemma_id=word.lemma_id) }}">
-                                            {{ word.lemma_display_text }}
-                                        </a>
+                                        <a href="{{ url_for('lemmas.view_lemma', lemma_id=word.lemma_id) }}">{{ word.lemma_display_text }}</a>
                                         {% if word.lemma.guid %}
                                             <small class="text-muted">({{ word.lemma.guid }})</small>
                                         {% endif %}


### PR DESCRIPTION
### Motivation
- The sentence pattern table on `/sentences/<id>` displayed an extra underlined/visible space before the lemma GUID because the anchor text in the template was split across multiple lines, which introduced unintended whitespace.

### Description
- Render the lemma anchor inline by collapsing the multi-line `<a>` into a single-line anchor in `src/barsukas/templates/sentences/view.html`, removing the stray space before the GUID.

### Testing
- No automated tests were run for this template-only change; visual verification in the Barsukas UI on `/sentences/<id>` is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7af162ac832782f9eb9cfab7e129)