### PR TITLE
Add LSTR/SSTR string accessors, default module routing, and migrate templates to explicit common keys

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -16,7 +16,12 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, cast
 
 from barsukas.config import Config
-from barsukas.helpers.strings import SUPPORTED_UI_LANGS, load_all_barsukas_strings
+from barsukas.helpers.strings import (
+    SUPPORTED_UI_LANGS,
+    create_lstr_accessor,
+    create_sstr_accessor,
+    load_all_barsukas_strings,
+)
 from barsukas.helpers.ui_language import (
     UI_LANGUAGE_COOKIE,
     normalize_ui_language,
@@ -340,6 +345,8 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
         """Set up database session and start request timing for metrics."""
         g.db = app.db_session_factory()
         g.ui_lang = resolve_ui_language(request)
+        endpoint_name = request.endpoint or "common"
+        g.strings_default_module = endpoint_name.split(".", 1)[0]
         RequestMetricsMiddleware.before_request()
 
     @app.teardown_appcontext
@@ -418,11 +425,18 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
     def utility_processor() -> Dict[str, Any]:
         """Add utility values to Jinja templates."""
         ui_lang = getattr(g, "ui_lang", "en")
+        strings_by_namespace = load_all_barsukas_strings(ui_lang)
+        default_module = getattr(g, "strings_default_module", "common")
+        lstr = create_lstr_accessor(strings_by_namespace, default_module=default_module)
+        sstr = create_sstr_accessor(strings_by_namespace, default_module=default_module)
+
         return {
             "config": app.config,
             "UI_LANG": ui_lang,
             "SUPPORTED_UI_LANGS": sorted(SUPPORTED_UI_LANGS),
-            "STRINGS": load_all_barsukas_strings(ui_lang),
+            "STRINGS": strings_by_namespace,
+            "LSTR": lstr,
+            "SSTR": sstr,
         }
 
     return app

--- a/src/barsukas/helpers/strings.py
+++ b/src/barsukas/helpers/strings.py
@@ -5,7 +5,7 @@
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, Sequence, cast
 
 SUPPORTED_UI_LANGS = frozenset({"en", "lt"})
 _STRINGS_ROOT = Path(__file__).resolve().parents[3] / "strings" / "barsukas"
@@ -53,3 +53,108 @@ def load_all_barsukas_strings(ui_lang: str) -> Dict[str, Dict[str, Any]]:
         namespace: _load_namespace_file(namespace=namespace, ui_lang=ui_lang)
         for namespace in namespaces
     }
+
+
+class _StringPathNode:
+    """Lazy accessor object used by Jinja for LSTR/SSTR paths."""
+
+    def __init__(
+        self,
+        resolver: "StringAccessor",
+        segments: Optional[Sequence[str]] = None,
+    ) -> None:
+        self._resolver = resolver
+        self._segments = tuple(segments or ())
+
+    def __getattr__(self, name: str) -> "_StringPathNode":
+        return _StringPathNode(self._resolver, (*self._segments, name))
+
+    def get(self, default: str = "") -> str:
+        """Resolve current path with optional default."""
+        return self._resolver.resolve(self._segments, default=default)
+
+    def __str__(self) -> str:
+        return self._resolver.resolve(self._segments, default="")
+
+
+class StringAccessor:
+    """Template accessor for legacy STRINGS namespaces and new LSTR/SSTR paths."""
+
+    def __init__(
+        self,
+        strings_by_namespace: Dict[str, Dict[str, Any]],
+        mode: str,
+        default_module: str = "common",
+    ) -> None:
+        self._strings_by_namespace = strings_by_namespace
+        self._mode = mode
+        self._default_module = default_module
+
+    def __getattr__(self, name: str) -> _StringPathNode:
+        return _StringPathNode(self, (name,))
+
+    def resolve(self, segments: Sequence[str], default: str = "") -> str:
+        """Resolve a dotted path to a string value.
+
+        Modes:
+        - lstr: default shared namespace with CURRENT/OTHER support.
+        - sstr: explicit namespace required (first segment).
+        """
+        if not segments:
+            return default
+
+        if self._mode == "lstr":
+            return self._resolve_lstr(segments, default=default)
+
+        if self._mode == "sstr":
+            return self._resolve_sstr(segments, default=default)
+
+        return default
+
+    def _resolve_lstr(self, segments: Sequence[str], default: str = "") -> str:
+        head = segments[0]
+
+        if head == "CURRENT":
+            key = ".".join(segments[1:])
+            return self._get_value(self._default_module, key, default=default)
+
+        if head == "OTHER" and len(segments) >= 3:
+            namespace = segments[1]
+            key = ".".join(segments[2:])
+            return self._get_value(namespace, key, default=default)
+
+        if head in self._strings_by_namespace and len(segments) >= 2:
+            key = ".".join(segments[1:])
+            return self._get_value(head, key, default=default)
+
+        key = ".".join(segments)
+        return self._get_value("common", key, default=default)
+
+    def _resolve_sstr(self, segments: Sequence[str], default: str = "") -> str:
+        if len(segments) < 2:
+            return default
+
+        namespace = segments[0]
+        key = ".".join(segments[1:])
+        return self._get_value(namespace, key, default=default)
+
+    def _get_value(self, namespace: str, key: str, default: str = "") -> str:
+        namespace_strings = self._strings_by_namespace.get(namespace, {})
+        value = namespace_strings.get(key, default)
+        if value is None:
+            return default
+        return str(value)
+
+
+def create_lstr_accessor(
+    strings_by_namespace: Dict[str, Dict[str, Any]], default_module: str
+) -> StringAccessor:
+    """Create accessor for short lemma-like strings (LSTR)."""
+    return StringAccessor(strings_by_namespace, mode="lstr", default_module=default_module)
+
+
+def create_sstr_accessor(
+    strings_by_namespace: Dict[str, Dict[str, Any]], default_module: str
+) -> StringAccessor:
+    """Create accessor for sentence strings (SSTR)."""
+    return StringAccessor(strings_by_namespace, mode="sstr", default_module=default_module)

--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -30,7 +30,7 @@
         <div class="col-auto">
             <label for="sort" class="form-label mb-0 small text-muted">{{ STRINGS.navigation.sort_by }}</label>
             <select class="form-select form-select-sm" id="sort" name="sort" onchange="this.form.submit()">
-                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ STRINGS.dictionary.sort_alpha }}</option>
+                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ STRINGS.common.label_sort_order_alphabetical }}</option>
                 <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ STRINGS.common.level }}</option>
                 <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ STRINGS.common.category }}</option>
             </select>
@@ -93,7 +93,7 @@
                 {% for code in display_langs %}
                     <th class="dict-trans-col">{{ language_names[code] }}</th>
                 {% endfor %}
-                <th class="dict-pos-col">{{ STRINGS.dictionary.pos }}</th>
+                <th class="dict-pos-col">{{ STRINGS.common.label_part_of_speech }}</th>
             </tr>
         </thead>
         <tbody>

--- a/src/barsukas/templates/lemmas/sections/translations.html
+++ b/src/barsukas/templates/lemmas/sections/translations.html
@@ -121,7 +121,7 @@
                                                 {% if lang_code != 'en' %}
                                                 <div class="mb-3">
                                                     <label for="disambiguation{{ lang_code }}" class="form-label">
-                                                        {{ STRINGS.sentences.disambiguation }} <small class="text-muted">({{ STRINGS.sentences.optional }})</small>
+                                                        {{ STRINGS.sentences.disambiguation }} <small class="text-muted">({{ STRINGS.common.token_optional }})</small>
                                                     </label>
                                                     <input type="text" class="form-control" id="disambiguation{{ lang_code }}"
                                                            name="disambiguation" value="{{ translation_disambiguations[lang_code] or '' }}"

--- a/src/barsukas/templates/rhymes/family.html
+++ b/src/barsukas/templates/rhymes/family.html
@@ -52,9 +52,9 @@
             <thead>
                 <tr>
                     <th>{{ STRINGS.linguistics.word }}</th>
-                    <th>{{ STRINGS.linguistics.ipa }}</th>
+                    <th>{{ STRINGS.common.abbreviation_international_phonetic_alphabet }}</th>
                     <th>{{ STRINGS.linguistics.form }}</th>
-                    <th>{{ STRINGS.linguistics.pos }}</th>
+                    <th>{{ STRINGS.common.abbreviation_part_of_speech }}</th>
                     <th>{{ STRINGS.common.level }}</th>
                 </tr>
             </thead>

--- a/src/barsukas/templates/sync_derivative_release/index.html
+++ b/src/barsukas/templates/sync_derivative_release/index.html
@@ -55,7 +55,7 @@
                     <tr>
                         <th>{{ STRINGS.common.language }}</th>
                         <th class="text-center">{{ STRINGS.sync.release }}</th>
-                        <th class="text-center">{{ STRINGS.sync.database }}</th>
+                        <th class="text-center">{{ STRINGS.common.token_database }}</th>
                         <th class="text-center text-success">{{ STRINGS.sync.additions }}</th>
                         <th class="text-center text-danger">{{ STRINGS.sync.removals }}</th>
                         <th class="text-center text-warning">{{ STRINGS.sync.changes }}</th>

--- a/strings/NAMING.md
+++ b/strings/NAMING.md
@@ -1,0 +1,135 @@
+# Barsukas STRINGS Naming Design (LSTR / SSTR / CSTR, namespace rules)
+
+This is a design-only proposal for clearer string naming.
+
+## Primary objective
+
+Make it obvious whether a string is:
+- short / lemma-like (`LSTR`)
+- sentence-length (`SSTR`)
+- long multi-sentence block (`CSTR`)
+
+---
+
+## Top-level buckets
+
+- `LSTR` = short strings (single lemma/term/short phrase)
+- `SSTR` = sentence-length strings
+- `CSTR` = 3+ sentence text blocks
+
+---
+
+## LSTR namespace rules
+
+For `LSTR`, namespace behavior is special:
+
+1. **Default namespace is common**
+   - `LSTR.<key_path>` means the value comes from common namespace.
+   - Example: `LSTR.linguistics.verb`
+
+2. **CURRENT for current page/module strings**
+   - `LSTR.CURRENT.<key_path>`
+   - Example: `LSTR.CURRENT.play_xylophone`
+
+3. **OTHER for explicit cross-page references**
+   - `LSTR.OTHER.<page_namespace>.<key_path>`
+   - Example: `LSTR.OTHER.lemmas.search_placeholder`
+
+### Interpretation summary
+
+- `LSTR.foo.bar` → common (`common/foo/bar` conceptually)
+- `LSTR.CURRENT.foo` → current page/module namespace
+- `LSTR.OTHER.lemmas.foo` → explicitly from `lemmas` namespace
+
+---
+
+## SSTR / CSTR namespace rules
+
+For sentences and long blocks, a namespace is always required.
+
+- `SSTR.<namespace>.<key_path>`
+- `CSTR.<namespace>.<key_path>`
+
+Examples:
+- `SSTR.lemmas.search_placeholder`
+- `SSTR.sync.lemma.add_lemma_confirmation`
+- `CSTR.sync.lemma.release_sync_intro`
+
+No implicit `common` default for `SSTR`/`CSTR`.
+
+---
+
+## File/source mapping guidance
+
+This proposal is naming-focused; implementation can map these paths to existing
+JSON files however is most practical. Conceptually:
+
+- `LSTR.<key_path>` resolves to shared/common files first
+  - example source idea: `common/linguistics/*.json`
+- `LSTR.CURRENT.*` resolves in-page namespace
+- `LSTR.OTHER.<ns>.*` resolves that explicit namespace
+- `SSTR.<ns>.*` and `CSTR.<ns>.*` resolve directly in namespace `<ns>`
+
+---
+
+## Naming conventions for keys
+
+- Use explicit names (`part_of_speech_abbreviation`, `sort_order.alphabetical`)
+- Avoid ambiguous short names in new keys (`pos`, `ipa`, `sort_alpha`)
+- snake_case leaf keys
+
+---
+
+## Examples mapped to current concerns
+
+### Common/shared short terms
+
+- `LSTR.database`
+- `LSTR.import`
+- `LSTR.export`
+- `LSTR.optional`
+- `LSTR.linguistics.part_of_speech_abbreviation`
+
+### Current page short strings
+
+- `LSTR.CURRENT.play_xylophone`
+
+### Cross-page short-string reuse
+
+- `LSTR.OTHER.lemmas.search_placeholder`
+
+### Sentence-level strings
+
+- `SSTR.lemmas.search_placeholder`
+- `SSTR.sentence.empty.no_results`
+- `SSTR.sync.lemma.add_lemma_confirmation`
+
+### Long text blocks
+
+- `CSTR.sync.lemma.release_sync_intro`
+
+---
+
+## Migration approach (incremental)
+
+1. Introduce `LSTR/SSTR/CSTR` helpers while keeping existing `STRINGS` lookups.
+2. Add compatibility mapping from new symbolic paths to existing JSON locations.
+3. Migrate high-traffic templates first.
+4. Add validation rules:
+   - `LSTR` allows implicit common + `CURRENT` + `OTHER`
+   - `SSTR`/`CSTR` require explicit namespace
+   - disallow new ambiguous keys (`pos`, `ipa`, `sort_alpha`)
+5. Remove compatibility aliases after deprecation window.
+
+---
+
+## Decision summary
+
+Use:
+- `LSTR.<key_path>` as common default
+- `LSTR.CURRENT.<key_path>` for current page namespace
+- `LSTR.OTHER.<ns>.<key_path>` for explicit cross-page lookup
+- `SSTR.<ns>.<key_path>` (namespace required)
+- `CSTR.<ns>.<key_path>` (namespace required)
+
+This preserves concise access for common terms while making sentence/long-text ownership explicit.

--- a/strings/README.md
+++ b/strings/README.md
@@ -42,6 +42,18 @@ Rule of thumb: pages should use shared namespaces for generic labels, but avoid
 importing another module's namespace (for example, `lemmas` should not use
 `rhymes` keys).
 
+## Key naming conventions
+
+To make key intent obvious in templates, use prefixes:
+
+- `token_*` for single words/tokens (`token_import`, `token_optional`)
+- `label_*` for form/table labels and short UI phrases (`label_part_of_speech`)
+- `message_*` for full-sentence user-facing messages and confirmations
+- `abbreviation_*` for acronym-style labels (`abbreviation_international_phonetic_alphabet`)
+
+When creating new keys, prefer descriptive names over short jargon-heavy names.
+For example, use `label_part_of_speech` instead of `pos`.
+
 ## File format
 
 - Files are UTF-8 JSON objects.
@@ -65,6 +77,9 @@ Barsukas loads all namespaces into a global `STRINGS` object for templates.
 - Access dynamic keys with `.get(...)` when needed.
 - For counts, keep text and number as separate template blocks:
   - `{{ STRINGS.dictionary.entries_count }}: {{ total }}`
+- New forward-looking accessors are also available:
+  - `LSTR` for short labels/terms (with `CURRENT`/`OTHER` support)
+  - `SSTR` for sentence-level strings with explicit namespaces
 
 ## Fallback behavior
 

--- a/strings/barsukas/common/en.json
+++ b/strings/barsukas/common/en.json
@@ -11,5 +11,13 @@
   "status": "Status",
   "translation": "Translation",
   "translations": "Translations",
-  "view": "View"
+  "view": "View",
+  "token_database": "Database",
+  "token_export": "Export",
+  "token_import": "Import",
+  "token_optional": "Optional",
+  "abbreviation_international_phonetic_alphabet": "IPA",
+  "abbreviation_part_of_speech": "POS",
+  "label_part_of_speech": "Part of Speech",
+  "label_sort_order_alphabetical": "Alphabetical"
 }

--- a/strings/barsukas/common/lt.json
+++ b/strings/barsukas/common/lt.json
@@ -11,5 +11,13 @@
   "status": "Būsena",
   "translation": "Vertimas",
   "translations": "Vertimai",
-  "view": "Peržiūrėti"
+  "view": "Peržiūrėti",
+  "token_database": "Duomenų bazė",
+  "token_export": "Eksportuoti",
+  "token_import": "Importuoti",
+  "token_optional": "Pasirinktina",
+  "abbreviation_international_phonetic_alphabet": "IPA",
+  "abbreviation_part_of_speech": "Kalbos dalis",
+  "label_part_of_speech": "Kalbos dalis",
+  "label_sort_order_alphabetical": "Abėcėlė"
 }

--- a/strings/barsukas/dictionary/en.json
+++ b/strings/barsukas/dictionary/en.json
@@ -7,5 +7,7 @@
   "no_entries": "No entries",
   "no_entries_for_letter": "No entries for this letter.",
   "no_entries_for_level": "No entries for this level.",
-  "no_entries_for_category": "No entries for this category."
+  "no_entries_for_category": "No entries for this category.",
+  "label_sort_order_alphabetical": "Alphabetical",
+  "label_part_of_speech": "Part of Speech"
 }

--- a/strings/barsukas/dictionary/lt.json
+++ b/strings/barsukas/dictionary/lt.json
@@ -7,5 +7,7 @@
   "no_entries": "Įrašų nėra",
   "no_entries_for_letter": "Šiai raidei įrašų nėra.",
   "no_entries_for_level": "Šiam lygiui įrašų nėra.",
-  "no_entries_for_category": "Šiai kategorijai įrašų nėra."
+  "no_entries_for_category": "Šiai kategorijai įrašų nėra.",
+  "label_sort_order_alphabetical": "Abėcėlė",
+  "label_part_of_speech": "Kalbos dalis"
 }

--- a/strings/barsukas/linguistics/en.json
+++ b/strings/barsukas/linguistics/en.json
@@ -2,5 +2,7 @@
   "form": "Form",
   "ipa": "IPA",
   "pos": "POS",
-  "word": "Word"
+  "word": "Word",
+  "abbreviation_international_phonetic_alphabet": "IPA",
+  "abbreviation_part_of_speech": "POS"
 }

--- a/strings/barsukas/linguistics/lt.json
+++ b/strings/barsukas/linguistics/lt.json
@@ -2,5 +2,7 @@
   "form": "Forma",
   "ipa": "IPA",
   "pos": "Kalbos dalis",
-  "word": "Žodis"
+  "word": "Žodis",
+  "abbreviation_international_phonetic_alphabet": "IPA",
+  "abbreviation_part_of_speech": "Kalbos dalis"
 }

--- a/strings/barsukas/sentences/en.json
+++ b/strings/barsukas/sentences/en.json
@@ -101,5 +101,6 @@
   "vocabulary_words": "Vocabulary Words",
   "role": "Role",
   "english": "English",
-  "grammatical_form": "Grammatical Form"
+  "grammatical_form": "Grammatical Form",
+  "token_optional": "Optional"
 }

--- a/strings/barsukas/sentences/lt.json
+++ b/strings/barsukas/sentences/lt.json
@@ -101,5 +101,6 @@
   "vocabulary_words": "Žodyno žodžiai",
   "role": "Vaidmuo",
   "english": "Anglų",
-  "grammatical_form": "Gramatinė forma"
+  "grammatical_form": "Gramatinė forma",
+  "token_optional": "Pasirinktina"
 }


### PR DESCRIPTION
### Motivation

- Introduce clearer, namespaced accessors for short labels and sentence strings to avoid ambiguous keys and make ownership explicit across templates.
- Provide a way for templates to resolve default/current/other namespaces (LSTR) and explicit sentence namespaces (SSTR) while preserving existing `STRINGS` compatibility.

### Description

- Add `helpers/strings.py` StringAccessor implementation with `_StringPathNode`, `create_lstr_accessor`, and `create_sstr_accessor` to provide `LSTR` (short labels with `CURRENT`/`OTHER` semantics) and `SSTR` (explicit namespace) accessors for Jinja templates while keeping `STRINGS` loading functions and fallback behavior. 
- Wire accessors into the Flask app by resolving the request endpoint to set a `strings_default_module` and exposing `LSTR`, `SSTR`, and `STRINGS` in the `utility_processor` after loading all namespaces. 
- Update multiple templates to use the new, less-ambiguous common keys (for example `label_part_of_speech`, `token_optional`, `abbreviation_international_phonetic_alphabet`, `label_sort_order_alphabetical`, and `token_database`) instead of short/ambiguous keys like `pos`, `ipa`, or `sort_alpha`.
- Add and update string JSONs under `strings/barsukas/*` with the new keys and add `strings/NAMING.md` plus README guidance documenting the LSTR/SSTR/CSTR naming design and key naming conventions.

### Testing

- No automated tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddabbea08c8327ad870f31e47b0cf6)