### PR TITLE
Migrate Barsukas `STRINGS.common` template calls to `LSTR`

### DIFF
--- a/src/barsukas/templates/dictionary/index.html
+++ b/src/barsukas/templates/dictionary/index.html
@@ -30,14 +30,14 @@
         <div class="col-auto">
             <label for="sort" class="form-label mb-0 small text-muted">{{ STRINGS.navigation.sort_by }}</label>
             <select class="form-select form-select-sm" id="sort" name="sort" onchange="this.form.submit()">
-                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ STRINGS.common.label_sort_order_alphabetical }}</option>
-                <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ STRINGS.common.level }}</option>
-                <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ STRINGS.common.category }}</option>
+                <option value="alpha" {% if sort == 'alpha' %}selected{% endif %}>{{ LSTR.label_sort_order_alphabetical }}</option>
+                <option value="level" {% if sort == 'level' %}selected{% endif %}>{{ LSTR.level }}</option>
+                <option value="category" {% if sort == 'category' %}selected{% endif %}>{{ LSTR.category }}</option>
             </select>
         </div>
         {% if sort == 'category' %}
         <div class="col-auto">
-            <label for="category" class="form-label mb-0 small text-muted">{{ STRINGS.common.category }}</label>
+            <label for="category" class="form-label mb-0 small text-muted">{{ LSTR.category }}</label>
             <select class="form-select form-select-sm dict-category-select" id="category" name="category" onchange="this.form.submit()">
                 {% for group in category_options %}
                     <optgroup label="{{ STRINGS.parts_of_speech.get(group.pos_type ~ '_plural', group.pos_type|title) }}">
@@ -93,7 +93,7 @@
                 {% for code in display_langs %}
                     <th class="dict-trans-col">{{ language_names[code] }}</th>
                 {% endfor %}
-                <th class="dict-pos-col">{{ STRINGS.common.label_part_of_speech }}</th>
+                <th class="dict-pos-col">{{ LSTR.label_part_of_speech }}</th>
             </tr>
         </thead>
         <tbody>

--- a/src/barsukas/templates/lemmas/list.html
+++ b/src/barsukas/templates/lemmas/list.html
@@ -26,14 +26,14 @@
     <form method="get" action="{{ url_for('lemmas.list_lemmas') }}">
         <div class="row g-3">
             <div class="col-md-5">
-                <label for="search" class="form-label">{{ STRINGS.common.search }}</label>
+                <label for="search" class="form-label">{{ LSTR.search }}</label>
                 <input type="text" class="form-control" id="search" name="search"
                        value="{{ search }}" placeholder="{{ STRINGS.lemmas.search_placeholder }}">
             </div>
             <div class="col-md-2">
                 <label for="pos_type" class="form-label">{{ STRINGS.lemmas.pos_type }}</label>
                 <select class="form-select" id="pos_type" name="pos_type">
-                    <option value="">{{ STRINGS.common.all }}</option>
+                    <option value="">{{ LSTR.all }}</option>
                     {% for pt in pos_types %}
                         <option value="{{ pt }}" {% if pt == pos_type %}selected{% endif %}>
                             {{ STRINGS.parts_of_speech.get(pt, pt|replace('_', ' ')|title) }}
@@ -44,7 +44,7 @@
             <div class="col-md-2">
                 <label for="pos_subtype" class="form-label">{{ STRINGS.lemmas.subcategory }}</label>
                 <select class="form-select" id="pos_subtype" name="pos_subtype">
-                    <option value="">{{ STRINGS.common.all }}</option>
+                    <option value="">{{ LSTR.all }}</option>
                     {% for pst in pos_subtypes %}
                         <option value="{{ pst }}" {% if pst == pos_subtype %}selected{% endif %}>
                             {{ pst }}
@@ -55,12 +55,12 @@
             <div class="col-md-3">
                 <label for="difficulty" class="form-label">{{ STRINGS.lemmas.difficulty }}</label>
                 <select class="form-select" id="difficulty" name="difficulty">
-                    <option value="">{{ STRINGS.common.all }}</option>
+                    <option value="">{{ LSTR.all }}</option>
                     <option value="null" {% if difficulty == 'null' %}selected{% endif %}>{{ STRINGS.lemmas.no_level_set }}</option>
                     <option value="-1" {% if difficulty == '-1' %}selected{% endif %}>{{ STRINGS.lemmas.excluded }}</option>
                     {% for i in range(1, config.MAX_DIFFICULTY_LEVEL + 1) %}
                         <option value="{{ i }}" {% if difficulty == i|string %}selected{% endif %}>
-                            {{ STRINGS.common.level }} {{ i }}
+                            {{ LSTR.level }} {{ i }}
                         </option>
                     {% endfor %}
                 </select>
@@ -69,10 +69,10 @@
         <div class="row mt-3">
             <div class="col">
                 <button type="submit" class="btn btn-primary">
-                    <i class="bi bi-search"></i> {{ STRINGS.common.search }}
+                    <i class="bi bi-search"></i> {{ LSTR.search }}
                 </button>
                 <a href="{{ url_for('lemmas.list_lemmas') }}" class="btn btn-outline-secondary">
-                    <i class="bi bi-x-circle"></i> {{ STRINGS.common["clear"] }}
+                    <i class="bi bi-x-circle"></i> {{ LSTR.clear }}
                 </a>
             </div>
         </div>
@@ -111,7 +111,7 @@
                                         {% if lemma.difficulty_level == -1 %}
                                             <span class="badge bg-warning difficulty-badge">{{ STRINGS.lemmas.excluded_short }}</span>
                                         {% else %}
-                                            <span class="badge bg-info difficulty-badge">{{ STRINGS.common.level }} {{ lemma.difficulty_level }}</span>
+                                            <span class="badge bg-info difficulty-badge">{{ LSTR.level }} {{ lemma.difficulty_level }}</span>
                                         {% endif %}
                                     {% endif %}
                                 </div>
@@ -119,12 +119,12 @@
                             <div class="col-md-4 text-end">
                                 <a href="{{ url_for('lemmas.view_lemma', lemma_id=lemma.id) }}"
                                    class="btn btn-sm btn-outline-primary">
-                                    <i class="bi bi-eye"></i> {{ STRINGS.common.view }}
+                                    <i class="bi bi-eye"></i> {{ LSTR.view }}
                                 </a>
                                 <a href="{{ url_for('lemmas.edit_lemma', lemma_id=lemma.id) }}"
                                    class="btn btn-sm btn-outline-secondary {% if config.get('READONLY', False) %}disabled{% endif %}"
                                    {% if config.get('READONLY', False) %}aria-disabled="true" tabindex="-1"{% endif %}>
-                                    <i class="bi bi-pencil"></i> {{ STRINGS.common.edit }}
+                                    <i class="bi bi-pencil"></i> {{ LSTR.edit }}
                                 </a>
                             </div>
                         </div>

--- a/src/barsukas/templates/lemmas/sections/audio.html
+++ b/src/barsukas/templates/lemmas/sections/audio.html
@@ -18,10 +18,10 @@
                 <table class="table table-sm">
                     <thead>
                         <tr>
-                            <th>{{ STRINGS.common.language }}</th>
+                            <th>{{ LSTR.language }}</th>
                             <th>{{ STRINGS.sentences.voice }}</th>
                             <th>{{ STRINGS.sentences.expected_text }}</th>
-                            <th>{{ STRINGS.common.status }}</th>
+                            <th>{{ LSTR.status }}</th>
                             <th>{{ STRINGS.sentences.issues }}</th>
                             <th>{{ STRINGS.sentences.audio }}</th>
                             <th>{{ STRINGS.sentences.actions }}</th>
@@ -124,7 +124,7 @@
                     <div class="form-text">{{ STRINGS.sentences.choose_tts_engine_for_audio_generation }}</div>
                 </div>
                 <div class="mb-3">
-                    <label for="audio_language" class="form-label">{{ STRINGS.common.language }} <span class="text-danger">*</span></label>
+                    <label for="audio_language" class="form-label">{{ LSTR.language }} <span class="text-danger">*</span></label>
                     <select class="form-select" id="audio_language" name="language" required>
                         <option value="">{{ STRINGS.sentences.select_language }}</option>
                         {% for lang_code, lang_name in language_names.items() %}

--- a/src/barsukas/templates/lemmas/sections/translations.html
+++ b/src/barsukas/templates/lemmas/sections/translations.html
@@ -3,7 +3,7 @@
     <div class="col">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <span><i class="bi bi-translate"></i> {{ STRINGS.common.translations }}</span>
+                <span><i class="bi bi-translate"></i> {{ LSTR.translations }}</span>
                 <div>
                     <form method="post" action="{{ url_for('agents.check_translations', lemma_id=lemma.id) }}" style="display: inline;">
                         <button type="submit" class="btn btn-sm btn-light"
@@ -25,8 +25,8 @@
                 <table class="table table-hover translation-table">
                     <thead>
                         <tr>
-                            <th>{{ STRINGS.common.language }}</th>
-                            <th>{{ STRINGS.common.translation }}</th>
+                            <th>{{ LSTR.language }}</th>
+                            <th>{{ LSTR.translation }}</th>
                             <th>{{ STRINGS.sentences.disambiguation }}</th>
                             <th>{{ STRINGS.sentences.definition }}</th>
                             <th>{{ STRINGS.sentences.actions }}</th>
@@ -77,7 +77,7 @@
                                             {% else %}
                                             disabled title="Not available in hosted mode"
                                             {% endif %}>
-                                        <i class="bi bi-pencil"></i> {{ STRINGS.common.edit }}
+                                        <i class="bi bi-pencil"></i> {{ LSTR.edit }}
                                     </button>
                                     {% if lang_code != 'en' and translations[lang_code] %}
                                     <form method="post" action="{{ url_for('agents.check_translation_disambiguation', lemma_id=lemma.id, lang_code=lang_code) }}" style="display: inline;">
@@ -107,7 +107,7 @@
                                                 </div>
                                                 <div class="mb-3">
                                                     <label for="translation{{ lang_code }}" class="form-label">
-                                                        {{ STRINGS.common.translation }} ({{ lang_name }})
+                                                        {{ LSTR.translation }} ({{ lang_name }})
                                                     </label>
                                                     <input type="text" class="form-control" id="translation{{ lang_code }}"
                                                            name="translation" value="{{ translations[lang_code] or '' }}"
@@ -121,7 +121,7 @@
                                                 {% if lang_code != 'en' %}
                                                 <div class="mb-3">
                                                     <label for="disambiguation{{ lang_code }}" class="form-label">
-                                                        {{ STRINGS.sentences.disambiguation }} <small class="text-muted">({{ STRINGS.common.token_optional }})</small>
+                                                        {{ STRINGS.sentences.disambiguation }} <small class="text-muted">({{ LSTR.token_optional }})</small>
                                                     </label>
                                                     <input type="text" class="form-control" id="disambiguation{{ lang_code }}"
                                                            name="disambiguation" value="{{ translation_disambiguations[lang_code] or '' }}"

--- a/src/barsukas/templates/rhymes/family.html
+++ b/src/barsukas/templates/rhymes/family.html
@@ -18,7 +18,7 @@
 <form method="get" class="row g-2 align-items-end mb-3">
     <input type="hidden" name="key" value="{{ rhyme_key or '' }}">
     <div class="col-auto">
-        <label for="language" class="form-label mb-1">{{ STRINGS.common.language }}</label>
+        <label for="language" class="form-label mb-1">{{ LSTR.language }}</label>
         <select class="form-select form-select-sm" id="language" name="language">
             {% for lang_code, lang_name in language_options %}
                 <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
@@ -28,7 +28,7 @@
         </select>
     </div>
     <div class="col-auto">
-        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ STRINGS.common.apply }}</button>
+        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ LSTR.apply }}</button>
     </div>
 </form>
 
@@ -52,10 +52,10 @@
             <thead>
                 <tr>
                     <th>{{ STRINGS.linguistics.word }}</th>
-                    <th>{{ STRINGS.common.abbreviation_international_phonetic_alphabet }}</th>
+                    <th>{{ LSTR.abbreviation_international_phonetic_alphabet }}</th>
                     <th>{{ STRINGS.linguistics.form }}</th>
-                    <th>{{ STRINGS.common.abbreviation_part_of_speech }}</th>
-                    <th>{{ STRINGS.common.level }}</th>
+                    <th>{{ LSTR.abbreviation_part_of_speech }}</th>
+                    <th>{{ LSTR.level }}</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/barsukas/templates/rhymes/index.html
+++ b/src/barsukas/templates/rhymes/index.html
@@ -18,7 +18,7 @@
 
 <form method="get" class="row g-2 align-items-end mb-3">
     <div class="col-auto">
-        <label for="language" class="form-label mb-1">{{ STRINGS.common.language }}</label>
+        <label for="language" class="form-label mb-1">{{ LSTR.language }}</label>
         <select class="form-select form-select-sm" id="language" name="language">
             {% for lang_code, lang_name in language_options %}
                 <option value="{{ lang_code }}" {% if lang_code == selected_language %}selected{% endif %}>
@@ -34,7 +34,7 @@
         <input type="hidden" name="pen" value="{{ selected_penultimate }}">
     {% endif %}
     <div class="col-auto">
-        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ STRINGS.common.apply }}</button>
+        <button type="submit" class="btn btn-sm btn-outline-secondary">{{ LSTR.apply }}</button>
     </div>
 </form>
 
@@ -58,7 +58,7 @@
 <nav class="rhyme-nav rhyme-nav-tier2 mb-3" aria-label="Vowel sound navigation">
     <span class="rhyme-nav-label text-muted small me-2">{{ STRINGS.rhymes.vowel }}:</span>
     <a href="{{ url_for('rhymes.index', sound=selected_sound, language=selected_language) }}"
-       class="rhyme-sound rhyme-sound-sm {% if not selected_penultimate %}rhyme-sound-active{% endif %}">{{ STRINGS.common.all }}</a>
+       class="rhyme-sound rhyme-sound-sm {% if not selected_penultimate %}rhyme-sound-active{% endif %}">{{ LSTR.all }}</a>
     {% for pen in penultimate_sounds %}
         {% if pen == selected_penultimate %}
             <span class="rhyme-sound rhyme-sound-sm rhyme-sound-active">{{ pen }}</span>

--- a/src/barsukas/templates/sentences/list.html
+++ b/src/barsukas/templates/sentences/list.html
@@ -26,14 +26,14 @@
     <form method="get" action="{{ url_for('sentences.list_sentences') }}">
         <div class="row g-3">
             <div class="col-md-6">
-                <label for="search" class="form-label">{{ STRINGS.common.search }}</label>
+                <label for="search" class="form-label">{{ LSTR.search }}</label>
                 <input type="text" class="form-control" id="search" name="search"
                        value="{{ search }}" placeholder="{{ STRINGS.sentences.search_placeholder }}">
             </div>
             <div class="col-md-3">
                 <label for="pattern_type" class="form-label">{{ STRINGS.sentences.pattern_type }}</label>
                 <select class="form-select" id="pattern_type" name="pattern_type">
-                    <option value="">{{ STRINGS.common.all }}</option>
+                    <option value="">{{ LSTR.all }}</option>
                     {% for pt in pattern_types %}
                         <option value="{{ pt }}" {% if pt == pattern_type %}selected{% endif %}>
                             {{ pt }}
@@ -48,7 +48,7 @@
                     <option value="null" {% if minimum_level == 'null' %}selected{% endif %}>{{ STRINGS.sentences.no_level_set }}</option>
                     {% for i in range(1, config.MAX_DIFFICULTY_LEVEL + 1) %}
                         <option value="{{ i }}+" {% if minimum_level == i|string ~ '+' %}selected{% endif %}>
-                            {{ STRINGS.common.level }} {{ i }}+
+                            {{ LSTR.level }} {{ i }}+
                         </option>
                     {% endfor %}
                     {% for i in range(1, config.MAX_DIFFICULTY_LEVEL + 1) %}
@@ -86,10 +86,10 @@
         <div class="row mt-3">
             <div class="col">
                 <button type="submit" class="btn btn-primary">
-                    <i class="bi bi-search"></i> {{ STRINGS.common.search }}
+                    <i class="bi bi-search"></i> {{ LSTR.search }}
                 </button>
                 <a href="{{ url_for('sentences.list_sentences') }}" class="btn btn-outline-secondary">
-                    <i class="bi bi-x-circle"></i> {{ STRINGS.common.clear }}
+                    <i class="bi bi-x-circle"></i> {{ LSTR.clear }}
                 </a>
             </div>
         </div>
@@ -125,7 +125,7 @@
                                         <span class="badge bg-light text-dark me-2">{{ sentence.tense }}</span>
                                     {% endif %}
                                     {% if sentence.minimum_level is not none %}
-                                        <span class="badge bg-info difficulty-badge">{{ STRINGS.common.level }} {{ sentence.minimum_level }}</span>
+                                        <span class="badge bg-info difficulty-badge">{{ LSTR.level }} {{ sentence.minimum_level }}</span>
                                     {% else %}
                                         <span class="badge bg-warning difficulty-badge">{{ STRINGS.sentences.no_level }}</span>
                                     {% endif %}
@@ -135,7 +135,7 @@
                                 <div class="d-flex flex-wrap justify-content-end gap-1">
                                     <a href="{{ url_for('sentences.view_sentence', sentence_id=sentence.id) }}"
                                        class="btn btn-sm btn-outline-primary">
-                                        <i class="bi bi-eye"></i> {{ STRINGS.common.view }}
+                                        <i class="bi bi-eye"></i> {{ LSTR.view }}
                                     </a>
                                     {% if sentence.verified %}
                                     <span class="badge bg-success align-self-center">{{ STRINGS.sentences.verified }}</span>

--- a/src/barsukas/templates/sentences/view.html
+++ b/src/barsukas/templates/sentences/view.html
@@ -45,7 +45,7 @@
                             <dt class="col-sm-5">{{ STRINGS.sentences.minimum_level }}</dt>
                             <dd class="col-sm-7">
                                 {% if sentence.minimum_level is not none %}
-                                    <span class="badge bg-info difficulty-badge">{{ STRINGS.common.level }} {{ sentence.minimum_level }}</span>
+                                    <span class="badge bg-info difficulty-badge">{{ LSTR.level }} {{ sentence.minimum_level }}</span>
                                 {% else %}
                                     <span class="text-muted">{{ STRINGS.sentences.not_set }}</span>
                                 {% endif %}
@@ -214,7 +214,7 @@
     <div class="col">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <span><i class="bi bi-translate"></i> {{ STRINGS.common.translations }}</span>
+                <span><i class="bi bi-translate"></i> {{ LSTR.translations }}</span>
                 <button class="btn btn-sm btn-primary"
                         {% if config.get('ALLOW_OUTBOUND_CALLS', True) %}
                         data-bs-toggle="collapse" data-bs-target="#translateForm"
@@ -272,8 +272,8 @@
                 <table class="table table-hover translation-table">
                     <thead>
                         <tr>
-                            <th style="width: 20%;">{{ STRINGS.common.language }}</th>
-                            <th>{{ STRINGS.common.translation }}</th>
+                            <th style="width: 20%;">{{ LSTR.language }}</th>
+                            <th>{{ LSTR.translation }}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -333,7 +333,7 @@
                             <tr>
                                 <th>{{ STRINGS.sentences.voice }}</th>
                                 <th>{{ STRINGS.sentences.expected_text }}</th>
-                                <th>{{ STRINGS.common.status }}</th>
+                                <th>{{ LSTR.status }}</th>
                                 <th>{{ STRINGS.sentences.audio }}</th>
                                 <th>{{ STRINGS.sentences.actions }}</th>
                             </tr>
@@ -421,7 +421,7 @@
                     <div class="form-text">{{ STRINGS.sentences.choose_tts_engine }}</div>
                 </div>
                 <div class="mb-3">
-                    <label for="sentence_audio_language" class="form-label">{{ STRINGS.common.language }} <span class="text-danger">*</span></label>
+                    <label for="sentence_audio_language" class="form-label">{{ LSTR.language }} <span class="text-danger">*</span></label>
                     <select class="form-select" id="sentence_audio_language" name="language" required>
                         <option value="">{{ STRINGS.sentences.select_language }}</option>
                         {% for lang_code, lang_name in language_names.items() %}

--- a/src/barsukas/templates/sync_derivative_release/index.html
+++ b/src/barsukas/templates/sync_derivative_release/index.html
@@ -53,9 +53,9 @@
             <table class="table table-hover mb-0">
                 <thead class="table-light">
                     <tr>
-                        <th>{{ STRINGS.common.language }}</th>
+                        <th>{{ LSTR.language }}</th>
                         <th class="text-center">{{ STRINGS.sync.release }}</th>
-                        <th class="text-center">{{ STRINGS.common.token_database }}</th>
+                        <th class="text-center">{{ LSTR.token_database }}</th>
                         <th class="text-center text-success">{{ STRINGS.sync.additions }}</th>
                         <th class="text-center text-danger">{{ STRINGS.sync.removals }}</th>
                         <th class="text-center text-warning">{{ STRINGS.sync.changes }}</th>

--- a/src/barsukas/templates/sync_derivative_release/language_detail.html
+++ b/src/barsukas/templates/sync_derivative_release/language_detail.html
@@ -209,7 +209,7 @@
                         <table class="table table-sm table-bordered mb-0">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 80px;">{{ STRINGS.common.status }}</th>
+                                    <th style="width: 80px;">{{ LSTR.status }}</th>
                                     <th>Grammatical Form</th>
                                     <th>DB</th>
                                     <th>{{ STRINGS.sync.release }}</th>

--- a/src/barsukas/templates/sync_hub/index.html
+++ b/src/barsukas/templates/sync_hub/index.html
@@ -103,7 +103,7 @@
                         <li>{{ STRINGS.sync.additions }} & {{ STRINGS.sync.removals }}</li>
                         <li>{{ STRINGS.sync.text_changes }}</li>
                         <li>{{ STRINGS.sync.difficulty_levels }}</li>
-                        <li>{{ STRINGS.common.translations }}</li>
+                        <li>{{ LSTR.translations }}</li>
                     </ul>
                 </div>
                 <div class="card-footer">

--- a/src/barsukas/templates/sync_release/additions.html
+++ b/src/barsukas/templates/sync_release/additions.html
@@ -50,9 +50,9 @@
                                 </th>
                                 <th>{{ STRINGS.sync.guid }}</th>
                                 <th>{{ STRINGS.linguistics.word }}</th>
-                                <th>{{ STRINGS.common.category }}</th>
+                                <th>{{ LSTR.category }}</th>
                                 <th class="text-center">Level</th>
-                                <th>{{ STRINGS.common.translations }}</th>
+                                <th>{{ LSTR.translations }}</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/barsukas/templates/sync_release/changes.html
+++ b/src/barsukas/templates/sync_release/changes.html
@@ -50,7 +50,7 @@
                         <thead class="table-light">
                             <tr>
                                 <th>{{ STRINGS.sync.guid }}</th>
-                                <th>{{ STRINGS.common.category }}</th>
+                                <th>{{ LSTR.category }}</th>
                                 <th>SQLite Text</th>
                                 <th>{{ STRINGS.sync.release_text }}</th>
                                 <th>Action</th>

--- a/src/barsukas/templates/sync_release/difficulty.html
+++ b/src/barsukas/templates/sync_release/difficulty.html
@@ -48,7 +48,7 @@
                             <tr>
                                 <th>{{ STRINGS.sync.guid }}</th>
                                 <th>{{ STRINGS.linguistics.word }}</th>
-                                <th>{{ STRINGS.common.category }}</th>
+                                <th>{{ LSTR.category }}</th>
                                 <th class="text-center">SQLite</th>
                                 <th class="text-center">{{ STRINGS.sync.release }}</th>
                                 <th>Action</th>

--- a/src/barsukas/templates/sync_release/grammar_facts.html
+++ b/src/barsukas/templates/sync_release/grammar_facts.html
@@ -48,7 +48,7 @@
                                 </th>
                                 <th>{{ STRINGS.sync.guid }}</th>
                                 <th>{{ STRINGS.linguistics.word }}</th>
-                                <th>{{ STRINGS.common.category }}</th>
+                                <th>{{ LSTR.category }}</th>
                                 <th>{{ STRINGS.sync.fact_changes }}</th>
                             </tr>
                         </thead>

--- a/src/barsukas/templates/sync_release/index.html
+++ b/src/barsukas/templates/sync_release/index.html
@@ -160,11 +160,11 @@
             </div>
         </div>
 
-        <!-- {{ STRINGS.common.translations }} -->
+        <!-- {{ LSTR.translations }} -->
         <div class="col-md-6 col-lg-3 mb-3">
             <div class="card h-100 {% if counts.translations > 0 %}border-secondary{% endif %}">
                 <div class="card-header">
-                    <i class="bi bi-translate"></i> {{ STRINGS.common.translations }}
+                    <i class="bi bi-translate"></i> {{ LSTR.translations }}
                 </div>
                 <div class="card-body">
                     <h3 class="card-title {% if counts.translations > 0 %}{% else %}text-muted{% endif %}">

--- a/src/barsukas/templates/sync_release/removals.html
+++ b/src/barsukas/templates/sync_release/removals.html
@@ -56,7 +56,7 @@
                                 </th>
                                 <th>{{ STRINGS.sync.guid }}</th>
                                 <th>{{ STRINGS.linguistics.word }}</th>
-                                <th>{{ STRINGS.common.category }}</th>
+                                <th>{{ LSTR.category }}</th>
                                 <th class="text-center">Level</th>
                             </tr>
                         </thead>

--- a/src/barsukas/templates/sync_release/secondary_translations_detail.html
+++ b/src/barsukas/templates/sync_release/secondary_translations_detail.html
@@ -75,7 +75,7 @@
                         <table class="table table-sm table-hover mb-0">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 120px;">{{ STRINGS.common.language }}</th>
+                                    <th style="width: 120px;">{{ LSTR.language }}</th>
                                     <th>SQLite (DB)</th>
                                     <th>{{ STRINGS.sync.release }}</th>
                                     <th style="width: 150px;">Action</th>

--- a/src/barsukas/templates/sync_release/translations.html
+++ b/src/barsukas/templates/sync_release/translations.html
@@ -9,7 +9,7 @@
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ url_for('sync_release.index') }}">Sync</a></li>
-                    <li class="breadcrumb-item active">{{ STRINGS.common.translations }}</li>
+                    <li class="breadcrumb-item active">{{ LSTR.translations }}</li>
                 </ol>
             </nav>
             <h2><i class="bi bi-translate text-purple"></i> {{ STRINGS.sync.sync_translations_title }}</h2>
@@ -69,7 +69,7 @@
                         <table class="table table-sm table-hover mb-0">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 120px;">{{ STRINGS.common.language }}</th>
+                                    <th style="width: 120px;">{{ LSTR.language }}</th>
                                     <th>SQLite (DB)</th>
                                     <th>{{ STRINGS.sync.release }}</th>
                                     <th style="width: 150px;">Action</th>

--- a/src/barsukas/templates/sync_sentence_release/additions.html
+++ b/src/barsukas/templates/sync_sentence_release/additions.html
@@ -67,7 +67,7 @@
                                 <th>English Text</th>
                                 <th>Pattern</th>
                                 <th class="text-center">Level</th>
-                                <th>{{ STRINGS.common.translations }}</th>
+                                <th>{{ LSTR.translations }}</th>
                             </tr>
                         </thead>
                         <tbody>

--- a/src/barsukas/templates/sync_sentence_release/index.html
+++ b/src/barsukas/templates/sync_sentence_release/index.html
@@ -132,11 +132,11 @@
             </div>
         </div>
 
-        <!-- {{ STRINGS.common.translations }} -->
+        <!-- {{ LSTR.translations }} -->
         <div class="col-md-6 col-lg-3 mb-3">
             <div class="card h-100 {% if counts.translations > 0 %}border-secondary{% endif %}">
                 <div class="card-header">
-                    <i class="bi bi-translate"></i> {{ STRINGS.common.translations }}
+                    <i class="bi bi-translate"></i> {{ LSTR.translations }}
                 </div>
                 <div class="card-body">
                     <h3 class="card-title {% if counts.translations > 0 %}{% else %}text-muted{% endif %}">

--- a/src/barsukas/templates/sync_sentence_release/translations.html
+++ b/src/barsukas/templates/sync_sentence_release/translations.html
@@ -9,7 +9,7 @@
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item"><a href="{{ url_for('sync_sentence_release.index') }}">{{ STRINGS.sync.sentences_title }}</a></li>
-                    <li class="breadcrumb-item active">{{ STRINGS.common.translations }}</li>
+                    <li class="breadcrumb-item active">{{ LSTR.translations }}</li>
                 </ol>
             </nav>
             <h2><i class="bi bi-translate text-purple"></i> {{ STRINGS.sync.sync_sentence_translations_title }}</h2>
@@ -63,7 +63,7 @@
                         <table class="table table-sm table-hover mb-0">
                             <thead class="table-light">
                                 <tr>
-                                    <th style="width: 120px;">{{ STRINGS.common.language }}</th>
+                                    <th style="width: 120px;">{{ LSTR.language }}</th>
                                     <th>SQLite (DB)</th>
                                     <th>{{ STRINGS.sync.release }}</th>
                                     <th style="width: 150px;">Action</th>


### PR DESCRIPTION
### Motivation
- Update Barsukas templates to use the new `LSTR` accessor syntax for common UI strings so templates use the unified short-string accessor pattern implemented in `helpers/strings.py`.
- Only `common` namespace references were targeted to avoid unintended changes to other string namespaces.
- This is a non-functional, syntax-only migration to prepare templates for the `LSTR`/`SSTR` string accessor usage.

### Description
- Replaced all `STRINGS.common.<name>` and `STRINGS.common["<name>"]` usages with `LSTR.<name>` across Barsukas templates under `src/barsukas/templates`.
- Changes touch sentence, lemma, dictionary, rhymes, sync, and related template files while leaving other `STRINGS.*` namespaces unchanged.
- Both dot-access and bracket-access patterns were handled by a scripted find-and-replace to ensure consistent conversions.
- No runtime logic or template behavior was altered beyond switching the string accessor identifier.

### Testing
- Ran a targeted script to perform the replacements and verified the script completed without errors.
- Confirmed there are no remaining `STRINGS.common` references under `src/barsukas/templates` using `rg "STRINGS\.common" -n src/barsukas/templates` which returned no matches.
- Verified `LSTR` usage appears in the expected templates with `rg -n "LSTR\." src/barsukas/templates/...` which returned the updated occurrences.
- Performed a workspace status check to ensure the modified templates were detected by the repository tooling and the change set is cohesive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de58159614832791e850b1e74ea942)