### PR TITLE
Fix IPA reference vowel chart CSS layout

### DIFF
--- a/src/barsukas/static/css/ipa_reference.css
+++ b/src/barsukas/static/css/ipa_reference.css
@@ -35,7 +35,7 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     margin-bottom: 0.5rem;
-    font-size: 1.35rem;
+    font-size: clamp(1rem, 2.2vw, 2.5rem);
     font-weight: 600;
     text-align: center;
 }
@@ -53,30 +53,39 @@
 
 .ipa-vowel-plot {
     position: relative;
-    height: 20rem;
+    height: min(20rem, 50vw);
+    min-height: 16rem;
     border-radius: 0.35rem;
     overflow: hidden;
+    isolation: isolate;
+}
+
+.ipa-vowel-guides {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
 }
 
 .ipa-vowel-guides .ipa-guide {
     position: absolute;
     display: block;
     background-color: #252a33;
-    opacity: 0.75;
+    opacity: 0.62;
 }
 
 .ipa-guide-front {
-    left: 8%;
-    top: 10%;
+    left: 10%;
+    top: 12%;
     width: 2px;
-    height: 78%;
+    height: 74%;
     transform: rotate(-32deg);
     transform-origin: top;
 }
 
 .ipa-guide-central {
     left: 49%;
-    top: 11%;
+    top: 12%;
     width: 2px;
     height: 68%;
     transform: rotate(-18deg);
@@ -84,51 +93,53 @@
 }
 
 .ipa-guide-back {
-    right: 12%;
-    top: 8%;
+    right: 10%;
+    top: 10%;
     width: 2px;
-    height: 80%;
+    height: 78%;
 }
 
 .ipa-guide-close-mid {
-    left: 22%;
-    top: 31%;
-    width: 56%;
+    left: 25%;
+    top: 30%;
+    width: 54%;
     height: 2px;
 }
 
 .ipa-guide-open-mid {
-    left: 36%;
+    left: 37%;
     top: 57%;
-    width: 46%;
+    width: 44%;
     height: 2px;
 }
 
 .ipa-guide-open {
-    left: 52%;
-    top: 83%;
-    width: 32%;
+    left: 53%;
+    top: 82%;
+    width: 30%;
     height: 2px;
 }
 
 .ipa-vowel-symbol {
     position: absolute;
-    font-size: 2.35rem;
+    z-index: 2;
+    font-size: clamp(2rem, 4.8vw, 3.3rem);
     line-height: 1;
+    font-weight: 700;
 }
 
-.v-i { left: 4%; top: 6%; }
-.v-y { left: 14%; top: 6%; }
-.v-ii { left: 44%; top: 6%; }
-.v-uu { left: 82%; top: 6%; }
+.v-i { left: 4%; top: 5%; }
+.v-y { left: 14%; top: 5%; }
+.v-ii { left: 45%; top: 6%; }
+.v-uu { left: 83%; top: 5%; }
 
 .v-i-small { left: 24%; top: 22%; }
 .v-u-small { left: 72%; top: 22%; }
 
-.v-e { left: 17%; top: 33%; }
-.v-oe { left: 29%; top: 33%; }
-.v-schwa { left: 50%; top: 39%; }
-.v-o { left: 74%; top: 33%; }
+.v-e { left: 17%; top: 34%; }
+.v-oe { left: 29%; top: 34%; }
+.v-schwa { left: 51%; top: 40%; }
+.v-o { left: 74%; top: 34%; }
 
 .v-e-open { left: 31%; top: 56%; }
 .v-oe-open { left: 42%; top: 56%; }
@@ -136,11 +147,11 @@
 .v-lambda { left: 74%; top: 56%; }
 .v-open-o { left: 85%; top: 56%; }
 
-.v-ae { left: 29%; top: 72%; }
+.v-ae { left: 29%; top: 73%; }
 
-.v-a { left: 44%; top: 82%; }
-.v-alpha { left: 74%; top: 82%; }
-.v-open-back-o { left: 87%; top: 82%; }
+.v-a { left: 44%; top: 83%; }
+.v-alpha { left: 74%; top: 83%; }
+.v-open-back-o { left: 87%; top: 83%; }
 
 @media (max-width: 991px) {
     .ipa-vowel-classic {
@@ -158,9 +169,10 @@
 
     .ipa-vowel-plot {
         height: 17.5rem;
+        min-height: 14rem;
     }
 
     .ipa-vowel-symbol {
-        font-size: 2rem;
+        font-size: clamp(1.8rem, 6vw, 2.4rem);
     }
 }


### PR DESCRIPTION
### Motivation
- The IPA vowel chart on `/ipa-reference` appeared cramped and some guide lines could overlap glyphs, reducing readability.
- Make the chart responsive so it scales consistently across viewport sizes and avoids symbol crowding.
- Ensure visual layering so guide lines reliably render behind vowel symbols for clearer presentation.

### Description
- Use responsive sizing with `clamp()` for column headings and vowel symbol font sizes and bound chart height with `min()` and `min-height` to prevent overflow and extreme scaling.
- Add an explicit `.ipa-vowel-guides` wrapper with `z-index: 1`, `pointer-events: none`, and `inset: 0` so guide lines stay behind symbols, and set symbols to `z-index: 2` for proper stacking.
- Adjust guide geometry and vowel symbol coordinates to improve trapezoid alignment and spacing (tuned `left`, `top`, `width`, `height` values for guides and symbol position tweaks).
- Add `isolation: isolate` on the plot to scope stacking context and tune opacity for guide lines to improve contrast without overwhelming glyphs.

### Testing
- No automated tests were run because this is a CSS-only Barsukas frontend change; please validate visually by opening `/ipa-reference` in a browser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaaf8929c8327b2b5c10b8765dfb8)