### PR TITLE
Lazy-load Coqui/Piper TTS clients and disable worker in read-only mode

### DIFF
--- a/src/audioshoe/coqui/__init__.py
+++ b/src/audioshoe/coqui/__init__.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 """Coqui neural text-to-speech audio generation."""
 
-from .coqui_tts import CoquiClient, generate_audio
+from typing import Any
+
 from .types import DEFAULT_COQUI_VOICES, RECOMMENDED_VOICES, CoquiVoice
 
 __all__ = [
@@ -11,3 +12,16 @@ __all__ = [
     "DEFAULT_COQUI_VOICES",
     "RECOMMENDED_VOICES",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import Coqui runtime modules only when needed."""
+    if name in {"CoquiClient", "generate_audio"}:
+        from .coqui_tts import CoquiClient, generate_audio
+
+        exports = {
+            "CoquiClient": CoquiClient,
+            "generate_audio": generate_audio,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/audioshoe/piper/__init__.py
+++ b/src/audioshoe/piper/__init__.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 """Piper neural text-to-speech audio generation."""
 
-from .piper_tts import PiperClient, generate_audio
+from typing import Any
+
 from .types import DEFAULT_PIPER_VOICES, RECOMMENDED_VOICES, PiperVoice
 
 __all__ = [
@@ -11,3 +12,16 @@ __all__ = [
     "DEFAULT_PIPER_VOICES",
     "RECOMMENDED_VOICES",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import Piper runtime modules only when needed."""
+    if name in {"PiperClient", "generate_audio"}:
+        from .piper_tts import PiperClient, generate_audio
+
+        exports = {
+            "PiperClient": PiperClient,
+            "generate_audio": generate_audio,
+        }
+        return exports[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/barsukas/routes/audio.py
+++ b/src/barsukas/routes/audio.py
@@ -35,10 +35,10 @@ from sqlalchemy.exc import IntegrityError
 
 from agents.strazdas import StrazdasAgent
 from agents.vieversys import VieversysAgent
-from audioshoe.coqui import CoquiClient, CoquiVoice
+from audioshoe.coqui import CoquiVoice
 from audioshoe.espeak import EspeakVoice
 from audioshoe.qwen.types import QwenVoice
-from audioshoe.piper import PiperClient, PiperVoice
+from audioshoe.piper import PiperVoice
 from barsukas.helpers.audio_helpers import link_audio_to_lemma, validate_audio_translation
 from clients.audio import Voice
 from clients.audio.gpt_voices import GptVoice
@@ -859,6 +859,8 @@ def _generate_audio_piper(
     from storage.translation_helpers import get_translation
 
     try:
+        from audioshoe.piper import PiperClient
+
         # Get translation for the language
         translation = get_translation(session, lemma, language_code)
         if not translation:
@@ -946,6 +948,8 @@ def _generate_audio_coqui(
     from storage.translation_helpers import get_translation
 
     try:
+        from audioshoe.coqui import CoquiClient
+
         # Get translation for the language
         translation = get_translation(session, lemma, language_code)
         if not translation:

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -134,6 +134,11 @@ def main() -> None:
         if persona.use_postgres:
             args.postgres = True
 
+    # Safety rule: read-only mode never starts the background worker.
+    if args.readonly and not args.no_worker:
+        logger.info("Read-only mode enabled: disabling task worker")
+        args.no_worker = True
+
     # Set up logging
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(


### PR DESCRIPTION
### Motivation

- Avoid importing heavy runtime TTS modules at package import time to reduce startup cost and prevent optional dependency issues.  
- Ensure that starting the app in read-only mode cannot accidentally start the background worker.

### Description

- Add `__getattr__`-based lazy importers to `audioshoe.coqui.__init__` and `audioshoe.piper.__init__` so `CoquiClient`/`PiperClient` and `generate_audio` are imported only on first access.  
- Stop importing `CoquiClient` and `PiperClient` at module top-level in `barsukas/routes/audio.py` and instead import `CoquiClient`/`PiperClient` inside `_generate_audio_coqui` and `_generate_audio_piper` respectively, leaving only the voice enums imported at top-level.  
- Add a safety rule in `barsukas/unified_app.py` that forces `args.no_worker = True` when `args.readonly` is set and the worker flag was not explicitly disabled, and log the change.  
- Add small typing imports (`Any`) and adjust `__all__` exposures accordingly.

### Testing

- Ran the project test suite with `pytest -q` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfac0afb448327866f8ddac6e5d2cb)