### PR TITLE
Add sentence sync-back from SQLite to data/release sentences

### DIFF
--- a/src/barsukas/routes/sync_sentence_release.py
+++ b/src/barsukas/routes/sync_sentence_release.py
@@ -28,6 +28,7 @@ from storage.models.schema import (
 from storage.translation_helpers import (
     LANGUAGE_HIERARCHY,
     LANGUAGE_NAMES,
+    RELEASE_LANGUAGES,
 )
 
 if TYPE_CHECKING:
@@ -1452,6 +1453,95 @@ def _find_exportable_sentences(
     return exportable
 
 
+def _normalize_release_sentence_for_compare(release_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize release JSONL sentence data for comparison with DB export records."""
+    normalized: Dict[str, Any] = {"guid": release_data.get("guid")}
+
+    for field_name in ("pattern_type", "tense", "minimum_level", "notes"):
+        if field_name in release_data:
+            normalized[field_name] = release_data[field_name]
+
+    release_lang_set = set(RELEASE_LANGUAGES)
+    release_translations = release_data.get("translations", {})
+    translations: Dict[str, str] = {}
+    for lang_code, translation_text in release_translations.items():
+        if lang_code not in release_lang_set:
+            continue
+        if translation_text and str(translation_text).strip():
+            translations[lang_code] = str(translation_text)
+    if translations:
+        normalized["translations"] = translations
+
+    pattern_words = release_data.get("pattern_words", [])
+    if isinstance(pattern_words, list) and pattern_words:
+        normalized_words: List[Dict[str, Any]] = []
+        sorted_words = sorted(pattern_words, key=lambda p: p.get("position", 0))
+        for pattern_word in sorted_words:
+            normalized_words.append(
+                {
+                    "position": pattern_word.get("position", 0),
+                    "slot_name": pattern_word.get("slot_name"),
+                    "lemma_guid": pattern_word.get("lemma_guid"),
+                    "english_text": pattern_word.get("english_text"),
+                }
+            )
+        normalized["pattern_words"] = normalized_words
+
+    return normalized
+
+
+def _find_sync_back_candidates(
+    release_sentences: Dict[str, Dict[str, Any]], db_session: Any
+) -> List[Dict[str, Any]]:
+    """Find sentences that exist in both DB and release, but differ from DB canonical record."""
+    conversation_ids = _get_conversation_sentence_ids(db_session)
+    db_rows = db_session.query(Sentence.id, Sentence.guid).filter(Sentence.guid.isnot(None)).all()
+    db_guid_to_id = {guid: sentence_id for sentence_id, guid in db_rows if guid}
+    common_guids = sorted(set(release_sentences.keys()) & set(db_guid_to_id.keys()))
+    if not common_guids:
+        return []
+
+    candidates: List[Dict[str, Any]] = []
+    batch_size = 500
+    for index in range(0, len(common_guids), batch_size):
+        batch = common_guids[index : index + batch_size]
+        db_sentences = (
+            db_session.query(Sentence)
+            .filter(Sentence.guid.in_(batch))
+            .options(
+                selectinload(Sentence.translations),
+                selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+            )
+            .all()
+        )
+
+        for db_sentence in db_sentences:
+            if db_sentence.id in conversation_ids:
+                continue
+
+            release_data = release_sentences.get(db_sentence.guid)
+            if not release_data:
+                continue
+
+            db_record = _sentence_to_release_record(db_sentence)
+            normalized_release = _normalize_release_sentence_for_compare(release_data)
+            if db_record == normalized_release:
+                continue
+
+            candidates.append(
+                {
+                    "guid": db_sentence.guid,
+                    "sentence_id": db_sentence.id,
+                    "english_text": _get_db_sentence_english(db_session, db_sentence)[:120],
+                    "pattern_type": db_sentence.pattern_type or "",
+                    "minimum_level": db_sentence.minimum_level,
+                }
+            )
+
+    candidates.sort(key=lambda x: x["guid"])
+    return candidates
+
+
 @bp.route("/export")
 def export() -> ResponseReturnValue:
     """Display DB sentences that are not yet in release JSONL files."""
@@ -1459,10 +1549,12 @@ def export() -> ResponseReturnValue:
     release_sentences = _load_release_sentences(release_dir)
 
     exportable = _find_exportable_sentences(release_sentences, g.db)
+    sync_back_candidates = _find_sync_back_candidates(release_sentences, g.db)
 
     return render_template(
         "sync_sentence_release/export.html",
         exportable=exportable,
+        sync_back_candidates=sync_back_candidates,
         release_dir=str(release_dir),
     )
 
@@ -1581,4 +1673,90 @@ def apply_export() -> ResponseReturnValue:
     g.db.commit()
 
     flash(f"Exported {exported_count} sentence(s) to release files", "success")
+    return redirect(url_for("sync_sentence_release.export"))
+
+
+@bp.route("/export/sync-back", methods=["POST"])
+def apply_export_sync_back() -> ResponseReturnValue:
+    """Overwrite existing release sentence records with canonical SQLite records."""
+    app: "BarsukasFlask" = current_app  # type: ignore[assignment]
+    if app.config.get("READONLY", False):
+        flash("Database is in read-only mode", "error")
+        return redirect(url_for("sync_sentence_release.export"))
+
+    selected_guids = request.form.getlist("selected_guids")
+    if not selected_guids:
+        flash("No sentences selected for sync-back", "warning")
+        return redirect(url_for("sync_sentence_release.export"))
+
+    release_dir = _get_sentence_release_dir()
+    conversation_ids = _get_conversation_sentence_ids(g.db)
+    db_sentences = (
+        g.db.query(Sentence)
+        .filter(Sentence.guid.in_(selected_guids))
+        .options(
+            selectinload(Sentence.translations),
+            selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+        )
+        .all()
+    )
+    db_by_guid = {
+        sentence.guid: sentence for sentence in db_sentences if sentence.id not in conversation_ids
+    }
+
+    if not db_by_guid:
+        flash("No valid sentences found for sync-back", "warning")
+        return redirect(url_for("sync_sentence_release.export"))
+
+    updated_count = 0
+    for guid in selected_guids:
+        sentence = db_by_guid.get(guid)
+        if not sentence:
+            continue
+
+        new_record = _sentence_to_release_record(sentence)
+        release_file = _find_release_file_for_sentence(release_dir, guid)
+
+        # If no existing file is found (unexpected for sync-back), append via export category.
+        if not release_file:
+            category = _resolve_primary_lemma_category(sentence)
+            dir_name = _TYPE_TO_DIR.get(category[0], category[0])
+            category_dir = release_dir / dir_name / category[1]
+            category_dir.mkdir(parents=True, exist_ok=True)
+            release_file = category_dir / "base.jsonl"
+
+        existing_records: List[Dict[str, Any]] = []
+        replaced = False
+        if release_file.exists():
+            with open(release_file, "r", encoding="utf-8") as source_file:
+                for line in source_file:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    try:
+                        data = json.loads(stripped)
+                    except json.JSONDecodeError:
+                        continue
+                    existing_guid = data.get("guid")
+                    if existing_guid == guid:
+                        existing_records.append(new_record)
+                        replaced = True
+                    else:
+                        existing_records.append(data)
+        if not replaced:
+            existing_records.append(new_record)
+
+        existing_records.sort(key=lambda record: record.get("guid", ""))
+        _write_jsonl_atomic(release_file, existing_records)
+        updated_count += 1
+
+    log_operation(
+        session=g.db,
+        source="sync-release",
+        operation_type="sentence_sync_back",
+        details={"updated_count": updated_count, "selected_guids": selected_guids},
+    )
+    g.db.commit()
+
+    flash(f"Synced {updated_count} sentence(s) from SQLite to release files", "success")
     return redirect(url_for("sync_sentence_release.export"))

--- a/src/barsukas/routes/sync_sentence_release.py
+++ b/src/barsukas/routes/sync_sentence_release.py
@@ -24,6 +24,7 @@ from storage.models.schema import (
     Sentence,
     SentencePatternWord,
     SentenceTranslation,
+    SentenceWord,
 )
 from storage.translation_helpers import (
     LANGUAGE_HIERARCHY,
@@ -1487,6 +1488,50 @@ def _normalize_release_sentence_for_compare(release_data: Dict[str, Any]) -> Dic
             )
         normalized["pattern_words"] = normalized_words
 
+    words = release_data.get("words", [])
+    if isinstance(words, list) and words:
+        normalized_words_data: List[Dict[str, Any]] = []
+        sorted_sentence_words = sorted(
+            words, key=lambda item: (item.get("language_code", ""), item.get("position", 0))
+        )
+        for word_data in sorted_sentence_words:
+            normalized_words_data.append(
+                {
+                    "language_code": word_data.get("language_code"),
+                    "position": word_data.get("position", 0),
+                    "word_role": word_data.get("word_role"),
+                    "lemma_guid": word_data.get("lemma_guid"),
+                    "english_text": word_data.get("english_text"),
+                    "target_language_text": word_data.get("target_language_text"),
+                    "grammatical_form": word_data.get("grammatical_form"),
+                    "grammatical_case": word_data.get("grammatical_case"),
+                    "declined_form": word_data.get("declined_form"),
+                }
+            )
+        normalized["words"] = normalized_words_data
+
+    audio = release_data.get("audio", [])
+    if isinstance(audio, list) and audio:
+        normalized_audio_data: List[Dict[str, Any]] = []
+        sorted_audio = sorted(
+            audio, key=lambda item: (item.get("language_code", ""), item.get("voice_name", ""))
+        )
+        for audio_data in sorted_audio:
+            normalized_audio_data.append(
+                {
+                    "language_code": audio_data.get("language_code"),
+                    "voice_name": audio_data.get("voice_name"),
+                    "filename": audio_data.get("filename"),
+                    "status": audio_data.get("status"),
+                    "expected_text": audio_data.get("expected_text"),
+                    "manifest_md5": audio_data.get("manifest_md5"),
+                    "s3_prod_url": audio_data.get("s3_prod_url"),
+                    "s3_staging_url": audio_data.get("s3_staging_url"),
+                    "staging_agent": audio_data.get("staging_agent"),
+                }
+            )
+        normalized["audio"] = normalized_audio_data
+
     return normalized
 
 
@@ -1511,6 +1556,8 @@ def _find_sync_back_candidates(
             .options(
                 selectinload(Sentence.translations),
                 selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+                selectinload(Sentence.words).selectinload(SentenceWord.lemma),
+                selectinload(Sentence.audio_reviews),
             )
             .all()
         )
@@ -1588,6 +1635,8 @@ def apply_export() -> ResponseReturnValue:
         .options(
             selectinload(Sentence.translations),
             selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+            selectinload(Sentence.words).selectinload(SentenceWord.lemma),
+            selectinload(Sentence.audio_reviews),
         )
         .all()
     )
@@ -1697,6 +1746,8 @@ def apply_export_sync_back() -> ResponseReturnValue:
         .options(
             selectinload(Sentence.translations),
             selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+            selectinload(Sentence.words).selectinload(SentenceWord.lemma),
+            selectinload(Sentence.audio_reviews),
         )
         .all()
     )

--- a/src/barsukas/templates/sync_sentence_release/export.html
+++ b/src/barsukas/templates/sync_sentence_release/export.html
@@ -17,6 +17,15 @@
                 {{ STRINGS.sync.sentences_removals_desc|safe }}
                 Conversation sentences are excluded.
             </p>
+            <div class="alert alert-info mt-3 mb-0">
+                <i class="bi bi-info-circle"></i>
+                Want to remove database-only sentences instead of exporting them?
+                Use
+                <a href="{{ url_for('sync_sentence_release.removals') }}" class="alert-link">
+                    Removals
+                </a>
+                to delete those SQLite records.
+            </div>
         </div>
     </div>
 

--- a/src/barsukas/templates/sync_sentence_release/export.html
+++ b/src/barsukas/templates/sync_sentence_release/export.html
@@ -20,22 +20,24 @@
         </div>
     </div>
 
-    {% if not exportable %}
+    {% if not exportable and not sync_back_candidates %}
     <div class="alert alert-success">
-        <i class="bi bi-check-circle"></i> {{ STRINGS.sync.no_sentences_to_export }}
+        <i class="bi bi-check-circle"></i> No sentence export or sync-back work found.
     </div>
     <a href="{{ url_for('sync_sentence_release.index') }}" class="btn btn-secondary">
         <i class="bi bi-arrow-left"></i> Back
     </a>
-    {% else %}
+    {% endif %}
+
+    {% if exportable %}
     <div class="card">
         <div class="card-header d-flex justify-content-between align-items-center">
             <span><i class="bi bi-list-check"></i> Exportable Sentences: {{ exportable|length }}</span>
             <div>
-                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleAll(false)">
+                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleAll('export-checkbox', 'export-select-all-checkbox', false)">
                     {{ STRINGS.sync.deselect_all }}
                 </button>
-                <button type="button" class="btn btn-sm btn-outline-primary" onclick="toggleAll(true)">
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="toggleAll('export-checkbox', 'export-select-all-checkbox', true)">
                     {{ STRINGS.sync.select_all }}
                 </button>
             </div>
@@ -47,7 +49,7 @@
                         <thead class="table-light">
                             <tr>
                                 <th style="width: 40px;">
-                                    <input type="checkbox" id="select-all-checkbox" onchange="toggleAll(this.checked)">
+                                    <input type="checkbox" id="export-select-all-checkbox" onchange="toggleAll('export-checkbox', 'export-select-all-checkbox', this.checked)">
                                 </th>
                                 <th>{{ STRINGS.sync.guid }}</th>
                                 <th>English Text</th>
@@ -59,7 +61,7 @@
                             {% for item in exportable %}
                             <tr>
                                 <td>
-                                    <input type="checkbox" class="item-checkbox" name="selected_guids" value="{{ item.guid }}">
+                                    <input type="checkbox" class="export-checkbox" name="selected_guids" value="{{ item.guid }}">
                                 </td>
                                 <td><code>{{ item.guid }}</code></td>
                                 <td>{{ item.english_text }}</td>
@@ -93,14 +95,88 @@
         </div>
     </div>
     {% endif %}
+
+    {% if sync_back_candidates %}
+    <div class="card mt-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span><i class="bi bi-arrow-up-circle"></i> Sync Back to Release: {{ sync_back_candidates|length }}</span>
+            <div>
+                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="toggleAll('sync-back-checkbox', 'sync-back-select-all-checkbox', false)">
+                    {{ STRINGS.sync.deselect_all }}
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="toggleAll('sync-back-checkbox', 'sync-back-select-all-checkbox', true)">
+                    {{ STRINGS.sync.select_all }}
+                </button>
+            </div>
+        </div>
+        <div class="card-body">
+            <p class="text-muted">
+                These sentences exist in both SQLite and <code>data/release/sentences</code>, but the release record differs.
+                Use this to overwrite release records with the canonical SQLite sentence data.
+            </p>
+            <form method="post" action="{{ url_for('sync_sentence_release.apply_export_sync_back') }}">
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover">
+                        <thead class="table-light">
+                            <tr>
+                                <th style="width: 40px;">
+                                    <input type="checkbox" id="sync-back-select-all-checkbox" onchange="toggleAll('sync-back-checkbox', 'sync-back-select-all-checkbox', this.checked)">
+                                </th>
+                                <th>{{ STRINGS.sync.guid }}</th>
+                                <th>English Text</th>
+                                <th>Pattern</th>
+                                <th class="text-center">Level</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for item in sync_back_candidates %}
+                            <tr>
+                                <td>
+                                    <input type="checkbox" class="sync-back-checkbox" name="selected_guids" value="{{ item.guid }}">
+                                </td>
+                                <td><code>{{ item.guid }}</code></td>
+                                <td>{{ item.english_text }}</td>
+                                <td>
+                                    {% if item.pattern_type %}
+                                    <span class="badge bg-secondary">{{ item.pattern_type }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-center">
+                                    {% if item.minimum_level is none %}
+                                    <span class="badge bg-warning text-dark">None</span>
+                                    {% else %}
+                                    <span class="badge bg-primary">{{ item.minimum_level }}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center mt-3">
+                    <a href="{{ url_for('sync_sentence_release.index') }}" class="btn btn-secondary">
+                        <i class="bi bi-arrow-left"></i> Back
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-arrow-up-circle"></i> Sync Back Selected
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+    {% endif %}
 </div>
 
 <script>
-function toggleAll(checked) {
-    document.querySelectorAll('.item-checkbox').forEach(function(checkbox) {
+function toggleAll(checkboxClass, selectAllId, checked) {
+    document.querySelectorAll('.' + checkboxClass).forEach(function(checkbox) {
         checkbox.checked = checked;
     });
-    document.getElementById('select-all-checkbox').checked = checked;
+    var selectAll = document.getElementById(selectAllId);
+    if (selectAll) {
+        selectAll.checked = checked;
+    }
 }
 </script>
 {% endblock %}

--- a/src/barsukas/templates/sync_sentence_release/removals.html
+++ b/src/barsukas/templates/sync_sentence_release/removals.html
@@ -17,6 +17,15 @@
                 {{ STRINGS.sync.sentences_removals_desc|safe }}
                 Conversation sentences are excluded.
             </p>
+            <div class="alert alert-info mt-3 mb-0">
+                <i class="bi bi-info-circle"></i>
+                Want to keep these sentences in SQLite and write them to release files instead?
+                Use
+                <a href="{{ url_for('sync_sentence_release.export') }}" class="alert-link">
+                    Export / Sync Back
+                </a>
+                rather than deleting them here.
+            </div>
         </div>
     </div>
 

--- a/src/storage/migrate.py
+++ b/src/storage/migrate.py
@@ -596,6 +596,7 @@ def export_sqlite_to_sentence_release(sqlite_path: str, release_dir: str) -> Non
         Lemma,
         Sentence,
         SentencePatternWord,
+        SentenceWord,
     )
 
     session = create_database_session(sqlite_path)
@@ -627,6 +628,8 @@ def export_sqlite_to_sentence_release(sqlite_path: str, release_dir: str) -> Non
             .options(
                 selectinload(Sentence.translations),
                 selectinload(Sentence.pattern_words).selectinload(SentencePatternWord.lemma),
+                selectinload(Sentence.words).selectinload(SentenceWord.lemma),
+                selectinload(Sentence.audio_reviews),
             )
             .order_by(Sentence.guid)
             .all()
@@ -729,6 +732,50 @@ def _sentence_to_release_record(sentence: Any) -> Dict[str, Any]:
         record["pattern_words"] = pattern_words
     if sentence.notes:
         record["notes"] = sentence.notes
+
+    words: List[Dict[str, Any]] = []
+    for sentence_word in sorted(
+        sentence.words, key=lambda current_word: (current_word.language_code, current_word.position)
+    ):
+        lemma_guid = (
+            sentence_word.lemma.guid if sentence_word.lemma and sentence_word.lemma.guid else None
+        )
+        words.append(
+            {
+                "language_code": sentence_word.language_code,
+                "position": sentence_word.position,
+                "word_role": sentence_word.word_role,
+                "lemma_guid": lemma_guid,
+                "english_text": sentence_word.english_text,
+                "target_language_text": sentence_word.target_language_text,
+                "grammatical_form": sentence_word.grammatical_form,
+                "grammatical_case": sentence_word.grammatical_case,
+                "declined_form": sentence_word.declined_form,
+            }
+        )
+    if words:
+        record["words"] = words
+
+    audio: List[Dict[str, Any]] = []
+    for audio_review in sorted(
+        sentence.audio_reviews,
+        key=lambda current_audio: (current_audio.language_code, current_audio.voice_name),
+    ):
+        audio.append(
+            {
+                "language_code": audio_review.language_code,
+                "voice_name": audio_review.voice_name,
+                "filename": audio_review.filename,
+                "status": audio_review.status,
+                "expected_text": audio_review.expected_text,
+                "manifest_md5": audio_review.manifest_md5,
+                "s3_prod_url": audio_review.s3_prod_url,
+                "s3_staging_url": audio_review.s3_staging_url,
+                "staging_agent": audio_review.staging_agent,
+            }
+        )
+    if audio:
+        record["audio"] = audio
 
     return record
 

--- a/src/storage/models/schema.py
+++ b/src/storage/models/schema.py
@@ -323,6 +323,7 @@ class Sentence(Base):
     pattern_words = relationship(
         "SentencePatternWord", back_populates="sentence", cascade="all, delete-orphan"
     )
+    audio_reviews = relationship("AudioQualityReview", back_populates="sentence")
     conversation_sentences = relationship("ConversationSentence", back_populates="sentence")
 
 
@@ -620,7 +621,7 @@ class AudioQualityReview(Base):
 
     # Relationships
     lemma = relationship("Lemma")
-    sentence = relationship("Sentence")
+    sentence = relationship("Sentence", back_populates="audio_reviews")
 
     @hybrid_property
     def display_voice(self) -> str:


### PR DESCRIPTION
### Motivation
- Provide a way to push canonical sentence records from the SQLite DB back into the `data/release/sentences` JSONL files when release records are out of sync with the DB.
- Keep conversation sentences excluded and preserve existing export/import UI and workflows while adding a clear, atomic sync-back flow.

### Description
- Added normalization helpers to compare release JSONL sentence records with the DB canonical export by introducing `_normalize_release_sentence_for_compare` and `_find_sync_back_candidates` in `src/barsukas/routes/sync_sentence_release.py`.
- Implemented a new POST route `@bp.route("/export/sync-back", methods=["POST"])` (`apply_export_sync_back`) that overwrites or appends release JSONL sentence records using `_sentence_to_release_record(...)` and atomic writes via `_write_jsonl_atomic`.
- Updated the Export UI `src/barsukas/templates/sync_sentence_release/export.html` to show two sections: DB-only exportable sentences and a new "Sync Back to Release" table for mismatched GUIDs, with independent select-all controls and a shared JS helper `toggleAll`.
- Limited sync-back logic to release languages via importing `RELEASE_LANGUAGES`, preserved conversation exclusion, and logged operations with `log_operation` for auditability.

### Testing
- Ran formatting with `PYTHONPATH=src black src/barsukas/routes/sync_sentence_release.py`, which reformatted the file successfully.
- Ran static type checks with `PYTHONPATH=src mypy src/barsukas/routes/sync_sentence_release.py`, which reported no issues.
- No unit tests were added or modified in this change; manual UI verification is recommended per Barsukas guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb46c6f1083279d2271f47f27e76e)