### PR TITLE
Implement CSTR accessor pipeline and migrate IPA intro block

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -18,8 +18,10 @@ from typing import Any, Callable, Dict, Optional, cast
 from barsukas.config import Config
 from barsukas.helpers.strings import (
     SUPPORTED_UI_LANGS,
+    create_cstr_accessor,
     create_lstr_accessor,
     create_sstr_accessor,
+    load_all_barsukas_cstr_strings,
     load_all_barsukas_strings,
 )
 from barsukas.helpers.ui_language import (
@@ -426,9 +428,11 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
         """Add utility values to Jinja templates."""
         ui_lang = getattr(g, "ui_lang", "en")
         strings_by_namespace = load_all_barsukas_strings(ui_lang)
+        cstr_by_namespace = load_all_barsukas_cstr_strings(ui_lang)
         default_module = getattr(g, "strings_default_module", "common")
         lstr = create_lstr_accessor(strings_by_namespace, default_module=default_module)
         sstr = create_sstr_accessor(strings_by_namespace, default_module=default_module)
+        cstr = create_cstr_accessor(cstr_by_namespace, default_module=default_module)
 
         return {
             "config": app.config,
@@ -437,6 +441,7 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
             "STRINGS": strings_by_namespace,
             "LSTR": lstr,
             "SSTR": sstr,
+            "CSTR": cstr,
         }
 
     return app

--- a/src/barsukas/helpers/strings.py
+++ b/src/barsukas/helpers/strings.py
@@ -5,8 +5,10 @@
 from strings.barsukas_helpers import (
     SUPPORTED_UI_LANGS,
     StringAccessor,
+    create_cstr_accessor,
     create_lstr_accessor,
     create_sstr_accessor,
+    load_all_barsukas_cstr_strings,
     load_all_barsukas_strings,
     load_barsukas_strings,
 )
@@ -14,8 +16,10 @@ from strings.barsukas_helpers import (
 __all__ = [
     "SUPPORTED_UI_LANGS",
     "StringAccessor",
+    "create_cstr_accessor",
     "create_lstr_accessor",
     "create_sstr_accessor",
+    "load_all_barsukas_cstr_strings",
     "load_all_barsukas_strings",
     "load_barsukas_strings",
 ]

--- a/src/barsukas/templates/ipa_reference.html
+++ b/src/barsukas/templates/ipa_reference.html
@@ -25,14 +25,7 @@
                 <i class="bi bi-soundwave"></i> {{ STRINGS.ipa.page_title }}
             </div>
             <div class="card-body">
-                <p class="mb-3">
-                    {{ STRINGS.ipa.intro_line_1 }}
-                    {{ STRINGS.ipa.intro_line_2 }}
-                </p>
-                <p class="text-muted mb-0">
-                    {{ STRINGS.ipa.intro_line_3 }}
-                    {{ STRINGS.ipa.intro_line_4 }}
-                </p>
+                {{ CSTR.ipa.intro_block | safe }}
             </div>
         </div>
     </div>

--- a/src/strings/barsukas_helpers.py
+++ b/src/strings/barsukas_helpers.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional, Sequence, cast
 
 SUPPORTED_UI_LANGS = frozenset({"en", "lt"})
 _STRINGS_ROOT = Path(__file__).resolve().parents[2] / "strings" / "barsukas"
+_CSTR_ROOT = _STRINGS_ROOT / "cstr"
 _LEGACY_NAMESPACE_ALIASES = {
     "linguistics": "common.linguistics",
     "parts_of_speech": "common.linguistics",
@@ -18,6 +19,10 @@ _LEGACY_NAMESPACE_ALIASES = {
 
 def _namespace_path_from_string(namespace: str) -> Path:
     return _STRINGS_ROOT.joinpath(*namespace.split("."))
+
+
+def _cstr_namespace_path_from_string(namespace: str) -> Path:
+    return _CSTR_ROOT.joinpath(*namespace.split("."))
 
 
 def _discover_namespaces() -> list[str]:
@@ -34,6 +39,22 @@ def _discover_namespaces() -> list[str]:
     return sorted(namespace_set)
 
 
+def _discover_cstr_namespaces() -> list[str]:
+    namespace_set: set[str] = set()
+    if not _CSTR_ROOT.exists():
+        return []
+    for json_path in _CSTR_ROOT.rglob("en.json"):
+        namespace_dir = json_path.parent
+        try:
+            relative_parts = namespace_dir.relative_to(_CSTR_ROOT).parts
+        except ValueError:
+            continue
+        if not relative_parts:
+            continue
+        namespace_set.add(".".join(relative_parts))
+    return sorted(namespace_set)
+
+
 @lru_cache(maxsize=64)
 def _load_namespace_file(namespace: str, ui_lang: str) -> Dict[str, Any]:
     """Load one namespace JSON file with English fallback."""
@@ -41,6 +62,29 @@ def _load_namespace_file(namespace: str, ui_lang: str) -> Dict[str, Any]:
         ui_lang = "en"
 
     namespace_root = _namespace_path_from_string(namespace)
+    namespace_path = namespace_root / f"{ui_lang}.json"
+    fallback_path = namespace_root / "en.json"
+
+    if namespace_path.exists():
+        with namespace_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+            return cast(Dict[str, Any], loaded)
+
+    if fallback_path.exists():
+        with fallback_path.open("r", encoding="utf-8") as handle:
+            loaded = json.load(handle)
+            return cast(Dict[str, Any], loaded)
+
+    return {}
+
+
+@lru_cache(maxsize=64)
+def _load_cstr_namespace_file(namespace: str, ui_lang: str) -> Dict[str, Any]:
+    """Load one CSTR namespace JSON file with English fallback."""
+    if ui_lang not in SUPPORTED_UI_LANGS:
+        ui_lang = "en"
+
+    namespace_root = _cstr_namespace_path_from_string(namespace)
     namespace_path = namespace_root / f"{ui_lang}.json"
     fallback_path = namespace_root / "en.json"
 
@@ -93,6 +137,19 @@ def load_all_barsukas_strings(ui_lang: str) -> Dict[str, Dict[str, Any]]:
     return strings_by_namespace
 
 
+@lru_cache(maxsize=8)
+def load_all_barsukas_cstr_strings(ui_lang: str) -> Dict[str, Dict[str, Any]]:
+    """Load all Barsukas CSTR namespaces for a UI language."""
+    if ui_lang not in SUPPORTED_UI_LANGS:
+        ui_lang = "en"
+
+    namespaces = _discover_cstr_namespaces()
+    return {
+        namespace: _load_cstr_namespace_file(namespace=namespace, ui_lang=ui_lang)
+        for namespace in namespaces
+    }
+
+
 class _StringPathNode:
     """Lazy accessor object used by Jinja for LSTR/SSTR paths."""
 
@@ -118,7 +175,7 @@ class _StringPathNode:
 
 
 class StringAccessor:
-    """Template accessor for legacy STRINGS namespaces and new LSTR/SSTR paths."""
+    """Template accessor for legacy STRINGS namespaces and new LSTR/SSTR/CSTR paths."""
 
     def __init__(
         self,
@@ -141,6 +198,7 @@ class StringAccessor:
         Modes:
         - lstr: default shared namespace with CURRENT/OTHER support.
         - sstr: explicit namespace required (first segment).
+        - cstr: explicit namespace required (first segment).
         """
         if not segments:
             return default
@@ -149,6 +207,9 @@ class StringAccessor:
             return self._resolve_lstr(segments, default=default)
 
         if self._mode == "sstr":
+            return self._resolve_sstr(segments, default=default)
+
+        if self._mode == "cstr":
             return self._resolve_sstr(segments, default=default)
 
         return default
@@ -200,3 +261,10 @@ def create_sstr_accessor(
 ) -> StringAccessor:
     """Create accessor for sentence strings (SSTR)."""
     return StringAccessor(strings_by_namespace, mode="sstr", default_module=default_module)
+
+
+def create_cstr_accessor(
+    strings_by_namespace: Dict[str, Dict[str, Any]], default_module: str
+) -> StringAccessor:
+    """Create accessor for long multi-sentence block strings (CSTR)."""
+    return StringAccessor(strings_by_namespace, mode="cstr", default_module=default_module)

--- a/src/strings/count_barsukas_pending_strings.py
+++ b/src/strings/count_barsukas_pending_strings.py
@@ -5,10 +5,18 @@ from strings.generate_barsukas_strings import compute_plan
 
 
 def main() -> int:
-    template_plans, catalog_state, _stats = compute_plan()
+    (
+        template_plans,
+        standard_catalog_state,
+        cstr_catalog_state,
+        _standard_stats,
+        _cstr_stats,
+    ) = compute_plan()
     pending = sum(len(items) for items in template_plans.values())
     print(pending)
-    has_new_keys = any(catalog_state.new_keys.values())
+    has_new_keys = any(standard_catalog_state.new_keys.values()) or any(
+        cstr_catalog_state.new_keys.values()
+    )
     return 1 if pending > 0 or has_new_keys else 0
 
 

--- a/src/strings/generate_barsukas_strings.py
+++ b/src/strings/generate_barsukas_strings.py
@@ -11,11 +11,12 @@ import re
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Literal
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATES_ROOT = REPO_ROOT / "src" / "barsukas" / "templates"
 STRINGS_ROOT = REPO_ROOT / "strings" / "barsukas"
+CSTR_STRINGS_ROOT = STRINGS_ROOT / "cstr"
 ATTRIBUTE_ALLOWLIST = {
     "title",
     "placeholder",
@@ -33,6 +34,8 @@ ENTITY_PATTERN = re.compile(r"^(?:&[a-zA-Z]+;|&#\d+;|&#x[0-9a-fA-F]+;)+$")
 JINJA_OR_COMMENT_PATTERN = re.compile(r"<!--.*?-->|\{\{.*?\}\}|\{\%.*?\%\}|\{\#.*?\#\}", re.DOTALL)
 TAG_PATTERN = re.compile(r"<[^>]+>", re.DOTALL)
 ATTRIBUTE_PATTERN = re.compile(r"([:\w-]+)\s*=\s*([\"'])(.*?)\2", re.DOTALL)
+SENTENCE_END_PATTERN = re.compile(r"[.!?](?:\s|$)")
+AccessorName = Literal["STRINGS", "CSTR"]
 
 
 @dataclass(frozen=True)
@@ -49,6 +52,7 @@ class Replacement:
     original_text: str
     namespace: str
     string_key: str
+    accessor_name: AccessorName
 
 
 @dataclass
@@ -59,8 +63,9 @@ class CatalogUpdateStats:
 
 
 class CatalogState:
-    def __init__(self, strings_root: Path) -> None:
+    def __init__(self, strings_root: Path, allow_common_reuse: bool = True) -> None:
         self.strings_root = strings_root
+        self.allow_common_reuse = allow_common_reuse
         self.catalogs: dict[str, dict[str, str]] = {}
         self.reverse_lookup: dict[str, list[tuple[str, str]]] = {}
         self.new_keys: dict[str, set[str]] = {}
@@ -106,10 +111,13 @@ class CatalogState:
     ) -> tuple[str, str]:
         existing_locations = self.reverse_lookup.get(normalized_text, [])
         if existing_locations:
-            common_match = next((item for item in existing_locations if item[0] == "common"), None)
-            if common_match is not None:
-                stats.reused_common_count += 1
-                return common_match
+            if self.allow_common_reuse:
+                common_match = next(
+                    (item for item in existing_locations if item[0] == "common"), None
+                )
+                if common_match is not None:
+                    stats.reused_common_count += 1
+                    return common_match
             return sorted(existing_locations)[0]
 
         namespace = preferred_namespace
@@ -178,6 +186,11 @@ def should_ignore_text(normalized_text: str) -> bool:
     if normalized_text.replace("bi", "").replace("-", "").strip() == "":
         return True
     return False
+
+
+def is_multi_sentence_block(text: str) -> bool:
+    sentence_count = len(SENTENCE_END_PATTERN.findall(text))
+    return sentence_count >= 2
 
 
 def get_template_namespace(template_path: Path) -> str:
@@ -268,8 +281,10 @@ def build_text_replacement(
     content: str,
     span: Span,
     namespace: str,
-    catalog_state: CatalogState,
-    stats: CatalogUpdateStats,
+    standard_catalog_state: CatalogState,
+    cstr_catalog_state: CatalogState,
+    standard_stats: CatalogUpdateStats,
+    cstr_stats: CatalogUpdateStats,
 ) -> Replacement | None:
     original_segment = content[span.start : span.end]
     trimmed = original_segment.strip()
@@ -284,13 +299,21 @@ def build_text_replacement(
         original_segment[len(original_segment) - trailing_length :] if trailing_length else ""
     )
 
-    selected_namespace, selected_key = catalog_state.resolve_or_create_key(
+    replacement_accessor: AccessorName = "STRINGS"
+    selected_catalog_state = standard_catalog_state
+    selected_stats = standard_stats
+    if is_multi_sentence_block(trimmed):
+        replacement_accessor = "CSTR"
+        selected_catalog_state = cstr_catalog_state
+        selected_stats = cstr_stats
+
+    selected_namespace, selected_key = selected_catalog_state.resolve_or_create_key(
         normalized_text=normalized,
         original_text=trimmed,
         preferred_namespace=namespace,
-        stats=stats,
+        stats=selected_stats,
     )
-    expression = f"{{{{ STRINGS.{selected_namespace}.{selected_key} }}}}"
+    expression = f"{{{{ {replacement_accessor}.{selected_namespace}.{selected_key} }}}}"
     return Replacement(
         start=span.start,
         end=span.end,
@@ -298,13 +321,16 @@ def build_text_replacement(
         original_text=trimmed,
         namespace=selected_namespace,
         string_key=selected_key,
+        accessor_name=replacement_accessor,
     )
 
 
 def plan_template_replacements(
     template_path: Path,
-    catalog_state: CatalogState,
-    stats: CatalogUpdateStats,
+    standard_catalog_state: CatalogState,
+    cstr_catalog_state: CatalogState,
+    standard_stats: CatalogUpdateStats,
+    cstr_stats: CatalogUpdateStats,
 ) -> list[Replacement]:
     content = template_path.read_text(encoding="utf-8")
     protected_spans = find_protected_spans(content)
@@ -331,11 +357,11 @@ def plan_template_replacements(
                 continue
             value_start = tag_match.start() + attr_match.start(3)
             value_end = tag_match.start() + attr_match.end(3)
-            selected_namespace, selected_key = catalog_state.resolve_or_create_key(
+            selected_namespace, selected_key = standard_catalog_state.resolve_or_create_key(
                 normalized_text=normalized,
                 original_text=attribute_value.strip(),
                 preferred_namespace=namespace,
-                stats=stats,
+                stats=standard_stats,
             )
             planned.append(
                 Replacement(
@@ -345,6 +371,7 @@ def plan_template_replacements(
                     original_text=attribute_value.strip(),
                     namespace=selected_namespace,
                     string_key=selected_key,
+                    accessor_name="STRINGS",
                 )
             )
 
@@ -355,8 +382,10 @@ def plan_template_replacements(
                 content=content,
                 span=piece,
                 namespace=namespace,
-                catalog_state=catalog_state,
-                stats=stats,
+                standard_catalog_state=standard_catalog_state,
+                cstr_catalog_state=cstr_catalog_state,
+                standard_stats=standard_stats,
+                cstr_stats=cstr_stats,
             )
             if replacement is not None:
                 planned.append(replacement)
@@ -376,15 +405,29 @@ def apply_replacements(content: str, replacements: Iterable[Replacement]) -> str
     return updated
 
 
-def compute_plan() -> tuple[dict[Path, list[Replacement]], CatalogState, CatalogUpdateStats]:
-    catalog_state = CatalogState(STRINGS_ROOT)
-    stats = CatalogUpdateStats()
+def compute_plan() -> tuple[
+    dict[Path, list[Replacement]],
+    CatalogState,
+    CatalogState,
+    CatalogUpdateStats,
+    CatalogUpdateStats,
+]:
+    standard_catalog_state = CatalogState(STRINGS_ROOT)
+    cstr_catalog_state = CatalogState(CSTR_STRINGS_ROOT, allow_common_reuse=False)
+    standard_stats = CatalogUpdateStats()
+    cstr_stats = CatalogUpdateStats()
     template_plans: dict[Path, list[Replacement]] = {}
     for template_path in sorted(TEMPLATES_ROOT.rglob("*.html")):
-        replacements = plan_template_replacements(template_path, catalog_state, stats)
+        replacements = plan_template_replacements(
+            template_path,
+            standard_catalog_state,
+            cstr_catalog_state,
+            standard_stats,
+            cstr_stats,
+        )
         if replacements:
             template_plans[template_path] = replacements
-    return (template_plans, catalog_state, stats)
+    return (template_plans, standard_catalog_state, cstr_catalog_state, standard_stats, cstr_stats)
 
 
 def parse_args() -> argparse.Namespace:
@@ -406,10 +449,20 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     arguments = parse_args()
-    template_plans, catalog_state, stats = compute_plan()
+    (
+        template_plans,
+        standard_catalog_state,
+        cstr_catalog_state,
+        standard_stats,
+        cstr_stats,
+    ) = compute_plan()
 
     replacement_total = sum(len(items) for items in template_plans.values())
-    change_needed = bool(template_plans or any(catalog_state.new_keys.values()))
+    change_needed = bool(
+        template_plans
+        or any(standard_catalog_state.new_keys.values())
+        or any(cstr_catalog_state.new_keys.values())
+    )
 
     if arguments.count:
         print(replacement_total)
@@ -420,26 +473,33 @@ def main() -> int:
         print(f"{relative_template}: {len(replacements)} replacement(s)")
         for replacement in replacements:
             print(
-                f"  - '{replacement.original_text}' -> STRINGS.{replacement.namespace}.{replacement.string_key}"
+                f"  - '{replacement.original_text}' -> "
+                f"{replacement.accessor_name}.{replacement.namespace}.{replacement.string_key}"
             )
 
-    for namespace, keys in sorted(catalog_state.new_keys.items()):
+    for namespace, keys in sorted(standard_catalog_state.new_keys.items()):
         if keys:
             print(f"new keys [{namespace}]: {', '.join(sorted(keys))}")
+    for namespace, keys in sorted(cstr_catalog_state.new_keys.items()):
+        if keys:
+            print(f"new CSTR keys [{namespace}]: {', '.join(sorted(keys))}")
 
     print("summary:")
     print(f"  templates changed: {len(template_plans)}")
     print(f"  total replacements: {replacement_total}")
-    print(f"  reused common: {stats.reused_common_count}")
-    print(f"  new keys: {stats.new_key_count}")
-    print(f"  collisions resolved: {stats.collisions_resolved}")
+    print(f"  reused common (STRINGS): {standard_stats.reused_common_count}")
+    print(f"  new keys (STRINGS): {standard_stats.new_key_count}")
+    print(f"  collisions resolved (STRINGS): {standard_stats.collisions_resolved}")
+    print(f"  new keys (CSTR): {cstr_stats.new_key_count}")
+    print(f"  collisions resolved (CSTR): {cstr_stats.collisions_resolved}")
 
     if arguments.write and change_needed:
         for template_path, replacements in template_plans.items():
             original_content = template_path.read_text(encoding="utf-8")
             updated_content = apply_replacements(original_content, replacements)
             template_path.write_text(updated_content, encoding="utf-8")
-        catalog_state.write()
+        standard_catalog_state.write()
+        cstr_catalog_state.write()
 
     if arguments.check and change_needed:
         return 1

--- a/src/tests/barsukas/helpers/test_strings.py
+++ b/src/tests/barsukas/helpers/test_strings.py
@@ -3,7 +3,11 @@
 from markupsafe import escape
 
 from barsukas.helpers.strings import SUPPORTED_UI_LANGS
-from strings.barsukas_helpers import create_lstr_accessor, create_sstr_accessor
+from strings.barsukas_helpers import (
+    create_cstr_accessor,
+    create_lstr_accessor,
+    create_sstr_accessor,
+)
 
 
 def test_lstr_resolves_common_default_path() -> None:
@@ -36,6 +40,16 @@ def test_sstr_requires_namespace() -> None:
 
     assert str(sstr.sentences.edit_title) == "Edit sentence"
     assert str(sstr.edit_title) == ""
+
+
+def test_cstr_requires_namespace() -> None:
+    strings_by_namespace = {
+        "ipa": {"intro_block": "<p>Intro block.</p>"},
+    }
+    cstr = create_cstr_accessor(strings_by_namespace, default_module="common")
+
+    assert str(cstr.ipa.intro_block) == "<p>Intro block.</p>"
+    assert str(cstr.intro_block) == ""
 
 
 def test_accessors_do_not_expose_dunder_attributes_to_markupsafe() -> None:

--- a/strings/NAMING.md
+++ b/strings/NAMING.md
@@ -1,6 +1,6 @@
 # Barsukas STRINGS Naming Design (LSTR / SSTR / CSTR, namespace rules)
 
-This is a design-only proposal for clearer string naming.
+This document defines the canonical naming and placement rules for Barsukas string accessors.
 
 ## Primary objective
 
@@ -15,7 +15,7 @@ Make it obvious whether a string is:
 
 - `LSTR` = short strings (single lemma/term/short phrase)
 - `SSTR` = sentence-length strings
-- `CSTR` = 3+ sentence text blocks
+- `CSTR` = multi-sentence text blocks
 
 ---
 
@@ -57,18 +57,23 @@ Examples:
 
 No implicit `common` default for `SSTR`/`CSTR`.
 
+`CSTR` is additionally stored in a separate directory tree:
+
+- `strings/barsukas/cstr/<namespace>/en.json`
+- `strings/barsukas/cstr/<namespace>/lt.json`
+
+`CSTR` content is module/page-local only. Do not place `CSTR` entries in `common`.
+
 ---
 
 ## File/source mapping guidance
-
-This proposal is naming-focused; implementation can map these paths to existing
-JSON files however is most practical. Conceptually:
 
 - `LSTR.<key_path>` resolves to shared/common files first
   - example source idea: `common/linguistics/*.json`
 - `LSTR.CURRENT.*` resolves in-page namespace
 - `LSTR.OTHER.<ns>.*` resolves that explicit namespace
-- `SSTR.<ns>.*` and `CSTR.<ns>.*` resolve directly in namespace `<ns>`
+- `SSTR.<ns>.*` resolves directly in `strings/barsukas/<ns>/*.json`
+- `CSTR.<ns>.*` resolves directly in `strings/barsukas/cstr/<ns>/*.json`
 
 ---
 
@@ -107,6 +112,7 @@ JSON files however is most practical. Conceptually:
 ### Long text blocks
 
 - `CSTR.sync.lemma.release_sync_intro`
+- `CSTR.ipa.intro_block`
 
 ---
 
@@ -120,6 +126,14 @@ JSON files however is most practical. Conceptually:
    - `SSTR`/`CSTR` require explicit namespace
    - disallow new ambiguous keys (`pos`, `ipa`, `sort_alpha`)
 5. Remove compatibility aliases after deprecation window.
+
+### CSTR-specific migration checklist
+
+1. Identify a cluster of sentence keys that always render together.
+2. Replace that cluster with one block key in `strings/barsukas/cstr/<namespace>/*.json`.
+3. Update template usage to `CSTR.<namespace>.<key>`.
+4. Delete the replaced sentence keys from regular namespace files (`strings/barsukas/<namespace>/*.json`).
+5. Keep ownership local to the page/module namespace (no `common` relocation).
 
 ---
 

--- a/strings/README.md
+++ b/strings/README.md
@@ -6,12 +6,15 @@ This repository stores UI translation strings in JSON files under namespaced fol
 
 - `strings/barsukas/<namespace>/en.json`
 - `strings/barsukas/<namespace>/lt.json`
+- `strings/barsukas/cstr/<namespace>/en.json`
+- `strings/barsukas/cstr/<namespace>/lt.json`
 
 Each `<namespace>` groups related keys (for example: `navigation`, `dictionary`, `lemmas`, `rhymes`, `languages`, `common`).
 Nested namespaces are supported using subdirectories, such as:
 
 - `strings/barsukas/common/pagination/en.json` → `common.pagination`
 - `strings/barsukas/common/linguistics/en.json` → `common.linguistics`
+- `strings/barsukas/cstr/ipa/en.json` → `CSTR.ipa.*`
 
 Current convention: keep shared namespaces at two components (for example,
 `common.pagination`, `common.linguistics`).
@@ -85,6 +88,29 @@ Barsukas loads all namespaces into a global `STRINGS` object for templates.
 - New forward-looking accessors are also available:
   - `LSTR` for short labels/terms (with `CURRENT`/`OTHER` support)
   - `SSTR` for sentence-level strings with explicit namespaces
+  - `CSTR` for multi-sentence blocks with explicit namespaces (loaded only from `strings/barsukas/cstr/*`)
+
+Canonical examples:
+
+- `{{ LSTR.linguistics.verb }}`
+- `{{ SSTR.lemmas.no_results }}`
+- `{{ CSTR.ipa.intro_block|safe }}`
+
+`CSTR` has no implicit `common` fallback and must be addressed as `CSTR.<namespace>.<key>`.
+
+## CSTR migration rules
+
+When converting multiple sentence keys into one long block:
+
+1. Create the new key in `strings/barsukas/cstr/<namespace>/{en,lt}.json`.
+2. Keep the key module-local (`<namespace>`), do not move it to `common`.
+3. Update templates to use only `CSTR.<namespace>.<key>` for that block.
+4. Remove the old sentence keys from `strings/barsukas/<namespace>/{en,lt}.json` once migrated.
+
+Example migration (`ipa_reference.html`):
+
+- Before: `intro_line_1` … `intro_line_4` in `strings/barsukas/ipa/*.json`
+- After: `intro_block` in `strings/barsukas/cstr/ipa/*.json` and template call `CSTR.ipa.intro_block`
 
 ## Fallback behavior
 

--- a/strings/barsukas/cstr/ipa/en.json
+++ b/strings/barsukas/cstr/ipa/en.json
@@ -1,0 +1,3 @@
+{
+  "intro_block": "<p class=\"mb-3\">This page is a quick guide for the International Phonetic Alphabet (IPA) symbols shown in Barsukas. Use it when adding or reviewing pronunciation notes.</p><p class=\"text-muted mb-0\">This follows the traditional chart style: consonants are organized by manner × place of articulation, and vowels by height × backness. Hover over symbols for quick details. This guide is static and does not query the database.</p>"
+}

--- a/strings/barsukas/cstr/ipa/lt.json
+++ b/strings/barsukas/cstr/ipa/lt.json
@@ -1,0 +1,3 @@
+{
+  "intro_block": "<p class=\"mb-3\">Šis puslapis yra trumpa Tarptautinės fonetinės abėcėlės (IPA) simbolių, rodomų Barsukas, atmintinė. Naudokite jį pildydami ar tikrindami tarimo pastabas.</p><p class=\"text-muted mb-0\">Laikomasi tradicinio lentelės stiliaus: priebalsiai išdėstyti pagal artikuliacijos būdą × vietą, o balsiai pagal aukštį × užpakališkumą. Užveskite pelę ant simbolių, kad pamatytumėte trumpą paaiškinimą. Ši atmintinė yra statinė ir neklausia duomenų bazės.</p>"
+}

--- a/strings/barsukas/ipa/en.json
+++ b/strings/barsukas/ipa/en.json
@@ -1,9 +1,5 @@
 {
   "page_title": "IPA Reference",
-  "intro_line_1": "This page is a quick guide for the International Phonetic Alphabet (IPA) symbols shown in Barsukas.",
-  "intro_line_2": "Use it when adding or reviewing pronunciation notes.",
-  "intro_line_3": "This follows the traditional chart style: consonants are organized by manner × place of articulation, and vowels by height × backness.",
-  "intro_line_4": "Hover over symbols for quick details. This guide is static and does not query the database.",
   "consonants_title": "Consonants (Pulmonic) — 2D Chart",
   "consonants_manner_place": "Manner \\\\ Place",
   "place_bilabial": "Bilabial",

--- a/strings/barsukas/ipa/lt.json
+++ b/strings/barsukas/ipa/lt.json
@@ -1,9 +1,5 @@
 {
   "page_title": "IPA nuoroda",
-  "intro_line_1": "Šis puslapis yra trumpa Tarptautinės fonetinės abėcėlės (IPA) simbolių, rodomų Barsukas, atmintinė.",
-  "intro_line_2": "Naudokite jį pildydami ar tikrindami tarimo pastabas.",
-  "intro_line_3": "Laikomasi tradicinio lentelės stiliaus: priebalsiai išdėstyti pagal artikuliacijos būdą × vietą, o balsiai pagal aukštį × užpakališkumą.",
-  "intro_line_4": "Užveskite pelę ant simbolių, kad pamatytumėte trumpą paaiškinimą. Ši atmintinė yra statinė ir neklausia duomenų bazės.",
   "consonants_title": "Priebalsiai (pulmoniniai) — 2D lentelė",
   "consonants_manner_place": "Būdas \\\\ Vieta",
   "place_bilabial": "Dvilūpis",


### PR DESCRIPTION
### Motivation
- Add first-class support for long multi-sentence UI blocks (CSTR) so multi-sentence content is stored separately and referenced explicitly. 
- Keep CSTR entries module-local (no implicit `common` fallback) and make the accessor available to templates as `CSTR`.

### Description
- Added a dedicated CSTR strings root and loader: `strings/barsukas/cstr/*` with `load_all_barsukas_cstr_strings` and `_CSTR_ROOT` handling in `src/strings/barsukas_helpers.py`.
- Implemented `create_cstr_accessor` and `StringAccessor` `mode='cstr'` handling (explicit namespace required) and re-exported via `src/barsukas/helpers/strings.py`.
- Injected `CSTR` into the Jinja template context in `src/barsukas/app.py`'s `utility_processor` so templates can use `{{ CSTR.<namespace>.<key> }}`.
- Extended the extractor/generator `src/strings/generate_barsukas_strings.py` to detect multi-sentence blocks, emit `CSTR.<namespace>.<key>` for them, and maintain a separate CSTR catalog (with `allow_common_reuse=False` to prevent implicit `common` reuse).
- Updated `src/strings/count_barsukas_pending_strings.py` and `generate_barsukas_strings.py` `compute_plan()` to handle separate standard vs CSTR catalogs and report/write both.
- Migrated `ipa_reference.html` to use a single CSTR block: template now renders `{{ CSTR.ipa.intro_block | safe }}` and the four old keys were removed from `strings/barsukas/ipa/*.json`; the new block lives in `strings/barsukas/cstr/ipa/{en,lt}.json`.
- Documentation updates: `strings/NAMING.md` and `strings/README.md` include canonical `CSTR` usage and migration guidance.
- Added unit test `test_cstr_requires_namespace` to `src/tests/barsukas/helpers/test_strings.py` to verify `CSTR` accessor behavior.

### Testing
- Ran `black` on modified Python files; formatting applied where needed and completed successfully.
- Ran `PYTHONPATH=src mypy` on the modified files; `mypy` reported no issues.
- Ran `PYTHONPATH=src pytest -q src/tests/barsukas/helpers/test_strings.py`; all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc8868a648327ab54cafb146bb95f)