### PR TITLE
Add GYVATE Barsukas STRINGS export blueprint and service

### DIFF
--- a/src/agents/gyvate/__init__.py
+++ b/src/agents/gyvate/__init__.py
@@ -1,0 +1,5 @@
+"""GYVATE agent package."""
+
+from agents.gyvate.agent import GyvateAgent
+
+__all__ = ["GyvateAgent"]

--- a/src/agents/gyvate/agent.py
+++ b/src/agents/gyvate/agent.py
@@ -21,6 +21,7 @@ class GyvateAgent:
         strings_path: str,
         scopes: list[str],
         target_languages: list[str],
+        uploaded_english_catalogs: dict[str, dict[str, str]],
         write_mode: bool,
     ) -> GyvateServiceResult:
         """Run a STRINGS export operation via the reusable backend service."""
@@ -31,6 +32,7 @@ class GyvateAgent:
             strings_path=strings_path,
             scopes=scopes,
             target_languages=target_languages,
+            uploaded_english_catalogs=uploaded_english_catalogs,
             write_mode=write_mode,
         )
 

--- a/src/agents/gyvate/agent.py
+++ b/src/agents/gyvate/agent.py
@@ -1,0 +1,38 @@
+"""GYVATE agent for STRINGS export planning and generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from storage.backend.config import DataSourceConfig
+from strings.gyvate_service import GyvateServiceResult, GyvateStringsExportService
+
+
+@dataclass
+class GyvateAgent:
+    """Service-backed agent for STRINGS extraction/generation operations."""
+
+    config: DataSourceConfig
+
+    def run_export(
+        self,
+        *,
+        project_root: str,
+        template_path: str,
+        strings_path: str,
+        scopes: list[str],
+        target_languages: list[str],
+        write_mode: bool,
+    ) -> GyvateServiceResult:
+        """Run a STRINGS export operation via the reusable backend service."""
+        service = GyvateStringsExportService(config=self.config)
+        return service.export_strings(
+            project_root=project_root,
+            template_path=template_path,
+            strings_path=strings_path,
+            scopes=scopes,
+            target_languages=target_languages,
+            write_mode=write_mode,
+        )
+
+
+__all__ = ["GyvateAgent", "GyvateServiceResult"]

--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -73,6 +73,7 @@ from barsukas.routes import (
     sentence_stats,
     sentences,
     settings,
+    strings_export,
     sync_derivative_release,
     sync_hub,
     sync_relation_release,
@@ -210,6 +211,7 @@ def create_app(config_class: type[Config] = Config, db_url: Optional[str] = None
     app.register_blueprint(rapid_review.bp)
     app.register_blueprint(rapid_review_hub.bp)
     app.register_blueprint(settings.bp)
+    app.register_blueprint(strings_export.bp)
     app.register_blueprint(pattern_sentences.bp)
     app.register_blueprint(peleda.bp)
     app.register_blueprint(rhymes.bp)

--- a/src/barsukas/routes/strings_export.py
+++ b/src/barsukas/routes/strings_export.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python3
+
+"""Routes for GYVATE STRINGS export functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask.typing import ResponseReturnValue
+
+from agents.gyvate import GyvateAgent
+from storage.backend.config import DataSourceConfig
+
+bp = Blueprint("gyvate", __name__, url_prefix="/gyvate")
+DEFAULT_SCOPES = ["templates"]
+DEFAULT_TARGET_LANGUAGES = ["lt"]
+DEFAULT_TEMPLATE_PATH = "src/barsukas/templates"
+DEFAULT_STRINGS_PATH = "strings/barsukas"
+
+
+def _default_project_root() -> str:
+    return str(Path(__file__).resolve().parents[3])
+
+
+def _get_config() -> DataSourceConfig:
+    app = current_app
+    return app.backend_config  # type: ignore[no-any-return, attr-defined]
+
+
+def _normalize_languages(raw_languages: list[str], csv_languages: str) -> list[str]:
+    merged = set(raw_languages)
+    for csv_value in csv_languages.split(","):
+        normalized = csv_value.strip()
+        if normalized:
+            merged.add(normalized)
+    return sorted(merged)
+
+
+@bp.route("/")
+def export_page() -> ResponseReturnValue:
+    """Display the GYVATE STRINGS export form."""
+    return render_template(
+        "gyvate/export.html",
+        default_project_root=_default_project_root(),
+        default_template_path=DEFAULT_TEMPLATE_PATH,
+        default_strings_path=DEFAULT_STRINGS_PATH,
+        default_scopes=DEFAULT_SCOPES,
+        default_target_languages=DEFAULT_TARGET_LANGUAGES,
+    )
+
+
+@bp.route("/export", methods=["POST"])
+def export_strings() -> ResponseReturnValue:
+    """Run STRINGS extraction/generation via the GYVATE service layer."""
+    selected_scopes = request.form.getlist("scopes")
+    if not selected_scopes:
+        flash("Select at least one scope (templates/modules).", "error")
+        return redirect(url_for("gyvate.export_page"))
+
+    project_root = request.form.get("project_root", _default_project_root()).strip()
+    template_path = request.form.get("template_path", DEFAULT_TEMPLATE_PATH).strip()
+    strings_path = request.form.get("strings_path", DEFAULT_STRINGS_PATH).strip()
+    write_mode = request.form.get("mode", "dry") == "write"
+
+    selected_languages = request.form.getlist("target_languages")
+    language_csv = request.form.get("target_languages_csv", "")
+    target_languages = _normalize_languages(selected_languages, language_csv)
+
+    agent = GyvateAgent(config=_get_config())
+    result = agent.run_export(
+        project_root=project_root,
+        template_path=template_path,
+        strings_path=strings_path,
+        scopes=selected_scopes,
+        target_languages=target_languages,
+        write_mode=write_mode,
+    )
+
+    if not result.success:
+        flash(f"GYVATE export failed: {result.error}", "error")
+        return redirect(url_for("gyvate.export_page"))
+
+    flash(
+        f"GYVATE completed in {result.mode} mode with {result.replacements_total} replacements.",
+        "success",
+    )
+    return render_template("gyvate/results.html", result=result)

--- a/src/barsukas/routes/strings_export.py
+++ b/src/barsukas/routes/strings_export.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+import json
+import zipfile
+from io import BytesIO
 from pathlib import Path
 
 from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
@@ -37,6 +40,58 @@ def _normalize_languages(raw_languages: list[str], csv_languages: str) -> list[s
     return sorted(merged)
 
 
+def _normalize_namespace_from_path(relative_path: str) -> str:
+    normalized_path = relative_path.strip().replace("\\", "/")
+    if normalized_path.endswith("/en.json"):
+        normalized_path = normalized_path[: -len("/en.json")]
+    elif normalized_path.endswith("en.json"):
+        normalized_path = normalized_path[: -len("en.json")]
+
+    namespace = normalized_path.strip("/").replace("/", ".")
+    if not namespace:
+        raise ValueError(f'Could not infer namespace from path "{relative_path}"')
+    return namespace
+
+
+def _parse_uploaded_catalog_json(raw_bytes: bytes, source_name: str) -> dict[str, str]:
+    loaded = json.loads(raw_bytes.decode("utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{source_name} must contain a JSON object")
+    return {str(key_name): str(value_text) for key_name, value_text in loaded.items()}
+
+
+def _load_uploaded_english_catalogs() -> dict[str, dict[str, str]]:
+    uploaded_catalogs: dict[str, dict[str, str]] = {}
+
+    uploaded_files = [
+        entry for entry in request.files.getlist("english_strings_files") if entry.filename
+    ]
+    for uploaded_file in uploaded_files:
+        assert uploaded_file.filename is not None
+        namespace = _normalize_namespace_from_path(uploaded_file.filename)
+        uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
+            uploaded_file.read(),
+            uploaded_file.filename,
+        )
+
+    zip_bundle = request.files.get("english_strings_bundle")
+    if not zip_bundle or not zip_bundle.filename:
+        return uploaded_catalogs
+
+    zip_data = zip_bundle.read()
+    with zipfile.ZipFile(BytesIO(zip_data)) as zip_handle:
+        for entry_name in zip_handle.namelist():
+            if entry_name.endswith("/") or not entry_name.endswith("en.json"):
+                continue
+            namespace = _normalize_namespace_from_path(entry_name)
+            with zip_handle.open(entry_name) as zip_entry:
+                uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
+                    zip_entry.read(),
+                    entry_name,
+                )
+    return uploaded_catalogs
+
+
 @bp.route("/")
 def export_page() -> ResponseReturnValue:
     """Display the GYVATE STRINGS export form."""
@@ -66,6 +121,11 @@ def export_strings() -> ResponseReturnValue:
     selected_languages = request.form.getlist("target_languages")
     language_csv = request.form.get("target_languages_csv", "")
     target_languages = _normalize_languages(selected_languages, language_csv)
+    try:
+        uploaded_english_catalogs = _load_uploaded_english_catalogs()
+    except (ValueError, json.JSONDecodeError, zipfile.BadZipFile) as upload_error:
+        flash(f"Invalid uploaded STRINGS input: {upload_error}", "error")
+        return redirect(url_for("gyvate.export_page"))
 
     agent = GyvateAgent(config=_get_config())
     result = agent.run_export(
@@ -74,6 +134,7 @@ def export_strings() -> ResponseReturnValue:
         strings_path=strings_path,
         scopes=selected_scopes,
         target_languages=target_languages,
+        uploaded_english_catalogs=uploaded_english_catalogs,
         write_mode=write_mode,
     )
 

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -92,6 +92,9 @@
                             <li><a class="dropdown-item" href="{{ url_for('exports.exports_page') }}">
                                 <i class="bi bi-download"></i> {{ STRINGS.navigation.get('exports', 'Exports') }}
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('gyvate.export_page') }}">
+                                <i class="bi bi-translate"></i> GYVATE STRINGS Export
+                            </a></li>
                             {% endif %}
                             <li><a class="dropdown-item" href="{{ url_for('batch_operations.list_batches') }}">
                                 <i class="bi bi-collection"></i> {{ STRINGS.navigation.get('batch_jobs', 'Batch Jobs') }}

--- a/src/barsukas/templates/gyvate/export.html
+++ b/src/barsukas/templates/gyvate/export.html
@@ -17,7 +17,7 @@
                 <i class="bi bi-gear"></i> Export Configuration
             </div>
             <div class="card-body">
-                <form method="post" action="{{ url_for('gyvate.export_strings') }}">
+                <form method="post" action="{{ url_for('gyvate.export_strings') }}" enctype="multipart/form-data">
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label for="project_root" class="form-label">Project Root</label>
@@ -75,6 +75,36 @@
                         </div>
                         <label for="target_languages_csv" class="form-label">Additional language codes (comma-separated)</label>
                         <input class="form-control" id="target_languages_csv" name="target_languages_csv" placeholder="e.g. it,pt-BR,sv">
+                    </div>
+
+                    <div class="mb-4">
+                        <label for="english_strings_files" class="form-label">English STRINGS files (optional)</label>
+                        <input
+                            class="form-control"
+                            id="english_strings_files"
+                            name="english_strings_files"
+                            type="file"
+                            multiple
+                            accept=".json"
+                        >
+                        <small class="form-text text-muted">
+                            Upload one or more <code>en.json</code> files. File names may include paths like
+                            <code>common/en.json</code> to map namespaces.
+                        </small>
+                    </div>
+
+                    <div class="mb-4">
+                        <label for="english_strings_bundle" class="form-label">English STRINGS ZIP bundle (optional)</label>
+                        <input
+                            class="form-control"
+                            id="english_strings_bundle"
+                            name="english_strings_bundle"
+                            type="file"
+                            accept=".zip"
+                        >
+                        <small class="form-text text-muted">
+                            ZIP should contain one or more <code>*/en.json</code> files. Uploaded catalogs can be used as source input for translation catalog generation.
+                        </small>
                     </div>
 
                     <hr>

--- a/src/barsukas/templates/gyvate/export.html
+++ b/src/barsukas/templates/gyvate/export.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+
+{% block title %}GYVATE STRINGS Export{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+    <div class="col">
+        <h2><i class="bi bi-translate"></i> GYVATE STRINGS Export</h2>
+        <p class="text-muted">Generate STRINGS keys and language catalogs for Barsukas or any similarly-structured project.</p>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-10 offset-md-1">
+        <div class="card">
+            <div class="card-header">
+                <i class="bi bi-gear"></i> Export Configuration
+            </div>
+            <div class="card-body">
+                <form method="post" action="{{ url_for('gyvate.export_strings') }}">
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label for="project_root" class="form-label">Project Root</label>
+                            <input class="form-control" id="project_root" name="project_root" value="{{ default_project_root }}" required>
+                        </div>
+                        <div class="col-md-3">
+                            <label for="template_path" class="form-label">Templates Path</label>
+                            <input class="form-control" id="template_path" name="template_path" value="{{ default_template_path }}" required>
+                        </div>
+                        <div class="col-md-3">
+                            <label for="strings_path" class="form-label">STRINGS Path</label>
+                            <input class="form-control" id="strings_path" name="strings_path" value="{{ default_strings_path }}" required>
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">Scope</label>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="scope_templates" name="scopes" value="templates" checked>
+                            <label class="form-check-label" for="scope_templates">
+                                Templates (<code>*.html</code>)
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="scope_modules" name="scopes" value="modules">
+                            <label class="form-check-label" for="scope_modules">
+                                Modules (<code>*.py</code> scan/report)
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">Mode</label>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" id="mode_dry" name="mode" value="dry" checked>
+                            <label class="form-check-label" for="mode_dry">Dry run (preview changes)</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" id="mode_write" name="mode" value="write">
+                            <label class="form-check-label" for="mode_write">Write changes</label>
+                        </div>
+                    </div>
+
+                    <div class="mb-4">
+                        <label class="form-label">Target Languages</label>
+                        <div class="row g-2 mb-2">
+                            {% for lang_code in ['lt', 'es', 'fr', 'de', 'ko', 'zh', 'ja'] %}
+                            <div class="col-md-3 col-6">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="target_languages" id="lang_{{ lang_code }}" value="{{ lang_code }}" {% if lang_code in default_target_languages %}checked{% endif %}>
+                                    <label class="form-check-label" for="lang_{{ lang_code }}">{{ lang_code }}</label>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                        <label for="target_languages_csv" class="form-label">Additional language codes (comma-separated)</label>
+                        <input class="form-control" id="target_languages_csv" name="target_languages_csv" placeholder="e.g. it,pt-BR,sv">
+                    </div>
+
+                    <hr>
+                    <div class="d-flex justify-content-between">
+                        <a href="{{ url_for('index') }}" class="btn btn-secondary">
+                            <i class="bi bi-arrow-left"></i> Back to Home
+                        </a>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-play-circle"></i> Run GYVATE
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/barsukas/templates/gyvate/results.html
+++ b/src/barsukas/templates/gyvate/results.html
@@ -56,6 +56,7 @@
                     <li class="list-group-item"><strong>Templates Path:</strong> <code>{{ result.template_path }}</code></li>
                     <li class="list-group-item"><strong>STRINGS Path:</strong> <code>{{ result.strings_path }}</code></li>
                     <li class="list-group-item"><strong>Scope:</strong> {{ result.scopes|join(', ') }}</li>
+                    <li class="list-group-item"><strong>Uploaded English catalogs:</strong> {{ result.uploaded_english_catalogs }}</li>
                 </ul>
             </div>
         </div>

--- a/src/barsukas/templates/gyvate/results.html
+++ b/src/barsukas/templates/gyvate/results.html
@@ -1,0 +1,153 @@
+{% extends "base.html" %}
+
+{% block title %}GYVATE Results{% endblock %}
+
+{% block content %}
+<div class="row mb-4">
+    <div class="col">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{{ url_for('gyvate.export_page') }}">GYVATE Export</a></li>
+                <li class="breadcrumb-item active">Results</li>
+            </ol>
+        </nav>
+        <h2><i class="bi bi-check-circle"></i> GYVATE Export Results</h2>
+        <p class="text-muted">Mode: <strong>{{ result.mode }}</strong></p>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-10 offset-md-1">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="bi bi-info-circle"></i> Summary
+            </div>
+            <div class="card-body">
+                <div class="row text-center">
+                    <div class="col-md-3 mb-3">
+                        <div class="border rounded p-3">
+                            <div class="h4 mb-0">{{ result.templates_changed }}</div>
+                            <small class="text-muted">Templates Changed</small>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="border rounded p-3">
+                            <div class="h4 mb-0">{{ result.replacements_total }}</div>
+                            <small class="text-muted">Replacements</small>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="border rounded p-3">
+                            <div class="h4 mb-0">{{ result.new_key_count }}</div>
+                            <small class="text-muted">New Keys</small>
+                        </div>
+                    </div>
+                    <div class="col-md-3 mb-3">
+                        <div class="border rounded p-3">
+                            <div class="h4 mb-0">{{ result.module_files_scanned }}</div>
+                            <small class="text-muted">Module Files Scanned</small>
+                        </div>
+                    </div>
+                </div>
+
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item"><strong>Project Root:</strong> <code>{{ result.project_root }}</code></li>
+                    <li class="list-group-item"><strong>Templates Path:</strong> <code>{{ result.template_path }}</code></li>
+                    <li class="list-group-item"><strong>STRINGS Path:</strong> <code>{{ result.strings_path }}</code></li>
+                    <li class="list-group-item"><strong>Scope:</strong> {{ result.scopes|join(', ') }}</li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header"><i class="bi bi-table"></i> Per-language Generation Status</div>
+            <div class="card-body">
+                {% if result.language_statuses %}
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>Language</th>
+                                <th>Status</th>
+                                <th>Namespaces</th>
+                                <th>Keys Added</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for lang_status in result.language_statuses %}
+                            <tr>
+                                <td><code>{{ lang_status.language }}</code></td>
+                                <td><span class="badge bg-info text-dark">{{ lang_status.status }}</span></td>
+                                <td>{{ lang_status.namespaces_processed }}</td>
+                                <td>{{ lang_status.keys_added }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                {% else %}
+                    <p class="text-muted mb-0">No non-English target languages selected.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header"><i class="bi bi-list-check"></i> Template Replacements</div>
+            <div class="card-body">
+                {% if result.template_changes %}
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover">
+                            <thead>
+                                <tr>
+                                    <th>Template</th>
+                                    <th>Replacements</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for change in result.template_changes %}
+                                <tr>
+                                    <td><code>{{ change.template_path }}</code></td>
+                                    <td>{{ change.replacement_count }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p class="text-muted mb-0">No template replacements were needed.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header"><i class="bi bi-plus-circle"></i> New STRINGS Keys</div>
+            <div class="card-body">
+                {% if result.new_keys_by_namespace %}
+                    {% for namespace, keys in result.new_keys_by_namespace.items() %}
+                    <div class="mb-3">
+                        <h6><code>{{ namespace }}</code></h6>
+                        <p class="mb-0">
+                            {% for key in keys %}
+                                <span class="badge bg-secondary me-1">{{ key }}</span>
+                            {% endfor %}
+                        </p>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-muted mb-0">No new keys were created.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <div class="mt-4">
+            <a href="{{ url_for('gyvate.export_page') }}" class="btn btn-primary">
+                <i class="bi bi-arrow-repeat"></i> Run Again
+            </a>
+            <a href="{{ url_for('index') }}" class="btn btn-secondary">
+                <i class="bi bi-house"></i> Back to Home
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/strings/gyvate_service.py
+++ b/src/strings/gyvate_service.py
@@ -49,6 +49,7 @@ class GyvateServiceResult:
     new_keys_by_namespace: dict[str, list[str]]
     template_changes: list[TemplateChangeSummary]
     language_statuses: list[LanguageGenerationStatus]
+    uploaded_english_catalogs: int
     error: str | None = None
 
 
@@ -66,6 +67,7 @@ class GyvateStringsExportService:
         strings_path: str,
         scopes: list[str],
         target_languages: list[str],
+        uploaded_english_catalogs: dict[str, dict[str, str]],
         write_mode: bool,
     ) -> GyvateServiceResult:
         """Compute and optionally apply STRINGS extraction and catalog generation."""
@@ -83,6 +85,12 @@ class GyvateStringsExportService:
                 templates_root=templates_root,
                 strings_root=strings_root,
                 include_templates="templates" in scopes,
+            )
+            self._merge_uploaded_english_catalogs(
+                strings_root=strings_root,
+                catalog_state=catalog_state,
+                uploaded_english_catalogs=uploaded_english_catalogs,
+                write_mode=write_mode,
             )
             module_files_scanned = self._count_module_files(root_dir) if "modules" in scopes else 0
 
@@ -126,6 +134,7 @@ class GyvateStringsExportService:
                 },
                 template_changes=template_changes,
                 language_statuses=language_statuses,
+                uploaded_english_catalogs=len(uploaded_english_catalogs),
             )
         except Exception as error:  # pragma: no cover - defensive route safety
             return GyvateServiceResult(
@@ -144,8 +153,42 @@ class GyvateStringsExportService:
                 new_keys_by_namespace={},
                 template_changes=[],
                 language_statuses=[],
+                uploaded_english_catalogs=len(uploaded_english_catalogs),
                 error=str(error),
             )
+
+    def _merge_uploaded_english_catalogs(
+        self,
+        *,
+        strings_root: Path,
+        catalog_state: barsukas_generator.CatalogState,
+        uploaded_english_catalogs: dict[str, dict[str, str]],
+        write_mode: bool,
+    ) -> None:
+        for namespace, uploaded_catalog in uploaded_english_catalogs.items():
+            catalog_state.ensure_namespace(namespace)
+            english_catalog = catalog_state.catalogs.setdefault(namespace, {})
+            for key_name, english_text in uploaded_catalog.items():
+                normalized_text = barsukas_generator.normalize_for_lookup(english_text)
+                if normalized_text:
+                    existing_locations = catalog_state.reverse_lookup.setdefault(
+                        normalized_text, []
+                    )
+                    if (namespace, key_name) not in existing_locations:
+                        existing_locations.append((namespace, key_name))
+                english_catalog[key_name] = english_text
+
+            if not write_mode:
+                continue
+
+            namespace_dir = strings_root.joinpath(*namespace.split("."))
+            namespace_dir.mkdir(parents=True, exist_ok=True)
+            sorted_catalog = {
+                key_name: english_catalog[key_name] for key_name in sorted(english_catalog)
+            }
+            with (namespace_dir / "en.json").open("w", encoding="utf-8") as english_handle:
+                json.dump(sorted_catalog, english_handle, ensure_ascii=False, indent=2)
+                english_handle.write("\n")
 
     def _compute_template_plan(
         self,

--- a/src/strings/gyvate_service.py
+++ b/src/strings/gyvate_service.py
@@ -1,0 +1,258 @@
+"""Backend service for GYVATE STRINGS export operations."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from storage.backend.config import DataSourceConfig
+from strings import generate_barsukas_strings as barsukas_generator
+
+
+@dataclass(frozen=True)
+class TemplateChangeSummary:
+    """Summary information for one template file."""
+
+    template_path: str
+    replacement_count: int
+
+
+@dataclass(frozen=True)
+class LanguageGenerationStatus:
+    """Status for one target language catalog generation/update."""
+
+    language: str
+    file_path: str
+    namespaces_processed: int
+    keys_added: int
+    status: str
+
+
+@dataclass(frozen=True)
+class GyvateServiceResult:
+    """Result payload returned to route handlers."""
+
+    success: bool
+    mode: str
+    project_root: str
+    template_path: str
+    strings_path: str
+    scopes: list[str]
+    replacements_total: int
+    templates_changed: int
+    module_files_scanned: int
+    reused_common_count: int
+    new_key_count: int
+    collisions_resolved: int
+    new_keys_by_namespace: dict[str, list[str]]
+    template_changes: list[TemplateChangeSummary]
+    language_statuses: list[LanguageGenerationStatus]
+    error: str | None = None
+
+
+class GyvateStringsExportService:
+    """Service for extracting template strings and generating STRINGS catalogs."""
+
+    def __init__(self, config: DataSourceConfig) -> None:
+        self.config = config
+
+    def export_strings(
+        self,
+        *,
+        project_root: str,
+        template_path: str,
+        strings_path: str,
+        scopes: list[str],
+        target_languages: list[str],
+        write_mode: bool,
+    ) -> GyvateServiceResult:
+        """Compute and optionally apply STRINGS extraction and catalog generation."""
+        try:
+            root_dir = Path(project_root).expanduser().resolve()
+            templates_root = (root_dir / template_path).resolve()
+            strings_root = (root_dir / strings_path).resolve()
+
+            if not root_dir.exists():
+                raise ValueError(f"Project root does not exist: {root_dir}")
+            if "templates" in scopes and not templates_root.exists():
+                raise ValueError(f"Template path does not exist: {templates_root}")
+
+            template_plans, catalog_state, stats = self._compute_template_plan(
+                templates_root=templates_root,
+                strings_root=strings_root,
+                include_templates="templates" in scopes,
+            )
+            module_files_scanned = self._count_module_files(root_dir) if "modules" in scopes else 0
+
+            replacements_total = sum(len(replacements) for replacements in template_plans.values())
+            template_changes = [
+                TemplateChangeSummary(
+                    template_path=str(template_file.relative_to(root_dir)),
+                    replacement_count=len(replacements),
+                )
+                for template_file, replacements in sorted(template_plans.items())
+            ]
+
+            if write_mode:
+                self._apply_template_changes(template_plans)
+                catalog_state.write()
+
+            language_statuses = self._update_target_languages(
+                strings_root=strings_root,
+                catalog_state=catalog_state,
+                target_languages=target_languages,
+                write_mode=write_mode,
+            )
+
+            return GyvateServiceResult(
+                success=True,
+                mode="write" if write_mode else "dry-run",
+                project_root=str(root_dir),
+                template_path=str(templates_root),
+                strings_path=str(strings_root),
+                scopes=sorted(set(scopes)),
+                replacements_total=replacements_total,
+                templates_changed=len(template_plans),
+                module_files_scanned=module_files_scanned,
+                reused_common_count=stats.reused_common_count,
+                new_key_count=stats.new_key_count,
+                collisions_resolved=stats.collisions_resolved,
+                new_keys_by_namespace={
+                    namespace: sorted(keys)
+                    for namespace, keys in sorted(catalog_state.new_keys.items())
+                    if keys
+                },
+                template_changes=template_changes,
+                language_statuses=language_statuses,
+            )
+        except Exception as error:  # pragma: no cover - defensive route safety
+            return GyvateServiceResult(
+                success=False,
+                mode="write" if write_mode else "dry-run",
+                project_root=project_root,
+                template_path=template_path,
+                strings_path=strings_path,
+                scopes=sorted(set(scopes)),
+                replacements_total=0,
+                templates_changed=0,
+                module_files_scanned=0,
+                reused_common_count=0,
+                new_key_count=0,
+                collisions_resolved=0,
+                new_keys_by_namespace={},
+                template_changes=[],
+                language_statuses=[],
+                error=str(error),
+            )
+
+    def _compute_template_plan(
+        self,
+        *,
+        templates_root: Path,
+        strings_root: Path,
+        include_templates: bool,
+    ) -> tuple[
+        dict[Path, list[barsukas_generator.Replacement]],
+        barsukas_generator.CatalogState,
+        barsukas_generator.CatalogUpdateStats,
+    ]:
+        if not include_templates:
+            catalog_state = barsukas_generator.CatalogState(strings_root)
+            stats = barsukas_generator.CatalogUpdateStats()
+            return ({}, catalog_state, stats)
+
+        original_templates_root = barsukas_generator.TEMPLATES_ROOT
+        original_strings_root = barsukas_generator.STRINGS_ROOT
+        original_namespace_alias = barsukas_generator.NAMESPACE_ALIAS
+        try:
+            barsukas_generator.TEMPLATES_ROOT = templates_root
+            barsukas_generator.STRINGS_ROOT = strings_root
+            barsukas_generator.NAMESPACE_ALIAS = {}
+            return barsukas_generator.compute_plan()
+        finally:
+            barsukas_generator.TEMPLATES_ROOT = original_templates_root
+            barsukas_generator.STRINGS_ROOT = original_strings_root
+            barsukas_generator.NAMESPACE_ALIAS = original_namespace_alias
+
+    def _apply_template_changes(
+        self, template_plans: dict[Path, list[barsukas_generator.Replacement]]
+    ) -> None:
+        for template_file, replacements in template_plans.items():
+            original_content = template_file.read_text(encoding="utf-8")
+            updated_content = barsukas_generator.apply_replacements(original_content, replacements)
+            template_file.write_text(updated_content, encoding="utf-8")
+
+    def _update_target_languages(
+        self,
+        *,
+        strings_root: Path,
+        catalog_state: barsukas_generator.CatalogState,
+        target_languages: list[str],
+        write_mode: bool,
+    ) -> list[LanguageGenerationStatus]:
+        statuses: list[LanguageGenerationStatus] = []
+        languages = [lang for lang in target_languages if lang and lang != "en"]
+
+        for language_code in languages:
+            namespaces_processed = 0
+            added_keys_total = 0
+            for namespace in sorted(catalog_state.namespace_dirs):
+                namespace_dir = strings_root.joinpath(*namespace.split("."))
+                english_file = namespace_dir / "en.json"
+                if not english_file.exists():
+                    continue
+                namespaces_processed += 1
+
+                with english_file.open("r", encoding="utf-8") as english_handle:
+                    english_catalog = json.load(english_handle)
+                localized_file = namespace_dir / f"{language_code}.json"
+                localized_catalog = self._read_json_file(localized_file)
+
+                added_in_namespace = 0
+                for key_name, english_text in english_catalog.items():
+                    if key_name not in localized_catalog:
+                        localized_catalog[key_name] = english_text
+                        added_in_namespace += 1
+                added_keys_total += added_in_namespace
+
+                if write_mode:
+                    sorted_localized_catalog = {
+                        key_name: localized_catalog[key_name]
+                        for key_name in sorted(localized_catalog)
+                    }
+                    namespace_dir.mkdir(parents=True, exist_ok=True)
+                    with localized_file.open("w", encoding="utf-8") as localized_handle:
+                        json.dump(
+                            sorted_localized_catalog, localized_handle, ensure_ascii=False, indent=2
+                        )
+                        localized_handle.write("\n")
+
+            status = "updated" if write_mode else "would-update"
+            statuses.append(
+                LanguageGenerationStatus(
+                    language=language_code,
+                    file_path=str(strings_root),
+                    namespaces_processed=namespaces_processed,
+                    keys_added=added_keys_total,
+                    status=status,
+                )
+            )
+
+        return statuses
+
+    def _read_json_file(self, json_path: Path) -> dict[str, str]:
+        if not json_path.exists():
+            return {}
+        with json_path.open("r", encoding="utf-8") as source_handle:
+            loaded_json: Any = json.load(source_handle)
+        if not isinstance(loaded_json, dict):
+            return {}
+        return {str(key_name): str(value_text) for key_name, value_text in loaded_json.items()}
+
+    def _count_module_files(self, project_root: Path) -> int:
+        barsukas_src = project_root / "src" / "barsukas"
+        if not barsukas_src.exists():
+            return 0
+        return sum(1 for _ in barsukas_src.rglob("*.py"))


### PR DESCRIPTION
### Motivation
- Provide a reusable Barsukas export flow to generate STRINGS catalogs and extract template strings for arbitrary projects without embedding extraction logic in route handlers. 
- Allow safe preview (`dry-run`) and optional write mode and surface per-language generation status so maintainers can review planned changes before applying them.

### Description
- Add a new Barsukas blueprint at `@ /gyvate` with a GET form page and POST export endpoint implemented in `src/barsukas/routes/strings_export.py` that delegates work to an agent. 
- Implement a route-facing agent `GyvateAgent` in `src/agents/gyvate/agent.py` that accepts a `DataSourceConfig` and calls a reusable backend service. 
- Implement the backend service `GyvateStringsExportService` and result DTOs in `src/strings/gyvate_service.py` which reuse the existing `strings.generate_barsukas_strings` logic to plan template replacements, optionally apply template writes, create/update language JSON catalogs, and report statistics (replacements, new keys, collisions, namespaces processed). 
- Add Barsukas UI templates `src/barsukas/templates/gyvate/export.html` and `src/barsukas/templates/gyvate/results.html` modeled on the WireWord pages to collect scope/mode/languages and display replacements, new keys, and per-language status. 
- Register the new blueprint in the app startup and add a navigation link under Exports in `src/barsukas/app.py` and `src/barsukas/templates/base.html`.

### Testing
- Ran formatter with `python -m black src/barsukas/routes/strings_export.py src/strings/gyvate_service.py src/agents/gyvate/agent.py src/agents/gyvate/__init__.py src/barsukas/app.py` (reformatted as needed). 
- Ran static type checks with `PYTHONPATH=src mypy src/barsukas/routes/strings_export.py src/strings/gyvate_service.py src/agents/gyvate/agent.py` and received no type issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc71ddfb083279fdc2e9b6c9e1c80)