### PR TITLE
Refactor Barsukas replacement generation with text classification and directives

### DIFF
--- a/src/strings/barsukas_helpers.py
+++ b/src/strings/barsukas_helpers.py
@@ -237,6 +237,13 @@ class StringAccessor:
         if len(segments) < 2:
             return default
 
+        for index in range(len(segments) - 1, 0, -1):
+            namespace = ".".join(segments[:index])
+            if namespace not in self._strings_by_namespace:
+                continue
+            key = ".".join(segments[index:])
+            return self._get_value(namespace, key, default=default)
+
         namespace = segments[0]
         key = ".".join(segments[1:])
         return self._get_value(namespace, key, default=default)

--- a/src/strings/generate_barsukas_strings.py
+++ b/src/strings/generate_barsukas_strings.py
@@ -35,7 +35,9 @@ JINJA_OR_COMMENT_PATTERN = re.compile(r"<!--.*?-->|\{\{.*?\}\}|\{\%.*?\%\}|\{\#.
 TAG_PATTERN = re.compile(r"<[^>]+>", re.DOTALL)
 ATTRIBUTE_PATTERN = re.compile(r"([:\w-]+)\s*=\s*([\"'])(.*?)\2", re.DOTALL)
 SENTENCE_END_PATTERN = re.compile(r"[.!?](?:\s|$)")
-AccessorName = Literal["STRINGS", "CSTR"]
+DIRECTIVE_PATTERN = re.compile(r"<!--\s*strings:(?P<name>[-\w]+)\s*-->", re.IGNORECASE)
+AccessorName = Literal["LSTR", "SSTR", "CSTR"]
+TextKind = Literal["short", "sentence", "multi_sentence"]
 
 
 @dataclass(frozen=True)
@@ -60,6 +62,20 @@ class CatalogUpdateStats:
     reused_common_count: int = 0
     new_key_count: int = 0
     collisions_resolved: int = 0
+
+
+@dataclass(frozen=True)
+class ClassificationDirective:
+    start: int
+    end: int
+    name: str
+
+
+@dataclass(frozen=True)
+class ExtractionCandidate:
+    span: Span
+    text: str
+    namespace: str
 
 
 class CatalogState:
@@ -193,6 +209,32 @@ def is_multi_sentence_block(text: str) -> bool:
     return sentence_count >= 2
 
 
+def classify_extracted_segment(
+    text: str,
+    override: TextKind | None = None,
+) -> TextKind:
+    if override is not None:
+        return override
+
+    stripped = text.strip()
+    if is_multi_sentence_block(stripped):
+        return "multi_sentence"
+
+    token_count = len(re.findall(r"[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)?", stripped))
+    has_sentence_ending = bool(SENTENCE_END_PATTERN.search(stripped))
+    has_line_break = "\n" in stripped
+
+    if has_sentence_ending and token_count >= 3:
+        return "sentence"
+    if has_line_break and token_count >= 6:
+        return "sentence"
+    if token_count >= 9:
+        return "sentence"
+    if len(stripped) >= 70 and token_count >= 5:
+        return "sentence"
+    return "short"
+
+
 def get_template_namespace(template_path: Path) -> str:
     relative_path = template_path.relative_to(TEMPLATES_ROOT)
     root_part = relative_path.parts[0] if len(relative_path.parts) > 1 else "common"
@@ -277,6 +319,29 @@ def split_unprotected_segments(segment_span: Span, protected_spans: list[Span]) 
     return [entry for entry in slices if entry.start < entry.end]
 
 
+def parse_classification_directives(content: str) -> list[ClassificationDirective]:
+    directives: list[ClassificationDirective] = []
+    for match in DIRECTIVE_PATTERN.finditer(content):
+        directives.append(
+            ClassificationDirective(
+                start=match.start(),
+                end=match.end(),
+                name=match.group("name").casefold(),
+            )
+        )
+    return directives
+
+
+def resolve_override_kind(directive_name: str) -> TextKind | None:
+    if directive_name in {"short", "label", "token", "lstr"}:
+        return "short"
+    if directive_name in {"sentence", "sstr"}:
+        return "sentence"
+    if directive_name in {"multi", "multi_sentence", "paragraph", "cstr"}:
+        return "multi_sentence"
+    return None
+
+
 def build_text_replacement(
     content: str,
     span: Span,
@@ -285,6 +350,7 @@ def build_text_replacement(
     cstr_catalog_state: CatalogState,
     standard_stats: CatalogUpdateStats,
     cstr_stats: CatalogUpdateStats,
+    override_kind: TextKind | None = None,
 ) -> Replacement | None:
     original_segment = content[span.start : span.end]
     trimmed = original_segment.strip()
@@ -299,10 +365,14 @@ def build_text_replacement(
         original_segment[len(original_segment) - trailing_length :] if trailing_length else ""
     )
 
-    replacement_accessor: AccessorName = "STRINGS"
+    segment_kind = classify_extracted_segment(trimmed, override=override_kind)
+
+    replacement_accessor: AccessorName = "LSTR"
     selected_catalog_state = standard_catalog_state
     selected_stats = standard_stats
-    if is_multi_sentence_block(trimmed):
+    if segment_kind == "sentence":
+        replacement_accessor = "SSTR"
+    if segment_kind == "multi_sentence":
         replacement_accessor = "CSTR"
         selected_catalog_state = cstr_catalog_state
         selected_stats = cstr_stats
@@ -313,7 +383,10 @@ def build_text_replacement(
         preferred_namespace=namespace,
         stats=selected_stats,
     )
-    expression = f"{{{{ {replacement_accessor}.{selected_namespace}.{selected_key} }}}}"
+    if replacement_accessor == "LSTR":
+        expression = f"{{{{ {replacement_accessor}.{selected_key} }}}}"
+    else:
+        expression = f"{{{{ {replacement_accessor}.{selected_namespace}.{selected_key} }}}}"
     return Replacement(
         start=span.start,
         end=span.end,
@@ -334,9 +407,11 @@ def plan_template_replacements(
 ) -> list[Replacement]:
     content = template_path.read_text(encoding="utf-8")
     protected_spans = find_protected_spans(content)
+    directives = parse_classification_directives(content)
     namespace = get_template_namespace(template_path)
 
     planned: list[Replacement] = []
+    candidates: list[ExtractionCandidate] = []
 
     for tag_match in TAG_PATTERN.finditer(content):
         tag_span = Span(tag_match.start(), tag_match.end())
@@ -357,38 +432,62 @@ def plan_template_replacements(
                 continue
             value_start = tag_match.start() + attr_match.start(3)
             value_end = tag_match.start() + attr_match.end(3)
-            selected_namespace, selected_key = standard_catalog_state.resolve_or_create_key(
-                normalized_text=normalized,
-                original_text=attribute_value.strip(),
-                preferred_namespace=namespace,
-                stats=standard_stats,
-            )
-            planned.append(
-                Replacement(
-                    start=value_start,
-                    end=value_end,
-                    replacement_text=f"{{{{ STRINGS.{selected_namespace}.{selected_key} }}}}",
-                    original_text=attribute_value.strip(),
-                    namespace=selected_namespace,
-                    string_key=selected_key,
-                    accessor_name="STRINGS",
+            candidates.append(
+                ExtractionCandidate(
+                    span=Span(value_start, value_end),
+                    text=attribute_value,
+                    namespace=namespace,
                 )
             )
 
     for text_match in re.finditer(r">([^<]+)<", content, flags=re.DOTALL):
         candidate_span = Span(text_match.start(1), text_match.end(1))
         for piece in split_unprotected_segments(candidate_span, protected_spans):
-            replacement = build_text_replacement(
-                content=content,
-                span=piece,
-                namespace=namespace,
-                standard_catalog_state=standard_catalog_state,
-                cstr_catalog_state=cstr_catalog_state,
-                standard_stats=standard_stats,
-                cstr_stats=cstr_stats,
+            candidates.append(
+                ExtractionCandidate(
+                    span=piece,
+                    text=content[piece.start : piece.end],
+                    namespace=namespace,
+                )
             )
-            if replacement is not None:
-                planned.append(replacement)
+
+    sorted_candidates = sorted(candidates, key=lambda item: item.span.start)
+    pending_directives = sorted(directives, key=lambda item: item.start)
+    directive_index = 0
+
+    for candidate in sorted_candidates:
+        applied_directive: ClassificationDirective | None = None
+        while (
+            directive_index < len(pending_directives)
+            and pending_directives[directive_index].end <= candidate.span.start
+        ):
+            applied_directive = pending_directives[directive_index]
+            directive_index += 1
+
+        if applied_directive is not None and applied_directive.name in {
+            "literal",
+            "no_transform",
+            "do_not_transform",
+            "do-not-transform",
+            "skip",
+        }:
+            continue
+
+        override_kind = (
+            resolve_override_kind(applied_directive.name) if applied_directive is not None else None
+        )
+        replacement = build_text_replacement(
+            content=content,
+            span=candidate.span,
+            namespace=candidate.namespace,
+            standard_catalog_state=standard_catalog_state,
+            cstr_catalog_state=cstr_catalog_state,
+            standard_stats=standard_stats,
+            cstr_stats=cstr_stats,
+            override_kind=override_kind,
+        )
+        if replacement is not None:
+            planned.append(replacement)
 
     deduped_by_range: dict[tuple[int, int], Replacement] = {}
     for replacement in planned:

--- a/src/tests/barsukas/helpers/test_strings.py
+++ b/src/tests/barsukas/helpers/test_strings.py
@@ -42,6 +42,15 @@ def test_sstr_requires_namespace() -> None:
     assert str(sstr.edit_title) == ""
 
 
+def test_sstr_resolves_multi_segment_namespace_paths() -> None:
+    strings_by_namespace = {
+        "common.pagination": {"next": "Next"},
+    }
+    sstr = create_sstr_accessor(strings_by_namespace, default_module="common")
+
+    assert str(sstr.common.pagination.next) == "Next"
+
+
 def test_cstr_requires_namespace() -> None:
     strings_by_namespace = {
         "ipa": {"intro_block": "<p>Intro block.</p>"},

--- a/src/tests/strings/test_generate_barsukas_strings.py
+++ b/src/tests/strings/test_generate_barsukas_strings.py
@@ -1,0 +1,111 @@
+"""Tests for Barsukas template replacement generation."""
+
+from pathlib import Path
+
+import pytest
+
+from strings.generate_barsukas_strings import (
+    CatalogState,
+    CatalogUpdateStats,
+    Span,
+    build_text_replacement,
+    classify_extracted_segment,
+    plan_template_replacements,
+)
+
+
+def _create_catalog_states(tmp_path: Path) -> tuple[CatalogState, CatalogState]:
+    standard_root = tmp_path / "strings" / "barsukas"
+    cstr_root = standard_root / "cstr"
+    return (CatalogState(standard_root), CatalogState(cstr_root, allow_common_reuse=False))
+
+
+def test_classify_extracted_segment_distinguishes_short_sentence_and_multi() -> None:
+    assert classify_extracted_segment("Search") == "short"
+    assert classify_extracted_segment("This is a sentence.") == "sentence"
+    assert classify_extracted_segment("One sentence. Another sentence!") == "multi_sentence"
+
+
+def test_build_text_replacement_emits_expected_accessor_by_classification(tmp_path: Path) -> None:
+    standard_state, cstr_state = _create_catalog_states(tmp_path)
+    standard_stats = CatalogUpdateStats()
+    cstr_stats = CatalogUpdateStats()
+
+    short_replacement = build_text_replacement(
+        content="<div>Search</div>",
+        span=Span(start=5, end=11),
+        namespace="lemmas",
+        standard_catalog_state=standard_state,
+        cstr_catalog_state=cstr_state,
+        standard_stats=standard_stats,
+        cstr_stats=cstr_stats,
+    )
+    assert short_replacement is not None
+    assert short_replacement.replacement_text == "{{ LSTR.search }}"
+
+    sentence_replacement = build_text_replacement(
+        content="<div>This is a complete sentence.</div>",
+        span=Span(start=5, end=33),
+        namespace="lemmas",
+        standard_catalog_state=standard_state,
+        cstr_catalog_state=cstr_state,
+        standard_stats=standard_stats,
+        cstr_stats=cstr_stats,
+    )
+    assert sentence_replacement is not None
+    assert sentence_replacement.replacement_text == "{{ SSTR.lemmas.this_is_a_complete_sentence }}"
+
+    multi_sentence_content = "<div>One sentence. Another sentence!</div>"
+    multi_sentence_replacement = build_text_replacement(
+        content=multi_sentence_content,
+        span=Span(start=5, end=multi_sentence_content.index("</div>")),
+        namespace="lemmas",
+        standard_catalog_state=standard_state,
+        cstr_catalog_state=cstr_state,
+        standard_stats=standard_stats,
+        cstr_stats=cstr_stats,
+    )
+    assert multi_sentence_replacement is not None
+    assert (
+        multi_sentence_replacement.replacement_text
+        == "{{ CSTR.lemmas.one_sentence_another_sentence }}"
+    )
+
+
+def test_plan_template_replacements_honors_directives_and_escape_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from strings import generate_barsukas_strings as generator
+
+    template_root = tmp_path / "src" / "barsukas" / "templates"
+    template_path = template_root / "lemmas" / "sample.html"
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_text(
+        """
+<div><!-- strings:sentence -->Token</div>
+<div><!-- strings:do-not-transform -->Literal text</div>
+<input placeholder="Fill out this field.">
+<p>One sentence. Another sentence!</p>
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(generator, "TEMPLATES_ROOT", template_root)
+
+    standard_state, cstr_state = _create_catalog_states(tmp_path)
+    standard_stats = CatalogUpdateStats()
+    cstr_stats = CatalogUpdateStats()
+
+    replacements = plan_template_replacements(
+        template_path=template_path,
+        standard_catalog_state=standard_state,
+        cstr_catalog_state=cstr_state,
+        standard_stats=standard_stats,
+        cstr_stats=cstr_stats,
+    )
+
+    replacement_texts = [item.replacement_text for item in replacements]
+    assert "{{ SSTR.lemmas.token }}" in replacement_texts
+    assert "{{ SSTR.lemmas.fill_out_this_field }}" in replacement_texts
+    assert "{{ CSTR.lemmas.one_sentence_another_sentence }}" in replacement_texts
+    assert all("Literal text" not in item.original_text for item in replacements)

--- a/strings/NAMING.md
+++ b/strings/NAMING.md
@@ -17,6 +17,20 @@ Make it obvious whether a string is:
 - `SSTR` = sentence-length strings
 - `CSTR` = multi-sentence text blocks
 
+Generator mapping (`generate_barsukas_strings.py`) follows this automatically
+using heuristics:
+- short/token-like text → `LSTR`
+- sentence-like text → `SSTR`
+- 2+ sentence blocks → `CSTR`
+
+Override the next extracted segment with template comments when needed:
+- `<!-- strings:short -->`
+- `<!-- strings:sentence -->`
+- `<!-- strings:multi -->`
+
+Skip extraction for intentional literals:
+- `<!-- strings:do-not-transform -->`
+
 ---
 
 ## LSTR namespace rules

--- a/strings/README.md
+++ b/strings/README.md
@@ -98,6 +98,33 @@ Canonical examples:
 
 `CSTR` has no implicit `common` fallback and must be addressed as `CSTR.<namespace>.<key>`.
 
+## Generator classification and template directives
+
+`src/strings/generate_barsukas_strings.py` now classifies extracted text before
+rendering template expressions:
+
+- short labels/tokens → `{{ LSTR.<key> }}`
+- sentence-like text → `{{ SSTR.<namespace>.<key> }}`
+- multi-sentence blocks → `{{ CSTR.<namespace>.<key> }}`
+
+Default classification uses punctuation and length heuristics, and can be
+overridden for the *next extracted segment* with comments:
+
+- `<!-- strings:short -->`
+- `<!-- strings:sentence -->`
+- `<!-- strings:multi -->`
+
+Use an explicit escape marker to keep an intentional literal string unchanged:
+
+- `<!-- strings:do-not-transform -->`
+
+Example:
+
+```html
+<span><!-- strings:sentence -->Search</span>
+<span><!-- strings:do-not-transform -->Literal prototype text</span>
+```
+
 ## CSTR migration rules
 
 When converting multiple sentence keys into one long block:


### PR DESCRIPTION
### Motivation
- Improve extraction accuracy by classifying each extracted template segment as short/token, sentence, or multi-sentence before emitting a template accessor expression.
- Provide a simple way for template authors to override classification or skip transformation for intentional literal strings.

### Description
- Add a classifier `classify_extracted_segment` with heuristics and optional override via template comments, and parse directives with `DIRECTIVE_PATTERN` (see `src/strings/generate_barsukas_strings.py`).
- Emit accessor-specific expressions: short → `{{ LSTR.<key> }}`, sentence → `{{ SSTR.<namespace>.<key> }}`, multi-sentence → `{{ CSTR.<namespace>.<key> }}` by updating `build_text_replacement` and extraction flow in `src/strings/generate_barsukas_strings.py`.
- Add explicit template directive / escape marker support (`<!-- strings:short -->`, `<!-- strings:sentence -->`, `<!-- strings:multi -->`, and `<!-- strings:do-not-transform -->` / aliases) that apply to the next extractable segment.
- Improve SSTR/CSTR accessor namespace resolution to support multi-segment namespaces (longest-prefix match) in `src/strings/barsukas_helpers.py`.
- Add unit tests under `src/tests/strings/test_generate_barsukas_strings.py` covering classification, emitted expressions, directive overrides, and the do-not-transform escape marker, and extend `src/tests/barsukas/helpers/test_strings.py` with a multi-segment namespace test.
- Update docs `strings/README.md` and `strings/NAMING.md` to document the classifier mapping and template directive syntax.

### Testing
- Ran formatting with `black` on modified files which completed successfully.
- Ran unit tests with `PYTHONPATH=src pytest -q src/tests/strings/test_generate_barsukas_strings.py src/tests/barsukas/helpers/test_strings.py`, and all tests passed.
- Ran static type checks with `PYTHONPATH=src mypy` on the modified files and there were no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcf129de48327abd642af2fcade78)