### PR TITLE
docs(barsukas): rewrite README to human-focused architecture and route map

### DIFF
--- a/src/barsukas/README.md
+++ b/src/barsukas/README.md
@@ -1,51 +1,94 @@
 # Barsukas
 
-Barsukas is Greenland's Flask-based editor for managing multilingual linguistic
-data used by Trakaido.
+Barsukas is Greenland's Flask web interface for day-to-day human operations on the
+linguistic database.
 
-## Core capabilities
+In practice, it combines:
+- **database editing/review UX** (lemmas, translations, sentences, audio, categories, logs), and
+- **agent operations UX** (launching and reviewing selected agent-backed workflows).
 
-- Browse/search lemmas and edit core lexical data.
-- Manage translations across supported languages.
-- Review and edit sentence content.
-- Trigger selected agent workflows from the UI.
-- Track changes through operation logging/audit views.
-- Export selected data views for downstream use.
+This README is intentionally focused on **what Barsukas is and how it is organized**.
+For startup details, use `launch.sh` (deployment/runbook steps live outside this repo).
 
-## Run locally
+## What lives here
 
-From the repository root:
+`src/barsukas/` is the full web app package:
 
-```bash
-PYTHONPATH=src python src/barsukas/app.py
-```
+- `app.py` — Flask app factory, global routes (`/`, `/metrics`, `/ipa-reference`),
+  blueprint registration, request/session lifecycle.
+- `unified_app.py` — unified process launcher used by `launch.sh` (web server + worker in one process).
+- `routes/` — feature blueprints and URL handlers.
+- `templates/` — Jinja templates by feature area.
+- `static/` — JS/CSS assets.
+- `helpers/` — UI helpers (language selection, flash helpers, display helpers, db optimizations).
+- `config.py` and `personas.py` — runtime/server persona behavior.
 
-Default URL: `http://127.0.0.1:5555`
+## URL path map
 
-Optional flags:
+Barsukas routes are organized as Flask blueprints. The main top-level paths are:
 
-```bash
-PYTHONPATH=src python src/barsukas/app.py --port 8080
-PYTHONPATH=src python src/barsukas/app.py --readonly
-```
+- `/` — home/dashboard.
+- `/metrics` — Prometheus metrics endpoint.
+- `/ipa-reference` — IPA reference page.
+- `/lemmas` — lemma browse/view/edit flows.
+- `/translations` — translation tools.
+- `/sentences` — sentence browse/view flows.
+- `/sentences/rapid-review` — sentence rapid review.
+- `/sentence-stats` — sentence statistics.
+- `/categories` — category management.
+- `/overrides` — override management.
+- `/conversations` — conversation views/tools.
+- `/audio` — audio tooling and review.
+- `/audio/rapid-review` — audio rapid review workflow.
+- `/agents` — agent workflow endpoints/results.
+- `/agents-launcher` — web launcher for agent CLI tasks.
+- `/batch-operations` — queued/background task tracking.
+- `/pending-imports` — pending import review.
+- `/logs` — operation log and audit views.
+- `/exports` — export hub.
+- `/wireword` — wireword export tools.
+- `/gyvate` — strings export utilities.
+- `/dictionary` — dictionary-facing routes.
+- `/pattern-sentences` — pattern sentence tooling.
+- `/rhymes` — rhyme exploration views.
+- `/pradzia` — start-page style utilities.
+- `/rapid-review` — rapid review hub.
+- `/sync` — sync hub.
+- `/sync/lemmas` — lemma release sync.
+- `/sync/relations` — relation release sync.
+- `/sync/sentences` — sentence release sync.
+- `/sync/derivatives` — derivative release sync.
+- `/api` — core API endpoints.
+- `/api/llm` — LLM-oriented API endpoints.
+- `/api-client` — built-in API test client UI.
 
-## Background worker (for queued LLM-heavy tasks)
+Note: benchmark paths under `/benchmarks...` are conditionally registered when the
+benchmarks backend is available.
 
-Some actions enqueue asynchronous tasks. Run the worker in a second shell:
+## How the app is structured (mental model)
 
-```bash
-PYTHONPATH=src python -m workqueue.worker --poll-interval 2
-```
+Barsukas is organized by **feature slice**:
 
-## High-level structure
+1. **Route module** in `routes/*.py` defines URL handlers.
+2. **Template subtree** in `templates/<feature>/` renders the UI.
+3. **Static JS/CSS** in `static/js` and `static/css` handles feature-specific client behavior.
+4. **Shared helpers** in `helpers/` provide reusable formatting/language/session utilities.
 
-```text
-barsukas/
-├── app.py            # Flask app entry point
-├── routes/           # Feature blueprints (lemmas, translations, sentences, etc.)
-├── templates/        # Jinja templates
-├── static/           # Front-end assets
-└── config.py         # Runtime configuration
-```
+This keeps most changes local to one feature area (route + template + optional JS/CSS).
 
-Barsukas is intended for local/internal use and binds to localhost by default.
+## API and route documentation
+
+For machine/API route details, start with:
+
+- `src/barsukas/routes/API.md` — detailed API route reference for automation and integrations.
+
+For behavior details beyond that:
+
+- inspect the corresponding module under `src/barsukas/routes/` (source of truth for handlers), and
+- inspect templates under `src/barsukas/templates/` for UI flow and form expectations.
+
+## Running Barsukas
+
+Use `src/barsukas/launch.sh`.
+
+(Operational/server setup instructions are intentionally maintained in a separate repo.)


### PR DESCRIPTION
### Motivation

- Make `src/barsukas/README.md` a concise, human-readable overview of the web UI and its structure rather than a runbook-style startup guide.
- Help developers and reviewers quickly find the app entry points, feature organization, and top-level URL prefixes.
- Reduce duplicated operational/run instructions and point readers to the canonical launcher (`launch.sh`) and API docs instead.

### Description

- Rewrote the README to describe what Barsukas does (database editing + agent workflows) and its purpose in the project.
- Documented the package layout and key files (`app.py`, `unified_app.py`, `routes/`, `templates/`, `static/`, `helpers/`, `config.py`, `personas.py`).
- Added a consolidated URL path map enumerating the major top-level blueprints and conditional benchmark paths.
- Pointed readers to `src/barsukas/routes/API.md` and the route modules/templates for detailed API/handler semantics, and kept runtime guidance minimal (use `src/barsukas/launch.sh`).

### Testing

- This is a documentation-only change with no code modifications, so no automated tests were required or run.
- The change was committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e298d8adb8832784f8e16894520b03)