### PR TITLE
Enable Portuguese derivative forms and mechanical inflection

### DIFF
--- a/src/langtools/pt/conjugation.py
+++ b/src/langtools/pt/conjugation.py
@@ -2,15 +2,57 @@
 
 from typing import Dict, Optional, Set, Tuple
 
+# Common irregular verbs with hard-coded core forms.
+# We intentionally keep this list small and focused on high-frequency verbs.
+_HARDCODED_CONJUGATIONS: Dict[str, Dict[str, str]] = {
+    "ser": {
+        "1s_present": "sou",
+        "2s_present": "és",
+        "3s_present": "é",
+        "1p_present": "somos",
+        "2p_present": "sois",
+        "3p_present": "são",
+        "1s_past": "fui",
+        "2s_past": "foste",
+        "3s_past": "foi",
+        "1p_past": "fomos",
+        "2p_past": "fostes",
+        "3p_past": "foram",
+        "1s_future": "serei",
+        "2s_future": "serás",
+        "3s_future": "será",
+        "1p_future": "seremos",
+        "2p_future": "sereis",
+        "3p_future": "serão",
+    },
+    "estar": {
+        "1s_present": "estou",
+        "2s_present": "estás",
+        "3s_present": "está",
+        "1p_present": "estamos",
+        "2p_present": "estais",
+        "3p_present": "estão",
+        "1s_past": "estive",
+        "2s_past": "estiveste",
+        "3s_past": "esteve",
+        "1p_past": "estivemos",
+        "2p_past": "estivestes",
+        "3p_past": "estiveram",
+        "1s_future": "estarei",
+        "2s_future": "estarás",
+        "3s_future": "estará",
+        "1p_future": "estaremos",
+        "2p_future": "estareis",
+        "3p_future": "estarão",
+    },
+}
+
 # Irregular verbs that must NOT be mechanically conjugated.
 _IRREGULAR_VERBS: Set[str] = {
     # Fully irregular
-    "ser",
-    "estar",
     "ir",
     "ter",
     "haver",
-    "ser",
     # Irregular present / preterite / participle
     "fazer",
     "dizer",
@@ -69,6 +111,10 @@ _PERSONS: Tuple[str, str, str, str, str, str] = ("1s", "2s", "3s", "1p", "2p", "
 def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
     """Conjugate a regular Portuguese infinitive across present/past/future."""
     infinitive_value = infinitive.strip().lower()
+    hardcoded_conjugation = _HARDCODED_CONJUGATIONS.get(infinitive_value)
+    if hardcoded_conjugation is not None:
+        return dict(hardcoded_conjugation)
+
     verb_class = ""
     for candidate in ("ar", "er", "ir"):
         if infinitive_value.endswith(candidate):

--- a/src/langtools/pt/forms_config.py
+++ b/src/langtools/pt/forms_config.py
@@ -23,6 +23,13 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "PortugueseVerbConjugations",
 }
 
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "portuguese_adjective_forms",
+    "schema_name": "PortugueseAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_PT_PLURAL_F": "adjective/pt_plural_f",
     "ADJ_PT_PLURAL_M": "adjective/pt_plural_m",

--- a/src/langtools/pt/inflection.py
+++ b/src/langtools/pt/inflection.py
@@ -1,0 +1,103 @@
+"""Rule-based Portuguese noun/adjective inflection helpers."""
+
+from typing import Dict, Optional
+
+
+_NOUN_IRREGULAR_PLURALS: Dict[str, str] = {
+    "cão": "cães",
+    "mão": "mãos",
+    "alemão": "alemães",
+    "capitão": "capitães",
+    "pão": "pães",
+}
+
+_ADJECTIVE_IRREGULAR_FEMININE: Dict[str, str] = {
+    "bom": "boa",
+    "mau": "má",
+}
+
+_ADJECTIVE_IRREGULAR_PLURALS: Dict[str, str] = {
+    "bom": "bons",
+    "boa": "boas",
+    "mau": "maus",
+    "má": "más",
+}
+
+
+def pluralize_noun(noun: str) -> Optional[str]:
+    """Return a noun plural for common European Portuguese rules."""
+    singular = noun.strip().lower()
+    if not singular:
+        return None
+
+    irregular_plural = _NOUN_IRREGULAR_PLURALS.get(singular)
+    if irregular_plural is not None:
+        return irregular_plural
+
+    if singular.endswith(("r", "z", "n")):
+        return singular + "es"
+    if singular.endswith("m"):
+        return singular[:-1] + "ns"
+    if singular.endswith("l"):
+        return singular[:-1] + "is"
+    if singular.endswith("ão"):
+        return singular[:-2] + "ões"
+    if singular.endswith(("s", "x")):
+        return singular
+    return singular + "s"
+
+
+def build_noun_forms(noun: str) -> Optional[Dict[str, str]]:
+    """Build singular/plural noun forms from a base singular noun."""
+    singular = noun.strip().lower()
+    if not singular:
+        return None
+    plural = pluralize_noun(singular)
+    if plural is None:
+        return None
+    return {"singular": singular, "plural": plural}
+
+
+def _adjective_feminine(singular_m: str) -> str:
+    irregular_form = _ADJECTIVE_IRREGULAR_FEMININE.get(singular_m)
+    if irregular_form is not None:
+        return irregular_form
+    if singular_m.endswith("o"):
+        return singular_m[:-1] + "a"
+    return singular_m
+
+
+def _adjective_plural(base: str) -> str:
+    irregular_form = _ADJECTIVE_IRREGULAR_PLURALS.get(base)
+    if irregular_form is not None:
+        return irregular_form
+
+    if base.endswith(("r", "z", "n")):
+        return base + "es"
+    if base.endswith("m"):
+        return base[:-1] + "ns"
+    if base.endswith("l"):
+        return base[:-1] + "is"
+    if base.endswith("ão"):
+        return base[:-2] + "ões"
+    if base.endswith(("s", "x")):
+        return base
+    return base + "s"
+
+
+def build_adjective_forms(adjective: str) -> Optional[Dict[str, str]]:
+    """Build core adjective agreement forms (m/f × singular/plural)."""
+    singular_m = adjective.strip().lower()
+    if not singular_m:
+        return None
+
+    singular_f = _adjective_feminine(singular_m)
+    plural_m = _adjective_plural(singular_m)
+    plural_f = _adjective_plural(singular_f)
+
+    return {
+        "singular_m": singular_m,
+        "singular_f": singular_f,
+        "plural_m": plural_m,
+        "plural_f": plural_f,
+    }

--- a/src/langtools/pt/llm_forms.py
+++ b/src/langtools/pt/llm_forms.py
@@ -10,6 +10,7 @@ from clients.unified_client import UnifiedLLMClient
 from langtools.form_registry import FORM_SPECS
 from langtools.llm_forms_base import query_forms
 from langtools.pt.conjugation import conjugate
+from langtools.pt.inflection import build_adjective_forms, build_noun_forms
 from sqlalchemy.orm import Session
 from storage import database as linguistic_db
 from storage.models.enums import GrammaticalForm
@@ -17,6 +18,7 @@ from storage.translation_helpers import get_translation
 
 logger = logging.getLogger(__name__)
 
+ADJECTIVE_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("pt", "adjective")].form_mapping
 NOUN_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("pt", "noun")].form_mapping
 VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("pt", "verb")].form_mapping
 
@@ -24,7 +26,32 @@ VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("pt", "verb")].form_
 def query_portuguese_noun_forms(
     client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
 ) -> Tuple[Dict[str, str], bool]:
-    """Query LLM for Portuguese noun forms."""
+    """Generate Portuguese noun forms mechanically when possible, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "noun":
+        portuguese_noun = get_translation(session, lemma, "pt")
+        if portuguese_noun:
+            noun_forms = build_noun_forms(portuguese_noun)
+            if noun_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=portuguese_noun,
+                    query_type="portuguese_noun_forms",
+                    prompt="[mechanical langtools.pt.inflection]",
+                    response=json.dumps(
+                        {
+                            "forms": noun_forms,
+                            "notes": "mechanical singular/plural generation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return noun_forms, True
+            logger.info("Falling back to LLM for Portuguese noun '%s'", portuguese_noun)
+
     return query_forms(FORM_SPECS[("pt", "noun")], client, lemma_id, get_session_func)
 
 
@@ -58,3 +85,35 @@ def query_portuguese_verb_conjugations(
             logger.info("Falling back to LLM for Portuguese verb '%s'", portuguese_verb)
 
     return query_forms(FORM_SPECS[("pt", "verb")], client, lemma_id, get_session_func)
+
+
+def query_portuguese_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Generate Portuguese adjective forms mechanically when possible, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "adjective":
+        portuguese_adjective = get_translation(session, lemma, "pt")
+        if portuguese_adjective:
+            adjective_forms = build_adjective_forms(portuguese_adjective)
+            if adjective_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=portuguese_adjective,
+                    query_type="portuguese_adjective_forms",
+                    prompt="[mechanical langtools.pt.inflection]",
+                    response=json.dumps(
+                        {
+                            "forms": adjective_forms,
+                            "notes": "mechanical adjective agreement generation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return adjective_forms, True
+            logger.info("Falling back to LLM for Portuguese adjective '%s'", portuguese_adjective)
+
+    return query_forms(FORM_SPECS[("pt", "adjective")], client, lemma_id, get_session_func)

--- a/src/tests/langtools/test_pt_conjugation.py
+++ b/src/tests/langtools/test_pt_conjugation.py
@@ -91,14 +91,28 @@ class TestRegularIr(unittest.TestCase):
         self.assertEqual(self.forms["3s_future"], "partirá")
 
 
-class TestIrregularVerbsReturnNone(unittest.TestCase):
-    """Irregular verbs must return None to trigger LLM fallback."""
+class TestHardcodedIrregularVerbs(unittest.TestCase):
+    """Common irregular verbs should be hard-coded for deterministic output."""
 
     def test_ser(self) -> None:
-        self.assertIsNone(conjugate("ser"))
+        result = conjugate("ser")
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["1s_present"], "sou")
+        self.assertEqual(result["3s_past"], "foi")
+        self.assertEqual(result["3p_future"], "serão")
 
     def test_estar(self) -> None:
-        self.assertIsNone(conjugate("estar"))
+        result = conjugate("estar")
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["1s_present"], "estou")
+        self.assertEqual(result["3s_past"], "esteve")
+        self.assertEqual(result["2p_future"], "estareis")
+
+
+class TestIrregularVerbsFallback(unittest.TestCase):
+    """Non-hardcoded irregular verbs should return None to trigger LLM fallback."""
 
     def test_ir(self) -> None:
         self.assertIsNone(conjugate("ir"))

--- a/src/tests/langtools/test_pt_inflection.py
+++ b/src/tests/langtools/test_pt_inflection.py
@@ -1,0 +1,33 @@
+"""Tests for Portuguese noun/adjective inflection helpers."""
+
+from langtools.pt.inflection import build_adjective_forms, build_noun_forms
+
+
+def test_noun_forms_regular() -> None:
+    forms = build_noun_forms("livro")
+    assert forms is not None
+    assert forms["singular"] == "livro"
+    assert forms["plural"] == "livros"
+
+
+def test_noun_forms_irregular() -> None:
+    forms = build_noun_forms("cão")
+    assert forms is not None
+    assert forms["plural"] == "cães"
+
+
+def test_adjective_forms_regular() -> None:
+    forms = build_adjective_forms("bonito")
+    assert forms is not None
+    assert forms["singular_m"] == "bonito"
+    assert forms["singular_f"] == "bonita"
+    assert forms["plural_m"] == "bonitos"
+    assert forms["plural_f"] == "bonitas"
+
+
+def test_adjective_forms_irregular() -> None:
+    forms = build_adjective_forms("bom")
+    assert forms is not None
+    assert forms["singular_f"] == "boa"
+    assert forms["plural_m"] == "bons"
+    assert forms["plural_f"] == "boas"

--- a/src/wordfreq/translation/client.py
+++ b/src/wordfreq/translation/client.py
@@ -410,6 +410,10 @@ class LinguisticClient:
             self.client, lemma_id, self.get_session
         )
 
+    def query_portuguese_adjective_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
+        """Query LLM for Portuguese adjective forms."""
+        return portuguese.query_portuguese_adjective_forms(self.client, lemma_id, self.get_session)
+
     # Italian forms
     def query_italian_noun_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
         """Query LLM for Italian noun forms."""

--- a/src/wordfreq/translation/generate_forms_tasks.py
+++ b/src/wordfreq/translation/generate_forms_tasks.py
@@ -152,6 +152,11 @@ _TASK_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
     # Portuguese — translation fetcher, gender on nouns
     ("pt", "noun"): {"fetcher": "translation", "threshold": 2, "gender": True},
     ("pt", "verb"): {"fetcher": "translation", "threshold": 10},
+    ("pt", "adjective"): {
+        "fetcher": "translation",
+        "threshold": 4,
+        "client_method": "query_portuguese_adjective_forms",
+    },
     # Chinese — named client methods
     ("zh", "noun"): {"client_method": "query_chinese_noun_forms"},
     ("zh", "verb"): {"threshold": 3, "client_method": "query_chinese_verb_forms"},


### PR DESCRIPTION
### Motivation
- Enable compact, deterministic derivative-form generation for Portuguese using a hybrid approach: small set of hard-coded irregulars, grammar-based mechanical rules for regular cases, and LLM fallback when needed.

### Description
- Add adjective form spec for Portuguese with a compact m/f × s/p set via `ADJECTIVE_CONFIG` in `src/langtools/pt/forms_config.py` so adjective derivative forms are registered and generated.
- Implement deterministic noun/adjective inflection helpers in `src/langtools/pt/inflection.py` providing common irregulars and default plural/agreement rules and expose `build_noun_forms` / `build_adjective_forms`.
- Prefer mechanical generation in `src/langtools/pt/llm_forms.py` for nouns and adjectives (use inflection helpers) and preserve a mechanical-first verb path that falls back to LLM; add `query_portuguese_adjective_forms` to the language adapter.
- Add a small hard-coded irregular conjugation table for high-frequency verbs (`ser`, `estar`) in `src/langtools/pt/conjugation.py` while keeping other irregulars excluded from mechanical conjugation so they fall back to the LLM.
- Wire the adjective query into the client and tasks by adding `query_portuguese_adjective_forms` to `src/wordfreq/translation/client.py` and a `(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e298048b4c832796d6be5a1e034cd5)