### PR TITLE
Enable Italian derivative form generation for verbs, nouns, and adjectives

### DIFF
--- a/src/langtools/it/conjugation.py
+++ b/src/langtools/it/conjugation.py
@@ -1,24 +1,76 @@
-"""Rule-based Italian verb conjugation for common regular patterns."""
+"""Rule-based Italian derivative form generation for verbs."""
 
 from typing import Dict, Optional, Set, Tuple
 
-# Irregular verbs that must NOT be mechanically conjugated.
-# These are routed to the LLM fallback instead.
-_IRREGULAR_VERBS: Set[str] = {
-    # Fully irregular
-    "essere",
-    "avere",
+_PERSONS: Tuple[str, str, str, str, str, str] = ("1s", "2s", "3s", "1p", "2p", "3p")
+
+_PRESENT_ENDINGS: Dict[str, Tuple[str, str, str, str, str, str]] = {
+    "are": ("o", "i", "a", "iamo", "ate", "ano"),
+    "ere": ("o", "i", "e", "iamo", "ete", "ono"),
+    "ire": ("o", "i", "e", "iamo", "ite", "ono"),
+}
+
+_IMPERFECT_ENDINGS: Dict[str, Tuple[str, str, str, str, str, str]] = {
+    "are": ("avo", "avi", "ava", "avamo", "avate", "avano"),
+    "ere": ("evo", "evi", "eva", "evamo", "evate", "evano"),
+    "ire": ("ivo", "ivi", "iva", "ivamo", "ivate", "ivano"),
+}
+
+_FUTURE_ENDINGS: Tuple[str, str, str, str, str, str] = ("ò", "ai", "à", "emo", "ete", "anno")
+
+_COMMON_IRREGULAR_FORMS: Dict[str, Dict[str, str]] = {
+    "essere": {
+        "1s_present": "sono",
+        "2s_present": "sei",
+        "3s_present": "è",
+        "1p_present": "siamo",
+        "2p_present": "siete",
+        "3p_present": "sono",
+        "1s_past": "ero",
+        "2s_past": "eri",
+        "3s_past": "era",
+        "1p_past": "eravamo",
+        "2p_past": "eravate",
+        "3p_past": "erano",
+        "1s_future": "sarò",
+        "2s_future": "sarai",
+        "3s_future": "sarà",
+        "1p_future": "saremo",
+        "2p_future": "sarete",
+        "3p_future": "saranno",
+    },
+    "avere": {
+        "1s_present": "ho",
+        "2s_present": "hai",
+        "3s_present": "ha",
+        "1p_present": "abbiamo",
+        "2p_present": "avete",
+        "3p_present": "hanno",
+        "1s_past": "avevo",
+        "2s_past": "avevi",
+        "3s_past": "aveva",
+        "1p_past": "avevamo",
+        "2p_past": "avevate",
+        "3p_past": "avevano",
+        "1s_future": "avrò",
+        "2s_future": "avrai",
+        "3s_future": "avrà",
+        "1p_future": "avremo",
+        "2p_future": "avrete",
+        "3p_future": "avranno",
+    },
+}
+
+_BLOCKED_NON_REGULAR_VERBS: Set[str] = {
     "andare",
     "fare",
     "stare",
     "dare",
     "dire",
-    # Modal / semi-irregular
     "potere",
     "volere",
     "dovere",
     "sapere",
-    # Stem-changing / irregular present
     "venire",
     "tenere",
     "uscire",
@@ -33,7 +85,6 @@ _IRREGULAR_VERBS: Set[str] = {
     "sedere",
     "piacere",
     "tacere",
-    # -isco verbs (capire-type -ire verbs with inchoative infix)
     "capire",
     "finire",
     "preferire",
@@ -61,44 +112,78 @@ _IRREGULAR_VERBS: Set[str] = {
     "gestire",
 }
 
-_PRESENT_ENDINGS: Dict[str, Tuple[str, str, str, str, str, str]] = {
-    "are": ("o", "i", "a", "iamo", "ate", "ano"),
-    "ere": ("o", "i", "e", "iamo", "ete", "ono"),
-    "ire": ("o", "i", "e", "iamo", "ite", "ono"),
-}
 
-_IMPERFECT_ENDINGS: Dict[str, Tuple[str, str, str, str, str, str]] = {
-    "are": ("avo", "avi", "ava", "avamo", "avate", "avano"),
-    "ere": ("evo", "evi", "eva", "evamo", "evate", "evano"),
-    "ire": ("ivo", "ivi", "iva", "ivamo", "ivate", "ivano"),
-}
-
-_FUTURE_ENDINGS: Tuple[str, str, str, str, str, str] = ("ò", "ai", "à", "emo", "ete", "anno")
-_PERSONS: Tuple[str, str, str, str, str, str] = ("1s", "2s", "3s", "1p", "2p", "3p")
-
-
-def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
-    """Conjugate a regular Italian infinitive across present/past/future."""
-    infinitive_value = infinitive.strip().lower()
-    verb_class = ""
+def _infer_verb_class(infinitive: str) -> str:
     for candidate in ("are", "ere", "ire"):
-        if infinitive_value.endswith(candidate):
-            verb_class = candidate
-            break
+        if infinitive.endswith(candidate):
+            return candidate
+    return ""
 
+
+def _derive_past_stem(verb_class: str, past_1s: str, infinitive: str) -> str:
+    expected_ending = _IMPERFECT_ENDINGS[verb_class][0]
+    if past_1s.endswith(expected_ending):
+        return past_1s[: -len(expected_ending)]
+    return infinitive[: -len(verb_class)]
+
+
+def _derive_future_stem(verb_class: str, future_1s: str, infinitive: str) -> str:
+    if future_1s.endswith(_FUTURE_ENDINGS[0]):
+        return future_1s[: -len(_FUTURE_ENDINGS[0])]
+    stem = infinitive[: -len(verb_class)]
+    return stem + ("er" if verb_class in {"are", "ere"} else "ir")
+
+
+def conjugate(
+    infinitive: str,
+    present_1s: Optional[str] = None,
+    past_1s: Optional[str] = None,
+    future_1s: Optional[str] = None,
+) -> Optional[Dict[str, str]]:
+    """Conjugate an Italian infinitive using irregular tables + grammar facts.
+
+    If *present_1s* / *past_1s* / *future_1s* are provided (typically from
+    grammar facts), those principal parts are used as stems for derived forms.
+    """
+    infinitive_value = infinitive.strip().lower()
+    if infinitive_value in _COMMON_IRREGULAR_FORMS:
+        return dict(_COMMON_IRREGULAR_FORMS[infinitive_value])
+
+    verb_class = _infer_verb_class(infinitive_value)
     if not verb_class:
         return None
 
-    if infinitive_value in _IRREGULAR_VERBS:
+    if infinitive_value in _BLOCKED_NON_REGULAR_VERBS:
         return None
 
-    stem = infinitive_value[: -len(verb_class)]
-    future_stem = stem + ("er" if verb_class in {"are", "ere"} else "ir")
+    default_stem = infinitive_value[: -len(verb_class)]
+    present_stem = (
+        present_1s.strip().lower()[: -len(_PRESENT_ENDINGS[verb_class][0])]
+        if present_1s and present_1s.strip().lower().endswith(_PRESENT_ENDINGS[verb_class][0])
+        else default_stem
+    )
+    past_stem = (
+        _derive_past_stem(verb_class, past_1s.strip().lower(), infinitive_value)
+        if past_1s
+        else default_stem
+    )
+    future_stem = (
+        _derive_future_stem(verb_class, future_1s.strip().lower(), infinitive_value)
+        if future_1s
+        else default_stem + ("er" if verb_class in {"are", "ere"} else "ir")
+    )
 
     forms: Dict[str, str] = {}
     for index, person in enumerate(_PERSONS):
-        forms[f"{person}_present"] = stem + _PRESENT_ENDINGS[verb_class][index]
-        forms[f"{person}_past"] = stem + _IMPERFECT_ENDINGS[verb_class][index]
+        forms[f"{person}_present"] = present_stem + _PRESENT_ENDINGS[verb_class][index]
+        forms[f"{person}_past"] = past_stem + _IMPERFECT_ENDINGS[verb_class][index]
         forms[f"{person}_future"] = future_stem + _FUTURE_ENDINGS[index]
+
+    if present_1s:
+        forms["1s_present"] = present_1s.strip().lower()
+    if past_1s:
+        forms["1s_past"] = past_1s.strip().lower()
+    if future_1s:
+        forms["1s_future"] = future_1s.strip().lower()
 
     return forms

--- a/src/langtools/it/derivative_forms.py
+++ b/src/langtools/it/derivative_forms.py
@@ -1,0 +1,82 @@
+"""Rule-based Italian noun/adjective derivative form generation."""
+
+from typing import Dict, Optional
+
+_IRREGULAR_NOUN_PLURALS: Dict[str, str] = {
+    "uomo": "uomini",
+    "uovo": "uova",
+    "dio": "dei",
+    "mano": "mani",
+}
+
+_IRREGULAR_ADJECTIVES: Dict[str, Dict[str, str]] = {
+    "buono": {
+        "singular_m": "buono",
+        "singular_f": "buona",
+        "plural_m": "buoni",
+        "plural_f": "buone",
+    },
+    "bello": {
+        "singular_m": "bello",
+        "singular_f": "bella",
+        "plural_m": "belli",
+        "plural_f": "belle",
+    },
+}
+
+
+def derive_noun_forms(noun: str, explicit_plural: Optional[str] = None) -> Optional[Dict[str, str]]:
+    """Return singular/plural noun forms using common Italian inflection rules."""
+    singular_form = noun.strip().lower()
+    if not singular_form:
+        return None
+
+    if explicit_plural:
+        plural_form = explicit_plural.strip().lower()
+    elif singular_form in _IRREGULAR_NOUN_PLURALS:
+        plural_form = _IRREGULAR_NOUN_PLURALS[singular_form]
+    elif singular_form.endswith("o"):
+        plural_form = singular_form[:-1] + "i"
+    elif singular_form.endswith("a"):
+        plural_form = singular_form[:-1] + "e"
+    elif singular_form.endswith("e"):
+        plural_form = singular_form[:-1] + "i"
+    else:
+        plural_form = singular_form
+
+    return {"singular": singular_form, "plural": plural_form}
+
+
+def derive_adjective_forms(adjective: str) -> Optional[Dict[str, str]]:
+    """Return m/f and singular/plural adjective forms for standard patterns."""
+    adjective_value = adjective.strip().lower()
+    if not adjective_value:
+        return None
+
+    if adjective_value in _IRREGULAR_ADJECTIVES:
+        return dict(_IRREGULAR_ADJECTIVES[adjective_value])
+
+    if adjective_value.endswith("o"):
+        stem = adjective_value[:-1]
+        return {
+            "singular_m": adjective_value,
+            "singular_f": f"{stem}a",
+            "plural_m": f"{stem}i",
+            "plural_f": f"{stem}e",
+        }
+
+    if adjective_value.endswith("e"):
+        stem = adjective_value[:-1]
+        return {
+            "singular_m": adjective_value,
+            "singular_f": adjective_value,
+            "plural_m": f"{stem}i",
+            "plural_f": f"{stem}i",
+        }
+
+    return {
+        "singular_m": adjective_value,
+        "singular_f": adjective_value,
+        "plural_m": adjective_value,
+        "plural_f": adjective_value,
+    }

--- a/src/langtools/it/forms_config.py
+++ b/src/langtools/it/forms_config.py
@@ -23,6 +23,13 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "ItalianVerbConjugations",
 }
 
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "italian_adjective_forms",
+    "schema_name": "ItalianAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_IT_PLURAL_F": "adjective/it_plural_f",
     "ADJ_IT_PLURAL_M": "adjective/it_plural_m",

--- a/src/langtools/it/llm_forms.py
+++ b/src/langtools/it/llm_forms.py
@@ -9,14 +9,17 @@ from typing import Callable, Dict, Tuple
 from clients.unified_client import UnifiedLLMClient
 from langtools.form_registry import FORM_SPECS
 from langtools.it.conjugation import conjugate
+from langtools.it.derivative_forms import derive_adjective_forms, derive_noun_forms
 from langtools.llm_forms_base import query_forms
 from sqlalchemy.orm import Session
 from storage import database as linguistic_db
 from storage.models.enums import GrammaticalForm
+from storage.crud.grammar_fact import get_grammar_fact_value
 from storage.translation_helpers import get_translation
 
 logger = logging.getLogger(__name__)
 
+ADJECTIVE_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("it", "adjective")].form_mapping
 NOUN_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("it", "noun")].form_mapping
 VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("it", "verb")].form_mapping
 
@@ -24,7 +27,33 @@ VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("it", "verb")].form_
 def query_italian_noun_forms(
     client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
 ) -> Tuple[Dict[str, str], bool]:
-    """Query LLM for Italian noun forms."""
+    """Generate Italian noun forms mechanically when possible, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "noun":
+        italian_noun = get_translation(session, lemma, "it")
+        if italian_noun:
+            plural_form = get_grammar_fact_value(session, lemma.id, "it", "plural")
+            noun_forms = derive_noun_forms(italian_noun, explicit_plural=plural_form)
+            if noun_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=italian_noun,
+                    query_type="italian_noun_forms",
+                    prompt="[mechanical langtools.it.derivative_forms]",
+                    response=json.dumps(
+                        {
+                            "forms": noun_forms,
+                            "notes": "mechanical regular noun derivation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return noun_forms, True
+            logger.info("Falling back to LLM for Italian noun '%s'", italian_noun)
+
     return query_forms(FORM_SPECS[("it", "noun")], client, lemma_id, get_session_func)
 
 
@@ -38,7 +67,15 @@ def query_italian_verb_conjugations(
     if lemma and lemma.pos_type.lower() == "verb":
         italian_verb = get_translation(session, lemma, "it")
         if italian_verb:
-            conjugation_forms = conjugate(italian_verb)
+            present_1s = get_grammar_fact_value(session, lemma.id, "it", "1s_present")
+            past_1s = get_grammar_fact_value(session, lemma.id, "it", "1s_past")
+            future_1s = get_grammar_fact_value(session, lemma.id, "it", "1s_future")
+            conjugation_forms = conjugate(
+                italian_verb,
+                present_1s=present_1s,
+                past_1s=past_1s,
+                future_1s=future_1s,
+            )
             if conjugation_forms:
                 linguistic_db.log_query(
                     session,
@@ -58,3 +95,35 @@ def query_italian_verb_conjugations(
             logger.info("Falling back to LLM for Italian verb '%s'", italian_verb)
 
     return query_forms(FORM_SPECS[("it", "verb")], client, lemma_id, get_session_func)
+
+
+def query_italian_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Generate Italian adjective agreement forms mechanically when possible."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "adjective":
+        italian_adjective = get_translation(session, lemma, "it")
+        if italian_adjective:
+            adjective_forms = derive_adjective_forms(italian_adjective)
+            if adjective_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=italian_adjective,
+                    query_type="italian_adjective_forms",
+                    prompt="[mechanical langtools.it.derivative_forms]",
+                    response=json.dumps(
+                        {
+                            "forms": adjective_forms,
+                            "notes": "mechanical adjective agreement derivation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return adjective_forms, True
+            logger.info("Falling back to LLM for Italian adjective '%s'", italian_adjective)
+
+    return query_forms(FORM_SPECS[("it", "adjective")], client, lemma_id, get_session_func)

--- a/src/storage/config/grammar_facts.py
+++ b/src/storage/config/grammar_facts.py
@@ -6,4 +6,5 @@ from typing import Dict, Set
 # Only these fact types are imported/exported via the release pipeline.
 RELEASE_GRAMMAR_FACT_TYPES: Dict[str, Set[str]] = {
     "lt": {"3p_present", "3p_past"},
+    "it": {"1s_present", "1s_past", "1s_future", "plural"},
 }

--- a/src/tests/langtools/it/test_derivative_forms.py
+++ b/src/tests/langtools/it/test_derivative_forms.py
@@ -1,0 +1,47 @@
+"""Tests for Italian noun/adjective derivative generation."""
+
+import unittest
+
+from langtools.it.derivative_forms import derive_adjective_forms, derive_noun_forms
+
+
+class TestItalianNounDerivatives(unittest.TestCase):
+    def test_regular_noun_plural(self) -> None:
+        self.assertEqual(derive_noun_forms("gatto"), {"singular": "gatto", "plural": "gatti"})
+
+    def test_irregular_noun_plural(self) -> None:
+        self.assertEqual(derive_noun_forms("uomo"), {"singular": "uomo", "plural": "uomini"})
+
+    def test_explicit_plural_fact(self) -> None:
+        self.assertEqual(
+            derive_noun_forms("braccio", explicit_plural="braccia"),
+            {"singular": "braccio", "plural": "braccia"},
+        )
+
+
+class TestItalianAdjectiveDerivatives(unittest.TestCase):
+    def test_o_ending_adjective(self) -> None:
+        self.assertEqual(
+            derive_adjective_forms("italiano"),
+            {
+                "singular_m": "italiano",
+                "singular_f": "italiana",
+                "plural_m": "italiani",
+                "plural_f": "italiane",
+            },
+        )
+
+    def test_e_ending_adjective(self) -> None:
+        self.assertEqual(
+            derive_adjective_forms("grande"),
+            {
+                "singular_m": "grande",
+                "singular_f": "grande",
+                "plural_m": "grandi",
+                "plural_f": "grandi",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/langtools/it/test_llm_forms.py
+++ b/src/tests/langtools/it/test_llm_forms.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 from typing import Any, Callable, cast
 from unittest.mock import patch
 
-from langtools.it.llm_forms import query_italian_verb_conjugations
+from langtools.it.llm_forms import (
+    query_italian_adjective_forms,
+    query_italian_noun_forms,
+    query_italian_verb_conjugations,
+)
 
 
 class _FakeQuery:
@@ -24,6 +28,15 @@ class _FakeSession:
     def query(self, _model: object) -> _FakeQuery:
         return _FakeQuery(self._lemma)
 
+    def add(self, _obj: object) -> None:
+        return None
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
 
 class TestItalianMechanicalLlmForms(unittest.TestCase):
     def test_uses_mechanical_conjugation(self) -> None:
@@ -32,6 +45,7 @@ class TestItalianMechanicalLlmForms(unittest.TestCase):
 
         with (
             patch("langtools.it.llm_forms.get_translation", return_value="parlare"),
+            patch("langtools.it.llm_forms.get_grammar_fact_value", return_value=None),
             patch("langtools.it.llm_forms.query_forms") as mock_query_forms,
             patch("langtools.it.llm_forms.linguistic_db.log_query") as mock_log_query,
         ):
@@ -43,3 +57,38 @@ class TestItalianMechanicalLlmForms(unittest.TestCase):
         self.assertEqual(forms["1s_future"], "parlerò")
         mock_query_forms.assert_not_called()
         mock_log_query.assert_called_once()
+
+    def test_noun_uses_grammar_fact_plural(self) -> None:
+        lemma = SimpleNamespace(id=2, pos_type="noun", lemma_text="arm")
+        client = cast(Any, SimpleNamespace(default_model="fake-model"))
+
+        with (
+            patch("langtools.it.llm_forms.get_translation", return_value="braccio"),
+            patch("langtools.it.llm_forms.get_grammar_fact_value", return_value="braccia"),
+            patch("langtools.it.llm_forms.query_forms") as mock_query_forms,
+        ):
+            get_session = cast(Callable[[], Any], lambda: _FakeSession(lemma))
+            forms, ok = query_italian_noun_forms(client, 2, get_session)
+
+        self.assertTrue(ok)
+        self.assertEqual(forms, {"singular": "braccio", "plural": "braccia"})
+        mock_query_forms.assert_not_called()
+
+    def test_adjective_mechanical_generation(self) -> None:
+        lemma = SimpleNamespace(id=3, pos_type="adjective", lemma_text="Italian")
+        client = cast(Any, SimpleNamespace(default_model="fake-model"))
+
+        with (
+            patch("langtools.it.llm_forms.get_translation", return_value="italiano"),
+            patch("langtools.it.llm_forms.query_forms") as mock_query_forms,
+        ):
+            get_session = cast(Callable[[], Any], lambda: _FakeSession(lemma))
+            forms, ok = query_italian_adjective_forms(client, 3, get_session)
+
+        self.assertTrue(ok)
+        self.assertEqual(forms["plural_f"], "italiane")
+        mock_query_forms.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/langtools/test_it_conjugation.py
+++ b/src/tests/langtools/test_it_conjugation.py
@@ -90,16 +90,24 @@ class TestRegularIre(unittest.TestCase):
         self.assertEqual(self.forms["3s_future"], "partirà")
 
 
-class TestIrregularVerbsReturnNone(unittest.TestCase):
-    """Irregular verbs must return None to trigger LLM fallback."""
+class TestIrregularVerbsHandling(unittest.TestCase):
+    """Common irregulars are hard-coded; other irregulars still fall back."""
 
-    def test_essere(self) -> None:
-        self.assertIsNone(conjugate("essere"))
+    def test_essere_is_hardcoded(self) -> None:
+        forms = conjugate("essere")
+        self.assertIsNotNone(forms)
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "sono")
+        self.assertEqual(forms["3s_future"], "sarà")
 
-    def test_avere(self) -> None:
-        self.assertIsNone(conjugate("avere"))
+    def test_avere_is_hardcoded(self) -> None:
+        forms = conjugate("avere")
+        self.assertIsNotNone(forms)
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "ho")
+        self.assertEqual(forms["1s_future"], "avrò")
 
-    def test_andare(self) -> None:
+    def test_andare_still_falls_back(self) -> None:
         self.assertIsNone(conjugate("andare"))
 
     def test_fare(self) -> None:
@@ -138,6 +146,17 @@ class TestFormCompleteness(unittest.TestCase):
         for person in ("1s", "2s", "3s", "1p", "2p", "3p"):
             for tense in ("present", "past", "future"):
                 self.assertIn(f"{person}_{tense}", result)
+
+
+class TestPrincipalPartsOverrides(unittest.TestCase):
+    """Principal parts from grammar facts should override default stems."""
+
+    def test_principal_parts_override(self) -> None:
+        forms = conjugate("mangiare", present_1s="mangio", future_1s="mangerò")
+        self.assertIsNotNone(forms)
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "mangio")
+        self.assertEqual(forms["3s_future"], "mangerà")
 
 
 if __name__ == "__main__":

--- a/src/wordfreq/translation/client.py
+++ b/src/wordfreq/translation/client.py
@@ -419,6 +419,10 @@ class LinguisticClient:
         """Query LLM for Italian verb conjugations."""
         return italian.query_italian_verb_conjugations(self.client, lemma_id, self.get_session)
 
+    def query_italian_adjective_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
+        """Query LLM for Italian adjective forms."""
+        return italian.query_italian_adjective_forms(self.client, lemma_id, self.get_session)
+
     # Swedish forms
     def query_swedish_noun_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
         """Query LLM for Swedish noun forms."""

--- a/src/wordfreq/translation/generate_forms_tasks.py
+++ b/src/wordfreq/translation/generate_forms_tasks.py
@@ -143,6 +143,11 @@ _TASK_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
     # Italian — translation fetcher, gender on nouns
     ("it", "noun"): {"fetcher": "translation", "threshold": 2, "gender": True},
     ("it", "verb"): {"fetcher": "translation", "threshold": 10},
+    ("it", "adjective"): {
+        "fetcher": "translation",
+        "threshold": 4,
+        "client_method": "query_italian_adjective_forms",
+    },
     # Swedish — translation fetcher
     ("sv", "noun"): {"fetcher": "translation", "threshold": 2},
     ("sv", "verb"): {"fetcher": "translation", "threshold": 2},


### PR DESCRIPTION
### Motivation
- Provide deterministic "derivative forms" generation for Italian so common irregulars and regular patterns can be produced mechanically and reduce LLM calls. 
- Use small hard-coded irregular tables plus available grammar facts to derive sufficient principal parts/stems for conjugation and agreement. 
- Support lightweight noun/adjective derivation (singular/plural for nouns; m/f × s/p for adjectives) to cover the typical forms needed by downstream tools.

### Description
- Added `src/langtools/it/derivative_forms.py` implementing rule-based noun pluralization (with a small irregular table and optional `explicit_plural` override) and adjective agreement expansion (`singular_m`, `singular_f`, `plural_m`, `plural_f`).
- Reworked `src/langtools/it/conjugation.py` to implement a hybrid verb generator that: hard-codes very common irregulars (`essere`, `avere`), blocks other irregular classes (falling back to LLM), and accepts principal-part overrides (`present_1s`, `past_1s`, `future_1s`) to influence stems when present.
- Updated `src/langtools/it/llm_forms.py` to attempt mechanical generation first for nouns (`query_italian_noun_forms`), verbs (`query_italian_verb_conjugations`), and adjectives (`query_italian_adjective_forms`), log mechanical derivations, and fall back to the shared LLM engine `query_forms(...)` when mechanical generation fails.
- Enabled adjective support in the registry by adding `ADJECTIVE_CONFIG` in `src/langtools/it/forms_config.py`, wired a `query_italian_adjective_forms` client method in `src/wordfreq/translation/client.py`, and registered a task override for Italian adjectives in `src/wordfreq/translation/generate_forms_tasks.py`.
- Added Italian grammar-fact release types (`1s_present`, `1s_past`, `1s_future`, `plural`) in `src/storage/config/grammar_facts.py` so principal parts and explicit plurals can be supplied via grammar facts.
- Added unit tests: `src/tests/langtools/it/test_derivative_forms.py`, extended `it` conjugation tests and `it` llm_forms tests to cover the new behaviors.

### Testing
- Formatted with `black` and type-checked with `mypy` using: `PYTHONPATH=src black ...` and `PYTHONPATH=src mypy ...`, both succeeded without issues.
- Ran unit tests with `pytest` for affected suites using: `PYTHONPATH=src pytest -q src/tests/langtools/test_it_conjugation.py src/tests/langtools/it/test_llm_forms.py src/tests/langtools/it/test_derivative_forms.py`, and all tests passed (`28 passed`).
- New tests exercise: mechanical noun pluralization (including explicit grammar-fact override), adjective agreement derivation, hard-coded irregular verbs, and principal-part stem overrides for verbs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e29787714483279410eb2219129558)