### PR TITLE
Add mechanical Lithuanian noun declension engine and integrate into form generation

### DIFF
--- a/src/langtools/lt/__init__.py
+++ b/src/langtools/lt/__init__.py
@@ -19,6 +19,11 @@ Or using convenience functions:
 """
 
 from langtools.lt.conjugation import conjugate_verb
+from langtools.lt.declension import (
+    decline_noun,
+    get_declension_requirements,
+    get_supported_declension_classes,
+)
 from langtools.lt.types import (
     AdjectiveDeclension,
     AdverbForms,
@@ -46,8 +51,11 @@ __all__ = [
     "AdverbForms",
     "NounDeclension",
     "VerbConjugation",
-    # Conjugation
+    # Conjugation / declension
     "conjugate_verb",
+    "decline_noun",
+    "get_declension_requirements",
+    "get_supported_declension_classes",
     # Convenience functions
     "get_lithuanian_adjective_forms",
     "get_lithuanian_adverb_forms",

--- a/src/langtools/lt/declension.py
+++ b/src/langtools/lt/declension.py
@@ -1,0 +1,318 @@
+"""Mechanical Lithuanian noun declension for common regular classes."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Set
+
+from clients.wiktionary.types import NounNumberType
+
+_CASES: tuple[str, ...] = (
+    "nominative",
+    "genitive",
+    "dative",
+    "accusative",
+    "instrumental",
+    "locative",
+    "vocative",
+)
+
+_IRREGULAR_NOUNS: Set[str] = {
+    "žmogus",
+    "dievas",
+    "sesuo",
+    "duktė",
+    "moteris",
+}
+
+
+@dataclass(frozen=True)
+class DeclensionPattern:
+    """Suffix table for a regular declension class."""
+
+    class_name: str
+    gender: str
+    nominative_suffix: str
+    singular_suffixes: Mapping[str, str]
+    plural_suffixes: Mapping[str, str]
+
+
+_PATTERNS: tuple[DeclensionPattern, ...] = (
+    DeclensionPattern(
+        class_name="masc_ius",
+        gender="masculine",
+        nominative_suffix="ius",
+        singular_suffixes={
+            "nominative": "ius",
+            "genitive": "iaus",
+            "dative": "iui",
+            "accusative": "ių",
+            "instrumental": "iumi",
+            "locative": "iuje",
+            "vocative": "iau",
+        },
+        plural_suffixes={
+            "nominative": "iai",
+            "genitive": "ių",
+            "dative": "iams",
+            "accusative": "ius",
+            "instrumental": "iais",
+            "locative": "iuose",
+            "vocative": "iai",
+        },
+    ),
+    DeclensionPattern(
+        class_name="masc_us",
+        gender="masculine",
+        nominative_suffix="us",
+        singular_suffixes={
+            "nominative": "us",
+            "genitive": "aus",
+            "dative": "ui",
+            "accusative": "ų",
+            "instrumental": "umi",
+            "locative": "uje",
+            "vocative": "au",
+        },
+        plural_suffixes={
+            "nominative": "ūs",
+            "genitive": "ų",
+            "dative": "ums",
+            "accusative": "us",
+            "instrumental": "umis",
+            "locative": "uose",
+            "vocative": "ūs",
+        },
+    ),
+    DeclensionPattern(
+        class_name="masc_ias",
+        gender="masculine",
+        nominative_suffix="ias",
+        singular_suffixes={
+            "nominative": "ias",
+            "genitive": "io",
+            "dative": "iui",
+            "accusative": "ią",
+            "instrumental": "iu",
+            "locative": "yje",
+            "vocative": "y",
+        },
+        plural_suffixes={
+            "nominative": "iai",
+            "genitive": "ių",
+            "dative": "iams",
+            "accusative": "ius",
+            "instrumental": "iais",
+            "locative": "iuose",
+            "vocative": "iai",
+        },
+    ),
+    DeclensionPattern(
+        class_name="masc_ys",
+        gender="masculine",
+        nominative_suffix="ys",
+        singular_suffixes={
+            "nominative": "ys",
+            "genitive": "io",
+            "dative": "iui",
+            "accusative": "į",
+            "instrumental": "iu",
+            "locative": "yje",
+            "vocative": "y",
+        },
+        plural_suffixes={
+            "nominative": "iai",
+            "genitive": "ių",
+            "dative": "iams",
+            "accusative": "ius",
+            "instrumental": "iais",
+            "locative": "iuose",
+            "vocative": "iai",
+        },
+    ),
+    DeclensionPattern(
+        class_name="masc_as",
+        gender="masculine",
+        nominative_suffix="as",
+        singular_suffixes={
+            "nominative": "as",
+            "genitive": "o",
+            "dative": "ui",
+            "accusative": "ą",
+            "instrumental": "u",
+            "locative": "e",
+            "vocative": "e",
+        },
+        plural_suffixes={
+            "nominative": "ai",
+            "genitive": "ų",
+            "dative": "ams",
+            "accusative": "us",
+            "instrumental": "ais",
+            "locative": "uose",
+            "vocative": "ai",
+        },
+    ),
+    DeclensionPattern(
+        class_name="masc_is",
+        gender="masculine",
+        nominative_suffix="is",
+        singular_suffixes={
+            "nominative": "is",
+            "genitive": "io",
+            "dative": "iui",
+            "accusative": "į",
+            "instrumental": "iu",
+            "locative": "yje",
+            "vocative": "i",
+        },
+        plural_suffixes={
+            "nominative": "iai",
+            "genitive": "ių",
+            "dative": "iams",
+            "accusative": "ius",
+            "instrumental": "iais",
+            "locative": "iuose",
+            "vocative": "iai",
+        },
+    ),
+    DeclensionPattern(
+        class_name="fem_is",
+        gender="feminine",
+        nominative_suffix="is",
+        singular_suffixes={
+            "nominative": "is",
+            "genitive": "ies",
+            "dative": "iai",
+            "accusative": "į",
+            "instrumental": "imi",
+            "locative": "yje",
+            "vocative": "ie",
+        },
+        plural_suffixes={
+            "nominative": "ys",
+            "genitive": "ių",
+            "dative": "ims",
+            "accusative": "is",
+            "instrumental": "imis",
+            "locative": "yse",
+            "vocative": "ys",
+        },
+    ),
+    DeclensionPattern(
+        class_name="fem_a",
+        gender="feminine",
+        nominative_suffix="a",
+        singular_suffixes={
+            "nominative": "a",
+            "genitive": "os",
+            "dative": "ai",
+            "accusative": "ą",
+            "instrumental": "a",
+            "locative": "oje",
+            "vocative": "a",
+        },
+        plural_suffixes={
+            "nominative": "os",
+            "genitive": "ų",
+            "dative": "oms",
+            "accusative": "as",
+            "instrumental": "omis",
+            "locative": "ose",
+            "vocative": "os",
+        },
+    ),
+    DeclensionPattern(
+        class_name="fem_ė",
+        gender="feminine",
+        nominative_suffix="ė",
+        singular_suffixes={
+            "nominative": "ė",
+            "genitive": "ės",
+            "dative": "ei",
+            "accusative": "ę",
+            "instrumental": "e",
+            "locative": "ėje",
+            "vocative": "e",
+        },
+        plural_suffixes={
+            "nominative": "ės",
+            "genitive": "ių",
+            "dative": "ėms",
+            "accusative": "es",
+            "instrumental": "ėmis",
+            "locative": "ėse",
+            "vocative": "ės",
+        },
+    ),
+)
+
+
+def _find_pattern(
+    noun: str, grammatical_gender: Optional[str] = None
+) -> Optional[DeclensionPattern]:
+    normalized_noun = noun.strip().lower()
+    matching_patterns: List[DeclensionPattern] = []
+    for pattern in _PATTERNS:
+        if normalized_noun.endswith(pattern.nominative_suffix):
+            matching_patterns.append(pattern)
+
+    if not matching_patterns:
+        return None
+
+    if grammatical_gender:
+        gender_matches = [
+            pattern for pattern in matching_patterns if pattern.gender == grammatical_gender
+        ]
+        if len(gender_matches) == 1:
+            return gender_matches[0]
+        return None
+
+    if len(matching_patterns) == 1:
+        return matching_patterns[0]
+
+    # Ambiguous suffix (e.g., -is can be masculine or feminine) without gender fact.
+    return None
+
+
+def decline_noun(noun: str, grammatical_gender: Optional[str] = None) -> Optional[Dict[str, str]]:
+    """Decline a Lithuanian noun using a conservative regular-pattern set.
+
+    Returns ``None`` when no safe mechanical pattern can be applied.
+    """
+    normalized_noun = noun.strip().lower()
+    if not normalized_noun or normalized_noun in _IRREGULAR_NOUNS:
+        return None
+
+    pattern = _find_pattern(normalized_noun, grammatical_gender=grammatical_gender)
+    if pattern is None:
+        return None
+
+    stem = normalized_noun[: -len(pattern.nominative_suffix)]
+    forms: Dict[str, str] = {}
+    for case_name in _CASES:
+        singular_suffix = pattern.singular_suffixes[case_name]
+        plural_suffix = pattern.plural_suffixes[case_name]
+        forms[f"{case_name}_singular"] = stem + singular_suffix
+        forms[f"{case_name}_plural"] = stem + plural_suffix
+
+    forms["number_type"] = NounNumberType.REGULAR.value
+    forms["declension_class"] = pattern.class_name
+    forms["gender"] = pattern.gender
+    return forms
+
+
+def get_declension_requirements() -> Dict[str, str]:
+    """Return metadata needed for high-accuracy mechanical declension."""
+    return {
+        "lemma": "Nominative singular lemma.",
+        "declension_class": "Class label (e.g., -as, -is, -a, -ė, consonant-stem, mixed).",
+        "gender": "Masculine/feminine, needed for overlapping endings.",
+        "number_type": "Regular vs plurale tantum vs singulare tantum.",
+        "irregular_flag": "Whether lemma is irregular or has stem alternations.",
+        "stem_override": "Optional stored stem if not derivable from nominative.",
+        "stress_pattern": "Needed for accent-correct output if accents are tracked.",
+    }
+
+
+def get_supported_declension_classes() -> List[str]:
+    """Return the currently supported mechanical declension classes."""
+    return [pattern.class_name for pattern in _PATTERNS]

--- a/src/langtools/lt/llm_forms.py
+++ b/src/langtools/lt/llm_forms.py
@@ -11,8 +11,10 @@ from clients.unified_client import UnifiedLLMClient
 from langtools.form_registry import FORM_SPECS
 from langtools.llm_forms_base import query_forms
 from langtools.lt.conjugation import conjugate_verb
+from langtools.lt.declension import decline_noun
 from langtools.lt.principal_parts import get_principal_parts
 from sqlalchemy.orm import Session
+from storage.crud.grammar_fact import get_grammatical_gender
 from storage import database as linguistic_db
 from storage.models.enums import GrammaticalForm
 from storage.translation_helpers import get_translation
@@ -51,7 +53,55 @@ def _parse_principal_parts(translation_text: str) -> Tuple[str, str, str] | None
 def query_lithuanian_noun_declensions(
     client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
 ) -> Tuple[Dict[str, str], bool]:
-    """Query LLM for Lithuanian noun forms."""
+    """Generate Lithuanian noun declensions mechanically when safe, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "noun":
+        lithuanian_noun = get_translation(session, lemma, "lt")
+        if lithuanian_noun:
+            known_gender = get_grammatical_gender(session, lemma.id, "lt")
+            mechanical_forms = decline_noun(lithuanian_noun, grammatical_gender=known_gender)
+            if mechanical_forms:
+                inferred_gender = mechanical_forms.get("gender")
+                declension_class = mechanical_forms.get("declension_class")
+                if inferred_gender:
+                    linguistic_db.add_grammar_fact(
+                        session,
+                        lemma_id=lemma.id,
+                        language_code="lt",
+                        fact_type="gender",
+                        fact_value=inferred_gender,
+                        notes="Inferred from mechanical Lithuanian noun declension",
+                        verified=False,
+                    )
+                if declension_class:
+                    linguistic_db.add_grammar_fact(
+                        session,
+                        lemma_id=lemma.id,
+                        language_code="lt",
+                        fact_type="declension",
+                        fact_value=declension_class,
+                        notes="Inferred from mechanical Lithuanian noun declension",
+                        verified=False,
+                    )
+                linguistic_db.log_query(
+                    session,
+                    word=lithuanian_noun,
+                    query_type="lithuanian_noun_declensions",
+                    prompt="[mechanical langtools.lt.declension]",
+                    response=json.dumps(
+                        {
+                            "forms": mechanical_forms,
+                            "notes": "mechanical from declension class by suffix",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return mechanical_forms, True
+            logger.info("Falling back to LLM for Lithuanian noun '%s'", lithuanian_noun)
+
     return query_forms(FORM_SPECS[("lt", "noun")], client, lemma_id, get_session_func)
 
 

--- a/src/langtools/noun_declensions.py
+++ b/src/langtools/noun_declensions.py
@@ -1,0 +1,24 @@
+"""Language selector for mechanical noun declension engines."""
+
+from importlib import import_module
+from typing import Callable, Dict, Optional, cast
+
+DeclineFunc = Callable[[str], Optional[Dict[str, str]]]
+
+
+def get_mechanical_noun_decliner(language_code: str) -> Optional[DeclineFunc]:
+    """Return a language-specific mechanical noun declension function if available."""
+    normalized = (language_code or "").strip().lower()
+    if not normalized:
+        return None
+
+    try:
+        module = import_module(f"langtools.{normalized}.declension")
+    except ModuleNotFoundError:
+        return None
+
+    decline_func = getattr(module, "decline_noun", None)
+    if callable(decline_func):
+        return cast(DeclineFunc, decline_func)
+
+    return None

--- a/src/tests/langtools/lt/test_declension.py
+++ b/src/tests/langtools/lt/test_declension.py
@@ -1,0 +1,59 @@
+import unittest
+
+from langtools.lt.declension import (
+    decline_noun,
+    get_declension_requirements,
+    get_supported_declension_classes,
+)
+
+
+class TestLithuanianMechanicalDeclension(unittest.TestCase):
+    def test_declines_masc_as(self) -> None:
+        forms = decline_noun("vilkas")
+        assert forms is not None
+        self.assertEqual(forms["genitive_singular"], "vilko")
+        self.assertEqual(forms["dative_plural"], "vilkams")
+        self.assertEqual(forms["declension_class"], "masc_as")
+        self.assertEqual(forms["gender"], "masculine")
+
+    def test_declines_fem_e(self) -> None:
+        forms = decline_noun("upė")
+        assert forms is not None
+        self.assertEqual(forms["accusative_singular"], "upę")
+        self.assertEqual(forms["locative_plural"], "upėse")
+
+    def test_declines_masc_us(self) -> None:
+        forms = decline_noun("sūnus")
+        assert forms is not None
+        self.assertEqual(forms["genitive_singular"], "sūnaus")
+        self.assertEqual(forms["locative_singular"], "sūnuje")
+        self.assertEqual(forms["nominative_plural"], "sūnūs")
+
+    def test_requires_gender_for_ambiguous_is(self) -> None:
+        self.assertIsNone(decline_noun("pilis"))
+        feminine_forms = decline_noun("pilis", grammatical_gender="feminine")
+        assert feminine_forms is not None
+        self.assertEqual(feminine_forms["genitive_singular"], "pilies")
+
+    def test_skips_irregular(self) -> None:
+        self.assertIsNone(decline_noun("žmogus"))
+
+    def test_respects_known_gender(self) -> None:
+        self.assertIsNone(decline_noun("vilkas", grammatical_gender="feminine"))
+
+    def test_requirements_shape(self) -> None:
+        requirements = get_declension_requirements()
+        self.assertIn("declension_class", requirements)
+        self.assertIn("irregular_flag", requirements)
+
+    def test_supported_classes_include_major_regular_sets(self) -> None:
+        classes = get_supported_declension_classes()
+        self.assertIn("masc_as", classes)
+        self.assertIn("masc_us", classes)
+        self.assertIn("masc_ys", classes)
+        self.assertIn("fem_a", classes)
+        self.assertIn("fem_ė", classes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/langtools/lt/test_llm_forms.py
+++ b/src/tests/langtools/lt/test_llm_forms.py
@@ -3,7 +3,11 @@ from types import SimpleNamespace
 from typing import Any, Callable, cast
 from unittest.mock import patch
 
-from langtools.lt.llm_forms import _parse_principal_parts, query_lithuanian_verb_conjugations
+from langtools.lt.llm_forms import (
+    _parse_principal_parts,
+    query_lithuanian_noun_declensions,
+    query_lithuanian_verb_conjugations,
+)
 
 
 class _FakeQuery:
@@ -33,6 +37,66 @@ class TestLithuanianMechanicalLlmForms(unittest.TestCase):
         self.assertEqual(
             _parse_principal_parts("dirbti (dirba, dirbo)"), ("dirbti", "dirba", "dirbo")
         )
+
+    def test_uses_mechanical_noun_declension(self) -> None:
+        lemma = SimpleNamespace(id=2, pos_type="noun", lemma_text="wolf", guid=None)
+        client = cast(Any, SimpleNamespace(default_model="fake-model"))
+
+        with (
+            patch("langtools.lt.llm_forms.get_translation", return_value="vilkas"),
+            patch("langtools.lt.llm_forms.get_grammatical_gender", return_value=None),
+            patch("langtools.lt.llm_forms.query_forms") as mock_query_forms,
+            patch("langtools.lt.llm_forms.linguistic_db.log_query") as mock_log_query,
+            patch("langtools.lt.llm_forms.linguistic_db.add_grammar_fact") as mock_add_fact,
+        ):
+            get_session = cast(Callable[[], Any], lambda: _FakeSession(lemma))
+            forms, ok = query_lithuanian_noun_declensions(client, 2, get_session)
+
+        self.assertTrue(ok)
+        self.assertEqual(forms["genitive_singular"], "vilko")
+        self.assertEqual(forms["nominative_plural"], "vilkai")
+        mock_query_forms.assert_not_called()
+        mock_log_query.assert_called_once()
+        self.assertGreaterEqual(mock_add_fact.call_count, 1)
+
+    def test_uses_gender_fact_for_ambiguous_is(self) -> None:
+        lemma = SimpleNamespace(id=3, pos_type="noun", lemma_text="castle", guid=None)
+        client = cast(Any, SimpleNamespace(default_model="fake-model"))
+
+        with (
+            patch("langtools.lt.llm_forms.get_translation", return_value="pilis"),
+            patch("langtools.lt.llm_forms.get_grammatical_gender", return_value="feminine"),
+            patch("langtools.lt.llm_forms.query_forms") as mock_query_forms,
+            patch("langtools.lt.llm_forms.linguistic_db.log_query"),
+            patch("langtools.lt.llm_forms.linguistic_db.add_grammar_fact"),
+        ):
+            get_session = cast(Callable[[], Any], lambda: _FakeSession(lemma))
+            forms, ok = query_lithuanian_noun_declensions(client, 3, get_session)
+
+        self.assertTrue(ok)
+        self.assertEqual(forms["genitive_singular"], "pilies")
+        mock_query_forms.assert_not_called()
+
+    def test_falls_back_for_ambiguous_is_without_gender_fact(self) -> None:
+        lemma = SimpleNamespace(id=4, pos_type="noun", lemma_text="castle", guid=None)
+        client = cast(Any, SimpleNamespace(default_model="fake-model"))
+
+        with (
+            patch("langtools.lt.llm_forms.get_translation", return_value="pilis"),
+            patch("langtools.lt.llm_forms.get_grammatical_gender", return_value=None),
+            patch(
+                "langtools.lt.llm_forms.query_forms",
+                return_value=({"nominative_singular": "pilis"}, True),
+            ) as mock_query_forms,
+            patch("langtools.lt.llm_forms.linguistic_db.log_query") as mock_log_query,
+            patch("langtools.lt.llm_forms.linguistic_db.add_grammar_fact"),
+        ):
+            get_session = cast(Callable[[], Any], lambda: _FakeSession(lemma))
+            _forms, ok = query_lithuanian_noun_declensions(client, 4, get_session)
+
+        self.assertTrue(ok)
+        mock_query_forms.assert_called_once()
+        mock_log_query.assert_not_called()
 
     def test_uses_mechanical_conjugation(self) -> None:
         lemma = SimpleNamespace(id=1, pos_type="verb", lemma_text="to work", guid=None)

--- a/src/tests/wordfreq/test_generate_forms_base.py
+++ b/src/tests/wordfreq/test_generate_forms_base.py
@@ -1,0 +1,29 @@
+import unittest
+
+from wordfreq.translation.generate_forms_base import FormGenerationConfig, extract_gender_from_forms
+
+
+class TestExtractGenderFromForms(unittest.TestCase):
+    def _lt_noun_config(self) -> FormGenerationConfig:
+        return FormGenerationConfig(
+            language_code="lt",
+            language_name="Lithuanian",
+            pos_type="noun",
+            form_mapping={},
+            client_method_name="query_lithuanian_noun_declensions",
+            min_forms_threshold=2,
+            base_form_identifier="nominative_singular",
+            extract_gender=True,
+        )
+
+    def test_lithuanian_masculine_ending(self) -> None:
+        forms = {"nominative_singular": "vilkas"}
+        self.assertEqual(extract_gender_from_forms(forms, self._lt_noun_config()), "masculine")
+
+    def test_lithuanian_feminine_ending(self) -> None:
+        forms = {"nominative_singular": "upė"}
+        self.assertEqual(extract_gender_from_forms(forms, self._lt_noun_config()), "feminine")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/wordfreq/test_generate_forms_tasks.py
+++ b/src/tests/wordfreq/test_generate_forms_tasks.py
@@ -1,0 +1,14 @@
+import unittest
+
+from wordfreq.translation.generate_forms_tasks import FORM_GENERATION_TASKS, get_task_key
+
+
+class TestGenerateFormsTasks(unittest.TestCase):
+    def test_lithuanian_noun_task_extracts_gender(self) -> None:
+        task_key = get_task_key("lt", "noun")
+        task = FORM_GENERATION_TASKS[task_key]
+        self.assertTrue(task.config.extract_gender)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/wordfreq/translation/generate_forms_base.py
+++ b/src/wordfreq/translation/generate_forms_base.py
@@ -27,7 +27,9 @@ from wordfreq.translation.client import LinguisticClient
 MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0  # seconds, doubles each retry
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 
@@ -319,8 +321,31 @@ def extract_gender_from_forms(
         gender = _detect_gender_from_article(forms_dict, config.language_code)
         if gender:
             return gender
+        if config.language_code == "lt":
+            gender = _detect_lithuanian_gender_from_nominative(forms_dict)
+            if gender:
+                return gender
 
     # If no gender could be determined, return None
+    return None
+
+
+def _detect_lithuanian_gender_from_nominative(forms_dict: Dict[str, str]) -> Optional[str]:
+    """Infer Lithuanian noun gender from nominative singular ending."""
+    nominative = forms_dict.get("nominative_singular")
+    if not nominative or not isinstance(nominative, str):
+        return None
+    normalized_nominative = nominative.strip().lower()
+    if not normalized_nominative:
+        return None
+
+    masculine_suffixes = ("as", "is", "ys", "us", "ius")
+    feminine_suffixes = ("a", "ė")
+
+    if normalized_nominative.endswith(masculine_suffixes):
+        return "masculine"
+    if normalized_nominative.endswith(feminine_suffixes):
+        return "feminine"
     return None
 
 

--- a/src/wordfreq/translation/generate_forms_tasks.py
+++ b/src/wordfreq/translation/generate_forms_tasks.py
@@ -102,6 +102,7 @@ _TASK_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
     # Lithuanian — translation fetcher, named client methods
     ("lt", "noun"): {
         "fetcher": "translation",
+        "gender": True,
         "client_method": "query_lithuanian_noun_declensions",
     },
     ("lt", "verb"): {


### PR DESCRIPTION
### Motivation

- Provide a conservative, mechanical declension engine for Lithuanian nouns to avoid unnecessary LLM calls for regular classes and to infer grammatical facts like gender and declension class.
- Surface a reusable language-specific decliner selector so mechanical declension can be plugged in per language.
- Improve gender extraction for Lithuanian nouns in the form generation pipeline so downstream tasks can use inferred gender where available.

### Description

- Added `langtools.lt.declension` implementing `decline_noun`, `_find_pattern`, `get_declension_requirements`, and `get_supported_declension_classes` with a set of regular declension `DeclensionPattern`s and an irregular-noun skip list.
- Added `langtools/noun_declensions.py` which exposes `get_mechanical_noun_decliner` to dynamically import a language-specific `decline_noun` implementation.
- Updated `langtools/lt/__init__.py` to export the new declension functions and integrated the decliner into `langtools.lt.llm_forms` by attempting mechanical declension (via `decline_noun`) before falling back to the LLM, and persisting inferred `gender` and `declension` facts via `linguistic_db.add_grammar_fact` and logging mechanical responses.
- Enhanced the form-generation pipeline by adding `_detect_lithuanian_gender_from_nominative` to `wordfreq/translation/generate_forms_base.py`, enabled Lithuanian noun gender extraction in `wordfreq/translation/generate_forms_tasks.py`, and made a small logging format cleanup.
- Added unit tests for the new declension engine and integration: `src/tests/langtools/lt/test_declension.py`, `src/tests/langtools/lt/test_llm_forms.py`, and new wordfreq tests `src/tests/wordfreq/test_generate_forms_base.py` and `src/tests/wordfreq/test_generate_forms_tasks.py`.

### Testing

- Ran the unit test suites for the modified components including `TestLithuanianMechanicalDeclension` and `TestLithuanianMechanicalLlmForms`, and they passed.
- Ran the wordfreq unit tests `TestExtractGenderFromForms` and `TestGenerateFormsTasks` and they passed.
- Verified that mechanical noun declension code paths cause the LLM fallback to not be called and that `linguistic_db.log_query` / `add_grammar_fact` hooks are invoked in the mechanical path via the added unit tests which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b35c92f574832791c06deca01fc216)