### PR TITLE
Add cognate metadata to WireWord exports

### DIFF
--- a/src/wireword/export_wireword.py
+++ b/src/wireword/export_wireword.py
@@ -40,13 +40,14 @@ from wireword.readings import (
 from wireword.text_rendering import format_subtype_display_name
 from wireword.helpers import (
     convert_to_wireword_grammatical_form_key,
+    extract_conjugation_slot,
+    extract_conjugation_tense,
     format_verb_entry,
     generate_simple_grammatical_form_label,
     normalize_pos_type,
-    extract_conjugation_slot,
-    extract_conjugation_tense,
 )
 from wireword.generate_manifest import generate_manifest
+from words.cognates import detect_cognate
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -780,6 +781,23 @@ class WirewordExporter:
                     wireword["base_english"] = source_word
                 else:
                     wireword["base_source"] = entry["source_word"]
+
+                noun_source_form: Optional[str]
+                if self.source_language == "en":
+                    noun_source_form = wireword.get("base_english")
+                else:
+                    noun_source_form = wireword.get("base_source")
+                if noun_source_form:
+                    noun_cognate_result = detect_cognate(
+                        noun_source_form,
+                        entry["target_language"],
+                        self.source_language,
+                        self.language,
+                    )
+                    wireword["cognate"] = noun_cognate_result.is_cognate
+                    if self.debug:
+                        wireword["cognate_score"] = noun_cognate_result.score
+                        wireword["cognate_reason_codes"] = list(noun_cognate_result.reasons)
                 wireword.update(
                     {
                         "corpus": assigned_corpus,
@@ -1513,6 +1531,23 @@ class WirewordExporter:
                     wireword["base_english"] = verb_source
                 else:
                     wireword["base_source"] = base_source
+
+                verb_source_form: Optional[str]
+                if self.source_language == "en":
+                    verb_source_form = wireword.get("base_english")
+                else:
+                    verb_source_form = wireword.get("base_source")
+                if verb_source_form:
+                    verb_cognate_result = detect_cognate(
+                        verb_source_form,
+                        base_target,
+                        self.source_language,
+                        self.language,
+                    )
+                    wireword["cognate"] = verb_cognate_result.is_cognate
+                    if self.debug:
+                        wireword["cognate_score"] = verb_cognate_result.score
+                        wireword["cognate_reason_codes"] = list(verb_cognate_result.reasons)
                 wireword.update(
                     {
                         "corpus": "VERBS",


### PR DESCRIPTION
### Motivation
- Provide a lightweight, deterministic cognate signal on exported WireWord entries so downstream consumers can surface likely shared-form/shared-origin pairs. 
- Ensure nouns/non-verbs and verbs export a consistent `cognate` flag and optionally richer debug information for inspection when `debug` is enabled.

### Description
- Import and invoke the cognate detector with source and target base forms via `detect_cognate` in `src/wireword/export_wireword.py`.
- Set `wireword["cognate"] = result.is_cognate` for noun/non-verb export path and for the verb export path using the appropriate `base_english`/`base_source` vs `base_target` values.
- When `debug` is true, also include `cognate_score` and `cognate_reason_codes` populated from the `CognateResult`; omit these fields in normal mode.
- Applied changes to both non-verb (noun/other) and verb construction branches so all exported entries have consistent cognate behavior.

### Testing
- Ran `black src/wireword/export_wireword.py` which succeeded.
- Ran `mypy src/wireword/export_wireword.py` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f342cc97a88327a082e37f1e211852)