### PR TITLE
Show lexeme frequency and tier signals on lemma view; import corpora into external annotations

### DIFF
--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -297,6 +297,16 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
     """View a single lemma with all details."""
     from barsukas.helpers.db_optimization import get_lemma_view_data
     from storage.crud.guid_tombstone import get_tombstones_by_lemma_id
+    from storage.lexeme import get_lexeme
+    from storage.models.schema import (
+        Corpus,
+        ExternalLexemeAnnotation,
+        ExternalLexemeAnnotationLemma,
+        LemmaTier,
+        TierDefinition,
+        WordFrequency,
+    )
+    from wordfreq.lexeme_frequency import get_lexeme_frequencies_all_corpora
 
     # Get all lemma data in optimized bulk queries (replaces 10+ separate queries)
     data = get_lemma_view_data(g.db, lemma_id)
@@ -412,6 +422,57 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
 
     queued_tasks = get_tasks_for_target(g.db, "lemma", lemma_id, limit=8)
 
+    lemma_tiers = (
+        g.db.query(LemmaTier)
+        .filter(LemmaTier.lemma_id == lemma_id)
+        .order_by(LemmaTier.source, LemmaTier.tier_name)
+        .all()
+    )
+    tier_definitions = (
+        g.db.query(TierDefinition)
+        .filter(TierDefinition.source.in_([tier.source for tier in lemma_tiers]))
+        .all()
+        if lemma_tiers
+        else []
+    )
+    tier_display_by_source_name = {
+        (row.source, row.tier_name): (row.display_name or row.tier_name) for row in tier_definitions
+    }
+
+    external_annotations = (
+        g.db.query(ExternalLexemeAnnotation)
+        .join(ExternalLexemeAnnotationLemma)
+        .filter(ExternalLexemeAnnotationLemma.lemma_id == lemma_id)
+        .order_by(ExternalLexemeAnnotation.source, ExternalLexemeAnnotation.tier_name)
+        .all()
+    )
+
+    frequency_rows = (
+        g.db.query(
+            DerivativeForm.derivative_form_text,
+            DerivativeForm.language_code,
+            Corpus.name,
+            WordFrequency.rank,
+            WordFrequency.frequency,
+        )
+        .join(WordFrequency, DerivativeForm.word_token_id == WordFrequency.word_token_id)
+        .join(Corpus, Corpus.id == WordFrequency.corpus_id)
+        .filter(DerivativeForm.lemma_id == lemma_id, DerivativeForm.word_token_id.isnot(None))
+        .order_by(DerivativeForm.language_code, Corpus.name, DerivativeForm.derivative_form_text)
+        .all()
+    )
+    enabled_corpora = {
+        corpus_name for (corpus_name,) in g.db.query(Corpus.name).filter(Corpus.enabled == True)
+    }
+    target_corpora = ["19th_books", "20th_books", "cooking", "wiki_vital"]
+    lexeme_frequency_by_corpus = {}
+    english_lexeme = get_lexeme(g.db, lemma_id, "en")
+    if english_lexeme:
+        all_rollups = get_lexeme_frequencies_all_corpora(g.db, english_lexeme)
+        for corpus_name in target_corpora:
+            if corpus_name in enabled_corpora:
+                lexeme_frequency_by_corpus[corpus_name] = all_rollups.get(corpus_name)
+
     return render_template(
         "lemmas/view.html",
         lemma=lemma,
@@ -445,6 +506,11 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
         google_voices=google_voices,
         related_lemmas=related_lemmas,
         queued_tasks=queued_tasks,
+        lemma_tiers=lemma_tiers,
+        tier_display_by_source_name=tier_display_by_source_name,
+        external_annotations=external_annotations,
+        frequency_rows=frequency_rows,
+        lexeme_frequency_by_corpus=lexeme_frequency_by_corpus,
         tier_3_languages=set(TIER_3_LANGUAGES),
     )
 

--- a/src/barsukas/templates/lemmas/sections/details.html
+++ b/src/barsukas/templates/lemmas/sections/details.html
@@ -118,3 +118,144 @@
         </div>
     </div>
 </div>
+
+<!-- Frequency and Tier Signals -->
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header">
+                <i class="bi bi-bar-chart"></i> Frequency and Tier Signals
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-lg-6 mb-3 mb-lg-0">
+                        <h6 class="mb-2">Lemma Tier Assignments</h6>
+                        {% if lemma_tiers %}
+                            <div class="table-responsive">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Source</th>
+                                            <th>Tier</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for tier in lemma_tiers %}
+                                        <tr>
+                                            <td><code>{{ tier.source }}</code></td>
+                                            <td>{{ tier_display_by_source_name.get((tier.source, tier.tier_name), tier.tier_name) }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <p class="text-muted mb-0">No lemma-tier assignment found yet.</p>
+                        {% endif %}
+
+                        <h6 class="mt-3 mb-2">External Lexeme Annotations (joined)</h6>
+                        {% if external_annotations %}
+                            <div class="table-responsive">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Source</th>
+                                            <th>Tier</th>
+                                            <th>POS hint</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for annotation in external_annotations %}
+                                        <tr>
+                                            <td><code>{{ annotation.source }}</code></td>
+                                            <td>{{ annotation.tier_name }}</td>
+                                            <td>{{ annotation.pos_hint or "—" }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <p class="text-muted mb-0">No linked external-annotation rows for this lemma.</p>
+                        {% endif %}
+                    </div>
+
+                    <div class="col-lg-6">
+                        <h6 class="mb-2">Lexeme Rollup (new system)</h6>
+                        {% if lexeme_frequency_by_corpus %}
+                            <div class="table-responsive mb-3">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Corpus</th>
+                                            <th>Total Lexeme Frequency</th>
+                                            <th>Contributing Forms</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for corpus_name, rollup in lexeme_frequency_by_corpus.items() %}
+                                        <tr>
+                                            <td><code>{{ corpus_name }}</code></td>
+                                            <td>
+                                                {% if rollup %}
+                                                    {{ "%.8f"|format(rollup.total_frequency) }}
+                                                {% else %}
+                                                    <span class="text-muted">No lexeme row</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if rollup %}
+                                                    {{ rollup.breakdown|length }}
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <p class="text-muted mb-3">No enabled lexeme-based corpora configured for this lemma yet.</p>
+                        {% endif %}
+
+                        <h6 class="mb-2">Word Frequency Modules</h6>
+                        {% if frequency_rows %}
+                            <div class="table-responsive">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Form</th>
+                                            <th>Lang</th>
+                                            <th>Module</th>
+                                            <th>Rank</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for row in frequency_rows %}
+                                        <tr>
+                                            <td>{{ row.derivative_form_text }}</td>
+                                            <td><code>{{ row.language_code }}</code></td>
+                                            <td><code>{{ row.name }}</code></td>
+                                            <td>
+                                                {% if row.rank is not none %}
+                                                    {{ row.rank }}
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p class="text-muted small mb-0">Supports current YLE-connected data and future corpora like <code>19th_books</code> and <code>cooking_wordfreq</code>.</p>
+                        {% else %}
+                            <p class="text-muted mb-0">No frequency-module rows linked to this lemma’s tokenized derivative forms yet.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/wordfreq/frequency/corpus.py
+++ b/src/wordfreq/frequency/corpus.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy.orm import Session
 
 import constants
-import wordfreq.frequency.analysis
 import wordfreq.frequency.importer
 from storage.backend.config import DataSourceConfig
 from storage.connection_pool import get_session
@@ -497,15 +496,14 @@ def load_corpus(corpus_name: str, config: Optional["DataSourceConfig"] = None) -
 
     logger.info(f"Loading corpus '{corpus_name}' from {full_file_path}")
 
-    # Call the import function with the configuration parameters
-    return wordfreq.frequency.importer.import_frequency_data(
+    # Import into external_lexeme_annotations (new system).
+    return wordfreq.frequency.importer.import_frequency_as_annotations(
         file_path=full_file_path,
         corpus_name=corpus_config.name,
         language_code=corpus_config.language_code,
         file_type=corpus_config.file_type,
         max_words=corpus_config.max_words,
         value_type=corpus_config.value_type,
-        corpus_description=corpus_config.description,
         config=config,
     )
 
@@ -547,14 +545,7 @@ def load_all_corpora() -> Dict[str, tuple[int, int]]:
             logger.error(f"Failed to load corpus {config.name}: {e}")
             results[config.name] = (0, 0)
 
-    # Calculate combined mean ranks (from original script)
-    logger.info("Calculating combined ranks...")
-    try:
-        analysis_config = DataSourceConfig()
-        wordfreq.frequency.analysis.calculate_combined_ranks(config=analysis_config)
-        logger.info("Harmonic mean ranks calculation completed!")
-    except Exception as e:
-        logger.error(f"Failed to calculate combined ranks: {e}")
+    logger.info("Skipping combined rank calculation: corpus import now targets annotations.")
 
     logger.info("Word frequency data population completed!")
     return results

--- a/src/wordfreq/frequency/importer.py
+++ b/src/wordfreq/frequency/importer.py
@@ -15,7 +15,7 @@ import wordfreq.frequency.corpus
 from storage import database
 from storage.backend.config import DataSourceConfig
 from storage.connection_pool import get_session
-from storage.models.schema import Corpus, WordFrequency, WordToken
+from storage.models.schema import Corpus, ExternalLexemeAnnotation, WordFrequency, WordToken
 from wordfreq.translation.client import LinguisticClient
 
 # Configure logging
@@ -363,11 +363,99 @@ def import_frequency_data(
             f"Successfully imported {imported_count}/{total_count} words for corpus '{corpus_name}'"
         )
         return (imported_count, total_count)
-
     except Exception as e:
         logger.error(f"Error importing frequency data: {e}")
         session.rollback()
         raise
+
+
+def import_frequency_as_annotations(
+    file_path: str,
+    corpus_name: str,
+    language_code: str = "en",
+    file_type: str = "json",
+    max_words: int = 5000,
+    value_type: str = "auto",
+    config: Optional["DataSourceConfig"] = None,
+) -> Tuple[int, int]:
+    """Import corpus rows into external_lexeme_annotations instead of word_frequencies.
+
+    Creates/updates rows under source ``wordfreq_<corpus_name>`` with:
+    - tier_name: rank bucket (very_common/common/rare)
+    - notes: JSON payload with original rank/frequency and corpus metadata
+    """
+    if config is None:
+        config = DataSourceConfig()
+    imported_count, total_count = import_frequency_data(
+        file_path=file_path,
+        corpus_name=corpus_name,
+        language_code=language_code,
+        file_type=file_type,
+        max_words=max_words,
+        value_type=value_type,
+        config=config,
+    )
+
+    # Re-read canonical rows from DB, then mirror into ExternalLexemeAnnotation.
+    session = get_session(config)
+    source_name = f"wordfreq_{corpus_name}"
+    try:
+        corpus = session.query(Corpus).filter(Corpus.name == corpus_name).first()
+        if corpus is None:
+            return (0, total_count)
+
+        rows = (
+            session.query(WordFrequency, WordToken)
+            .join(WordToken, WordToken.id == WordFrequency.word_token_id)
+            .filter(WordFrequency.corpus_id == corpus.id, WordToken.language_code == language_code)
+            .order_by(WordFrequency.rank.asc().nullslast(), WordToken.token.asc())
+            .limit(max_words)
+            .all()
+        )
+
+        for wf_row, token_row in rows:
+            rank_value = wf_row.rank if wf_row.rank is not None else 10**9
+            if rank_value <= 1000:
+                tier_name = "very_common"
+            elif rank_value <= 4000:
+                tier_name = "common"
+            else:
+                tier_name = "rare"
+
+            existing_annotation = (
+                session.query(ExternalLexemeAnnotation)
+                .filter(
+                    ExternalLexemeAnnotation.word_token_id == token_row.id,
+                    ExternalLexemeAnnotation.source == source_name,
+                    ExternalLexemeAnnotation.pos_hint.is_(None),
+                    ExternalLexemeAnnotation.sense_hint.is_(None),
+                )
+                .first()
+            )
+            notes_payload = json.dumps(
+                {
+                    "corpus": corpus_name,
+                    "rank": wf_row.rank,
+                    "frequency": wf_row.frequency,
+                }
+            )
+            if existing_annotation is None:
+                session.add(
+                    ExternalLexemeAnnotation(
+                        word_token_id=token_row.id,
+                        source=source_name,
+                        tier_name=tier_name,
+                        notes=notes_payload,
+                    )
+                )
+            else:
+                existing_annotation.tier_name = tier_name
+                existing_annotation.notes = notes_payload
+
+        session.commit()
+        return (len(rows), total_count)
+    finally:
+        session.close()
 
 
 # NOTE: The import_all_corpus_data function has been moved to corpus.py as load_all_corpora()


### PR DESCRIPTION
### Motivation

- Surface frequency and tier signals on the lemma detail page to aid review and QA of tier/lexeme data.
- Migrate corpus imports to populate the external-lexeme-annotation system instead of only word-frequency rows to support the new annotation-driven workflow.
- Stop running the legacy combined-rank calculation in the corpus loader since corpora now target annotations.

### Description

- Update `lemmas.view_lemma` to prefetch and pass `LemmaTier`, `TierDefinition`, `ExternalLexemeAnnotation`, frequency rows and lexeme rollup data into the template using `get_lexeme` and `get_lexeme_frequencies_all_corpora` and new queries. 
- Add a new "Frequency and Tier Signals" card in the lemma details template (`templates/lemmas/sections/details.html`) that shows lemma-tier assignments, linked external annotations, lexeme rollup per corpus, and token-level frequency rows.
- Change corpus import entrypoint (`wordfreq/frequency/corpus.py`) to call `import_frequency_as_annotations` instead of the old importer and remove the combined-ranks step from `load_all_corpora`.
- Add `import_frequency_as_annotations` to `wordfreq/frequency/importer.py`, which mirrors imported `WordFrequency`/`WordToken` rows into `ExternalLexemeAnnotation` rows with a `tier_name` (very_common/common/rare) and JSON `notes`, and leave existing `import_frequency_data` unchanged for backwards compatibility.

### Testing

- Ran the project test suite with `pytest` and the tests completed successfully.
- Exercised the corpus import path with a small sample corpus using `wordfreq.frequency.corpus.load_corpus(...)` and verified that `ExternalLexemeAnnotation` rows were created/updated as expected (smoke integration test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c4a2acec8327a53f9367086ff93f)