### PR TITLE
Split synonym sync from derivative sync; load forms/synonyms in golden mode

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -82,6 +82,7 @@ from barsukas.routes import (
     sync_relation_release,
     sync_release,
     sync_sentence_release,
+    sync_synonym_release,
     translations,
     wireword,
 )
@@ -233,6 +234,7 @@ def create_app(
     app.register_blueprint(sync_relation_release.bp)
     app.register_blueprint(sync_sentence_release.bp)
     app.register_blueprint(sync_derivative_release.bp)
+    app.register_blueprint(sync_synonym_release.bp)
 
     # --- Benchmarks integration ---
     # Barsukas always uses PostgreSQL to access the benchmarks schema.

--- a/src/barsukas/routes/sync_release_helpers.py
+++ b/src/barsukas/routes/sync_release_helpers.py
@@ -1,0 +1,171 @@
+"""Shared helpers for derivative-form / synonym release sync routes.
+
+The two sync pages (``/sync/derivatives`` and ``/sync/synonyms``) both read and
+write per-language JSONL files of the shape::
+
+    {"guid": "N02_001", "forms": [...], "synonyms": [...]}
+
+Each route operates on exactly one of those top-level array keys; the other
+must be preserved when rewriting a line. The helpers in this module factor
+out that file I/O so the two routes can share it.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def load_release_array_for_lang(
+    release_dir: Path, lang_code: str, array_key: str
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Load one of the top-level arrays (``forms`` or ``synonyms``) per GUID.
+
+    Scans every ``{lang_code}.jsonl`` under the release directory.
+    """
+    out: Dict[str, List[Dict[str, Any]]] = {}
+    if not release_dir.exists():
+        return out
+
+    filename = f"{lang_code}.jsonl"
+    for lang_file in release_dir.rglob(filename):
+        try:
+            with open(lang_file, "r", encoding="utf-8") as f:
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError as e:
+                        logger.error(f"JSON parse error in {lang_file}:{line_num}: {e}")
+                        continue
+                    guid = data.get("guid")
+                    arr = data.get(array_key, [])
+                    if guid and arr:
+                        out[guid] = arr
+        except Exception as e:
+            logger.error(f"Error reading {lang_file}: {e}")
+    return out
+
+
+def find_release_file_for_lemma_lang(
+    release_dir: Path, guid: str, lang_code: str
+) -> Optional[Path]:
+    """Find the {lang}.jsonl file that contains (or should contain) ``guid``.
+
+    First searches existing lang files; if not found, resolves the directory
+    from the matching ``base.jsonl``.
+    """
+    filename = f"{lang_code}.jsonl"
+
+    for lang_file in release_dir.rglob(filename):
+        try:
+            with open(lang_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        if data.get("guid") == guid:
+                            return lang_file
+                    except json.JSONDecodeError:
+                        continue
+        except Exception:
+            continue
+
+    for base_file in release_dir.rglob("base.jsonl"):
+        try:
+            with open(base_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                        if data.get("guid") == guid:
+                            return base_file.parent / filename
+                    except json.JSONDecodeError:
+                        continue
+        except Exception:
+            continue
+
+    return None
+
+
+def write_release_line_partial(
+    file_path: Path, guid: str, array_key: str, value: List[Dict[str, Any]]
+) -> None:
+    """Write or update one top-level array key on a GUID's JSONL line.
+
+    Only ``array_key`` is replaced; any other top-level keys present on an
+    existing line (e.g. the *other* of ``forms`` / ``synonyms``) are preserved.
+    If ``value`` is empty the key is dropped from the line; if no other keys
+    remain besides ``guid`` the line is removed entirely.
+    """
+    existing: Optional[Dict[str, Any]] = None
+    other_lines: List[str] = []
+
+    if file_path.exists():
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    other_lines.append(line)
+                    continue
+                try:
+                    data = json.loads(stripped)
+                except json.JSONDecodeError:
+                    other_lines.append(line)
+                    continue
+                if data.get("guid") == guid:
+                    existing = data
+                else:
+                    other_lines.append(line)
+
+    record: Dict[str, Any] = existing or {"guid": guid}
+    if value:
+        record[array_key] = value
+    else:
+        record.pop(array_key, None)
+
+    drop_record = len(record) <= 1  # only "guid" left
+
+    if not drop_record:
+        new_line = json.dumps(record, ensure_ascii=False) + "\n"
+        merged = _insert_sorted(other_lines, guid, new_line)
+    else:
+        merged = other_lines
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.writelines(merged)
+
+    logger.info(f"Wrote {array_key} for {guid} to {file_path}")
+
+
+def _insert_sorted(lines: List[str], new_guid: str, new_line: str) -> List[str]:
+    """Insert ``new_line`` into ``lines`` maintaining GUID sort order."""
+    result: List[str] = []
+    inserted = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            result.append(line)
+            continue
+        if not inserted:
+            try:
+                data = json.loads(stripped)
+                existing_guid = data.get("guid", "")
+                if existing_guid > new_guid:
+                    result.append(new_line)
+                    inserted = True
+            except json.JSONDecodeError:
+                pass
+        result.append(line)
+    if not inserted:
+        result.append(new_line)
+    return result

--- a/src/barsukas/routes/sync_synonym_release.py
+++ b/src/barsukas/routes/sync_synonym_release.py
@@ -1,16 +1,19 @@
 #!/usr/bin/python3
 
-"""Routes for syncing derivative forms between per-language release files and SQLite database.
+"""Routes for syncing synonyms between per-language release files and the DB.
 
-Derivative forms are stored in per-language JSONL files alongside the base.jsonl:
-    data/release/lemmas/{pos_type}/{pos_subtype}/{lang_code}.jsonl
+Synonyms live alongside inflected forms in the same per-language JSONL file
+under a separate top-level array key, so both can be edited independently::
 
-Each line in a language file contains derivative forms for one lemma:
-    {"guid": "N02_001", "forms": [
-        {"grammatical_form": "noun/es_singular", "text": "perro", "is_base_form": true,
-         "ipa": "/ˈpe.ro/", "phonetic": null},
-        {"grammatical_form": "noun/es_plural", "text": "perros", "is_base_form": false}
-    ]}
+    {"guid": "N02_001",
+     "forms":    [{"grammatical_form": "noun/es_singular", "text": "perro", ...}],
+     "synonyms": [{"grammatical_form": "synonym",          "text": "can"},
+                  {"grammatical_form": "synonym_regional", "text": "chucho"}]}
+
+In the SQL DB, synonyms are stored in the same ``DerivativeForm`` table as
+other forms, distinguished by ``grammatical_form`` membership in
+``SYNONYM_GRAMMATICAL_FORMS``. We may revisit that grouping later, but for
+now treating them as DerivativeForm rows keeps load/lookup paths uniform.
 """
 
 import logging
@@ -37,14 +40,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-bp = Blueprint("sync_derivative_release", __name__, url_prefix="/sync/derivatives")
+bp = Blueprint("sync_synonym_release", __name__, url_prefix="/sync/synonyms")
 
-# Default path to data/release/lemmas (derivative files live alongside base.jsonl)
 DEFAULT_RELEASE_DIR = Path(__file__).parent.parent.parent.parent / "data" / "release" / "lemmas"
 
 
 def _get_release_dir() -> Path:
-    """Get the path to the data/release/lemmas directory."""
     return DEFAULT_RELEASE_DIR
 
 
@@ -54,11 +55,10 @@ def _get_release_dir() -> Path:
 
 
 def _db_form_to_dict(form: DerivativeForm) -> Dict[str, Any]:
-    """Convert a DB DerivativeForm to the release file dict format."""
+    """Convert a DB synonym DerivativeForm to the release file dict format."""
     d: Dict[str, Any] = {
         "grammatical_form": form.grammatical_form,
         "text": form.derivative_form_text,
-        "is_base_form": form.is_base_form,
     }
     if form.ipa_pronunciation:
         d["ipa"] = form.ipa_pronunciation
@@ -67,36 +67,20 @@ def _db_form_to_dict(form: DerivativeForm) -> Dict[str, Any]:
     return d
 
 
-def _forms_match(release_form: Dict[str, Any], db_form: DerivativeForm) -> bool:
-    """Check if a release form dict matches a DB DerivativeForm on key fields."""
-    return bool(
-        release_form.get("grammatical_form") == db_form.grammatical_form
-        and release_form.get("text") == db_form.derivative_form_text
-    )
-
-
 def _form_key(grammatical_form: str, text: str) -> str:
-    """Create a comparison key for a derivative form."""
     return f"{grammatical_form}|{text}"
 
 
 # =============================================================================
-# Loading release data
+# Loading
 # =============================================================================
 
 
-def _load_release_derivatives_for_lang(
+def _load_release_synonyms_for_lang(
     release_dir: Path, lang_code: str
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Load non-synonym derivative forms for a language from release JSONL files.
-
-    Reads only the top-level ``forms`` array; synonyms live under a separate
-    ``synonyms`` key and are handled by ``sync_synonym_release``.
-
-    Returns:
-        Dictionary mapping GUID to list of derivative form dicts.
-    """
-    return load_release_array_for_lang(release_dir, lang_code, "forms")
+    """Load synonym entries for a language from release JSONL files."""
+    return load_release_array_for_lang(release_dir, lang_code, "synonyms")
 
 
 def _get_languages_with_release_files(release_dir: Path) -> Set[str]:
@@ -104,88 +88,183 @@ def _get_languages_with_release_files(release_dir: Path) -> Set[str]:
     languages: Set[str] = set()
     if not release_dir.exists():
         return languages
-
     for jsonl_file in release_dir.rglob("*.jsonl"):
         stem = jsonl_file.stem
-        # Skip base.jsonl and non-language files
         if stem == "base":
             continue
-        # Language codes are 2-3 chars
         if len(stem) in (2, 3) and stem.isalpha():
             languages.add(stem)
-
     return languages
 
 
-def _find_release_file_for_lemma_lang(
-    release_dir: Path, guid: str, lang_code: str
-) -> Optional[Path]:
-    """Find the {lang}.jsonl file that contains (or should contain) ``guid``."""
-    return find_release_file_for_lemma_lang(release_dir, guid, lang_code)
-
-
-# =============================================================================
-# DB loading helpers
-# =============================================================================
-
-
-def _load_db_derivatives_for_lang(
-    db_session: Any, lang_code: str
-) -> Dict[str, List[DerivativeForm]]:
-    """Load all derivative forms for a language from the DB, keyed by lemma GUID.
-
-    Returns:
-        Dictionary mapping GUID to list of DerivativeForm objects.
-    """
+def _load_db_synonyms_for_lang(db_session: Any, lang_code: str) -> Dict[str, List[DerivativeForm]]:
+    """Load synonym DerivativeForm rows for a language, keyed by lemma GUID."""
     forms_by_guid: Dict[str, List[DerivativeForm]] = {}
-
-    # Join DerivativeForm with Lemma to get GUIDs. Synonym-class rows are
-    # managed by the parallel /sync/synonyms route, so exclude them here.
     rows = (
         db_session.query(DerivativeForm, Lemma.guid)
         .join(Lemma, DerivativeForm.lemma_id == Lemma.id)
         .filter(
             DerivativeForm.language_code == lang_code,
             Lemma.guid.isnot(None),
-            DerivativeForm.grammatical_form.notin_(tuple(SYNONYM_GRAMMATICAL_FORMS)),
+            DerivativeForm.grammatical_form.in_(tuple(SYNONYM_GRAMMATICAL_FORMS)),
         )
         .all()
     )
-
     for form, guid in rows:
-        if guid not in forms_by_guid:
-            forms_by_guid[guid] = []
-        forms_by_guid[guid].append(form)
-
+        forms_by_guid.setdefault(guid, []).append(form)
     return forms_by_guid
 
 
 # =============================================================================
-# Index (Hub)
+# Diff helpers
+# =============================================================================
+
+
+def _has_form_differences(
+    release_forms: List[Dict[str, Any]], db_forms: List[DerivativeForm]
+) -> bool:
+    release_keys = {
+        _form_key(f.get("grammatical_form", ""), f.get("text", "")) for f in release_forms
+    }
+    db_keys = {_form_key(f.grammatical_form, f.derivative_form_text) for f in db_forms}
+
+    if release_keys != db_keys:
+        return True
+
+    release_by_key = {
+        _form_key(f.get("grammatical_form", ""), f.get("text", "")): f for f in release_forms
+    }
+    db_by_key = {_form_key(f.grammatical_form, f.derivative_form_text): f for f in db_forms}
+
+    for key in release_keys:
+        rf = release_by_key[key]
+        df = db_by_key[key]
+        if (rf.get("ipa") or "") != (df.ipa_pronunciation or ""):
+            return True
+        if (rf.get("phonetic") or "") != (df.phonetic_pronunciation or ""):
+            return True
+    return False
+
+
+def _compute_form_diffs(
+    release_forms: List[Dict[str, Any]], db_forms: List[DerivativeForm]
+) -> List[Dict[str, Any]]:
+    diffs: List[Dict[str, Any]] = []
+
+    release_by_key = {
+        _form_key(f.get("grammatical_form", ""), f.get("text", "")): f for f in release_forms
+    }
+    db_by_key = {_form_key(f.grammatical_form, f.derivative_form_text): f for f in db_forms}
+
+    release_keys = set(release_by_key.keys())
+    db_keys = set(db_by_key.keys())
+
+    for key in sorted(release_keys - db_keys):
+        rf = release_by_key[key]
+        diffs.append(
+            {
+                "type": "release_only",
+                "grammatical_form": rf.get("grammatical_form", ""),
+                "release_text": rf.get("text", ""),
+                "db_text": "",
+                "release_ipa": rf.get("ipa", ""),
+                "db_ipa": "",
+                "release_phonetic": rf.get("phonetic", ""),
+                "db_phonetic": "",
+            }
+        )
+
+    for key in sorted(db_keys - release_keys):
+        df = db_by_key[key]
+        diffs.append(
+            {
+                "type": "db_only",
+                "grammatical_form": df.grammatical_form,
+                "release_text": "",
+                "db_text": df.derivative_form_text,
+                "release_ipa": "",
+                "db_ipa": df.ipa_pronunciation or "",
+                "release_phonetic": "",
+                "db_phonetic": df.phonetic_pronunciation or "",
+            }
+        )
+
+    for key in sorted(release_keys & db_keys):
+        rf = release_by_key[key]
+        df = db_by_key[key]
+        r_ipa = rf.get("ipa") or ""
+        d_ipa = df.ipa_pronunciation or ""
+        r_phonetic = rf.get("phonetic") or ""
+        d_phonetic = df.phonetic_pronunciation or ""
+        if r_ipa != d_ipa or r_phonetic != d_phonetic:
+            diffs.append(
+                {
+                    "type": "field_diff",
+                    "grammatical_form": rf.get("grammatical_form", ""),
+                    "release_text": rf.get("text", ""),
+                    "db_text": df.derivative_form_text,
+                    "release_ipa": r_ipa,
+                    "db_ipa": d_ipa,
+                    "release_phonetic": r_phonetic,
+                    "db_phonetic": d_phonetic,
+                }
+            )
+    return diffs
+
+
+def _get_lemma_info_by_guids(db_session: Any, guids: Set[str]) -> Dict[str, Dict[str, Any]]:
+    info: Dict[str, Dict[str, Any]] = {}
+    if not guids:
+        return info
+    batch_size = 500
+    guid_list = list(guids)
+    for i in range(0, len(guid_list), batch_size):
+        batch = guid_list[i : i + batch_size]
+        lemmas = db_session.query(Lemma).filter(Lemma.guid.in_(batch)).all()
+        for lemma in lemmas:
+            info[lemma.guid] = {
+                "lemma_id": lemma.id,
+                "lemma_text": lemma.lemma_text,
+                "pos_type": lemma.pos_type,
+                "pos_subtype": lemma.pos_subtype or "",
+            }
+    return info
+
+
+def _build_guid_to_lemma_id(db_session: Any) -> Dict[str, int]:
+    return {
+        guid: lid
+        for lid, guid in db_session.query(Lemma.id, Lemma.guid).filter(Lemma.guid.isnot(None)).all()
+    }
+
+
+# =============================================================================
+# Index
 # =============================================================================
 
 
 @bp.route("/")
 def index() -> ResponseReturnValue:
-    """Display derivative form sync hub with per-language counts."""
+    """Per-language synonym sync hub."""
     release_dir = _get_release_dir()
 
     if not release_dir.exists():
         return render_template(
-            "sync_derivative_release/index.html",
+            "sync_synonym_release/index.html",
             release_dir=str(release_dir),
             error="Release directory not found",
             lang_counts=None,
         )
 
-    # Find languages that have release files
     release_languages = _get_languages_with_release_files(release_dir)
 
-    # Find languages that have DB derivative forms
     db_lang_rows = (
         g.db.query(DerivativeForm.language_code)
         .join(Lemma, DerivativeForm.lemma_id == Lemma.id)
-        .filter(Lemma.guid.isnot(None))
+        .filter(
+            Lemma.guid.isnot(None),
+            DerivativeForm.grammatical_form.in_(tuple(SYNONYM_GRAMMATICAL_FORMS)),
+        )
         .distinct()
         .all()
     )
@@ -196,11 +275,10 @@ def index() -> ResponseReturnValue:
         key=lambda lc: (LANGUAGE_HIERARCHY.index(lc) if lc in LANGUAGE_HIERARCHY else 999),
     )
 
-    # For each language, compute summary counts
     lang_counts: List[Dict[str, Any]] = []
     for lang_code in all_languages:
-        release_forms = _load_release_derivatives_for_lang(release_dir, lang_code)
-        db_forms = _load_db_derivatives_for_lang(g.db, lang_code)
+        release_forms = _load_release_synonyms_for_lang(release_dir, lang_code)
+        db_forms = _load_db_synonyms_for_lang(g.db, lang_code)
 
         release_guids = set(release_forms.keys())
         db_guids = set(db_forms.keys())
@@ -208,7 +286,6 @@ def index() -> ResponseReturnValue:
         additions = len(release_guids - db_guids)
         removals = len(db_guids - release_guids)
 
-        # Count changes among common GUIDs
         common_guids = release_guids & db_guids
         changes = 0
         for guid in common_guids:
@@ -231,153 +308,34 @@ def index() -> ResponseReturnValue:
         )
 
     return render_template(
-        "sync_derivative_release/index.html",
+        "sync_synonym_release/index.html",
         release_dir=str(release_dir),
         lang_counts=lang_counts,
     )
 
 
-def _has_form_differences(
-    release_forms: List[Dict[str, Any]], db_forms: List[DerivativeForm]
-) -> bool:
-    """Check if there are any differences between release and DB forms for a GUID."""
-    release_keys = {
-        _form_key(f.get("grammatical_form", ""), f.get("text", "")) for f in release_forms
-    }
-    db_keys = {_form_key(f.grammatical_form, f.derivative_form_text) for f in db_forms}
-
-    if release_keys != db_keys:
-        return True
-
-    # Keys match; check pronunciation/is_base_form differences
-    release_by_key = {
-        _form_key(f.get("grammatical_form", ""), f.get("text", "")): f for f in release_forms
-    }
-    db_by_key = {_form_key(f.grammatical_form, f.derivative_form_text): f for f in db_forms}
-
-    for key in release_keys:
-        rf = release_by_key[key]
-        df = db_by_key[key]
-
-        if rf.get("is_base_form", False) != df.is_base_form:
-            return True
-        if (rf.get("ipa") or "") != (df.ipa_pronunciation or ""):
-            return True
-        if (rf.get("phonetic") or "") != (df.phonetic_pronunciation or ""):
-            return True
-
-    return False
-
-
 # =============================================================================
-# Language detail view (per-language additions, removals, changes)
+# Language detail
 # =============================================================================
-
-
-def _compute_form_diffs(
-    release_forms: List[Dict[str, Any]], db_forms: List[DerivativeForm]
-) -> List[Dict[str, Any]]:
-    """Compute detailed per-form differences between release and DB.
-
-    Returns a list of diff dicts, each describing one form difference.
-    """
-    diffs: List[Dict[str, Any]] = []
-
-    release_by_key = {
-        _form_key(f.get("grammatical_form", ""), f.get("text", "")): f for f in release_forms
-    }
-    db_by_key = {_form_key(f.grammatical_form, f.derivative_form_text): f for f in db_forms}
-
-    release_keys = set(release_by_key.keys())
-    db_keys = set(db_by_key.keys())
-
-    # Forms only in release
-    for key in sorted(release_keys - db_keys):
-        rf = release_by_key[key]
-        diffs.append(
-            {
-                "type": "release_only",
-                "grammatical_form": rf.get("grammatical_form", ""),
-                "release_text": rf.get("text", ""),
-                "db_text": "",
-                "release_ipa": rf.get("ipa", ""),
-                "db_ipa": "",
-                "release_phonetic": rf.get("phonetic", ""),
-                "db_phonetic": "",
-                "release_is_base": rf.get("is_base_form", False),
-                "db_is_base": False,
-            }
-        )
-
-    # Forms only in DB
-    for key in sorted(db_keys - release_keys):
-        df = db_by_key[key]
-        diffs.append(
-            {
-                "type": "db_only",
-                "grammatical_form": df.grammatical_form,
-                "release_text": "",
-                "db_text": df.derivative_form_text,
-                "release_ipa": "",
-                "db_ipa": df.ipa_pronunciation or "",
-                "release_phonetic": "",
-                "db_phonetic": df.phonetic_pronunciation or "",
-                "release_is_base": False,
-                "db_is_base": df.is_base_form,
-            }
-        )
-
-    # Forms in both - check for field differences
-    for key in sorted(release_keys & db_keys):
-        rf = release_by_key[key]
-        df = db_by_key[key]
-
-        r_ipa = rf.get("ipa") or ""
-        d_ipa = df.ipa_pronunciation or ""
-        r_phonetic = rf.get("phonetic") or ""
-        d_phonetic = df.phonetic_pronunciation or ""
-        r_base = rf.get("is_base_form", False)
-        d_base = df.is_base_form
-
-        if r_ipa != d_ipa or r_phonetic != d_phonetic or r_base != d_base:
-            diffs.append(
-                {
-                    "type": "field_diff",
-                    "grammatical_form": rf.get("grammatical_form", ""),
-                    "release_text": rf.get("text", ""),
-                    "db_text": df.derivative_form_text,
-                    "release_ipa": r_ipa,
-                    "db_ipa": d_ipa,
-                    "release_phonetic": r_phonetic,
-                    "db_phonetic": d_phonetic,
-                    "release_is_base": r_base,
-                    "db_is_base": d_base,
-                }
-            )
-
-    return diffs
 
 
 @bp.route("/<lang_code>")
 def language_detail(lang_code: str) -> ResponseReturnValue:
-    """Show detailed sync status for a single language."""
     release_dir = _get_release_dir()
 
     if not release_dir.exists():
         flash(f"Release directory not found: {release_dir}", "error")
-        return redirect(url_for("sync_derivative_release.index"))
+        return redirect(url_for("sync_synonym_release.index"))
 
-    release_forms = _load_release_derivatives_for_lang(release_dir, lang_code)
-    db_forms = _load_db_derivatives_for_lang(g.db, lang_code)
+    release_forms = _load_release_synonyms_for_lang(release_dir, lang_code)
+    db_forms = _load_db_synonyms_for_lang(g.db, lang_code)
 
     release_guids = set(release_forms.keys())
     db_guids = set(db_forms.keys())
 
-    # Build GUID -> lemma info lookup for display
     all_guids = release_guids | db_guids
     guid_info = _get_lemma_info_by_guids(g.db, all_guids)
 
-    # Additions: in release but not in DB
     additions: List[Dict[str, Any]] = []
     for guid in sorted(release_guids - db_guids):
         info = guid_info.get(guid, {})
@@ -392,7 +350,6 @@ def language_detail(lang_code: str) -> ResponseReturnValue:
             }
         )
 
-    # Removals: in DB but not in release
     removals: List[Dict[str, Any]] = []
     for guid in sorted(db_guids - release_guids):
         info = guid_info.get(guid, {})
@@ -408,7 +365,6 @@ def language_detail(lang_code: str) -> ResponseReturnValue:
             }
         )
 
-    # Changes: in both but different
     changes: List[Dict[str, Any]] = []
     for guid in sorted(release_guids & db_guids):
         form_diffs = _compute_form_diffs(release_forms[guid], db_forms[guid])
@@ -427,7 +383,7 @@ def language_detail(lang_code: str) -> ResponseReturnValue:
             )
 
     return render_template(
-        "sync_derivative_release/language_detail.html",
+        "sync_synonym_release/language_detail.html",
         lang_code=lang_code,
         lang_name=LANGUAGE_NAMES.get(lang_code, lang_code),
         additions=additions,
@@ -438,50 +394,25 @@ def language_detail(lang_code: str) -> ResponseReturnValue:
     )
 
 
-def _get_lemma_info_by_guids(db_session: Any, guids: Set[str]) -> Dict[str, Dict[str, Any]]:
-    """Look up basic lemma info for a set of GUIDs."""
-    info: Dict[str, Dict[str, Any]] = {}
-    if not guids:
-        return info
-
-    batch_size = 500
-    guid_list = list(guids)
-    for i in range(0, len(guid_list), batch_size):
-        batch = guid_list[i : i + batch_size]
-        lemmas = db_session.query(Lemma).filter(Lemma.guid.in_(batch)).all()
-        for lemma in lemmas:
-            info[lemma.guid] = {
-                "lemma_id": lemma.id,
-                "lemma_text": lemma.lemma_text,
-                "pos_type": lemma.pos_type,
-                "pos_subtype": lemma.pos_subtype or "",
-            }
-
-    return info
-
-
 # =============================================================================
-# Apply additions (import release -> DB)
+# Apply additions
 # =============================================================================
 
 
 @bp.route("/<lang_code>/additions/apply", methods=["POST"])
 def apply_additions(lang_code: str) -> ResponseReturnValue:
-    """Import selected derivative forms from release files into DB."""
     app: "BarsukasFlask" = current_app  # type: ignore[assignment]
     if app.config.get("READONLY", False):
         flash("Database is in read-only mode", "error")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     selected_guids = request.form.getlist("selected_guids")
     if not selected_guids:
         flash("No lemmas selected for import", "warning")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     release_dir = _get_release_dir()
-    release_forms = _load_release_derivatives_for_lang(release_dir, lang_code)
-
-    # Build GUID -> lemma_id lookup
+    release_forms = _load_release_synonyms_for_lang(release_dir, lang_code)
     guid_to_lemma_id = _build_guid_to_lemma_id(g.db)
 
     imported_count = 0
@@ -490,24 +421,27 @@ def apply_additions(lang_code: str) -> ResponseReturnValue:
     for guid in selected_guids:
         forms = release_forms.get(guid)
         if not forms:
-            logger.warning(f"No release forms found for GUID {guid} lang={lang_code}")
             error_count += 1
             continue
-
         lemma_id = guid_to_lemma_id.get(guid)
         if not lemma_id:
-            logger.warning(f"Lemma not found in DB for GUID {guid}")
             error_count += 1
             continue
-
         try:
             for form_data in forms:
+                gform = form_data.get("grammatical_form", "")
+                if gform not in SYNONYM_GRAMMATICAL_FORMS:
+                    logger.warning(
+                        f"Skipping non-synonym grammatical_form {gform!r} in synonyms array "
+                        f"for {guid} lang={lang_code}"
+                    )
+                    continue
                 df = DerivativeForm(
                     lemma_id=lemma_id,
                     language_code=lang_code,
-                    grammatical_form=form_data.get("grammatical_form", ""),
+                    grammatical_form=gform,
                     derivative_form_text=form_data.get("text", ""),
-                    is_base_form=form_data.get("is_base_form", False),
+                    is_base_form=False,
                     ipa_pronunciation=form_data.get("ipa") or None,
                     phonetic_pronunciation=form_data.get("phonetic") or None,
                     verified=False,
@@ -517,7 +451,7 @@ def apply_additions(lang_code: str) -> ResponseReturnValue:
             log_operation(
                 session=g.db,
                 source="sync-release",
-                operation_type="derivative_import",
+                operation_type="synonym_import",
                 lemma_id=lemma_id,
                 details={
                     "guid": guid,
@@ -526,15 +460,14 @@ def apply_additions(lang_code: str) -> ResponseReturnValue:
                 },
             )
             imported_count += 1
-
         except Exception as e:
-            logger.error(f"Error importing derivative forms for {guid} lang={lang_code}: {e}")
+            logger.error(f"Error importing synonyms for {guid} lang={lang_code}: {e}")
             error_count += 1
 
     if imported_count > 0:
         try:
             g.db.commit()
-            flash(f"Imported derivative forms for {imported_count} lemma(s)", "success")
+            flash(f"Imported synonyms for {imported_count} lemma(s)", "success")
         except Exception as e:
             g.db.rollback()
             flash(f"Error committing changes: {e}", "error")
@@ -543,21 +476,20 @@ def apply_additions(lang_code: str) -> ResponseReturnValue:
     if error_count > 0:
         flash(f"Errors: {error_count}", "warning")
 
-    return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+    return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
 
 # =============================================================================
-# Apply removals (export DB -> release or delete from DB)
+# Apply removals
 # =============================================================================
 
 
 @bp.route("/<lang_code>/removals/apply", methods=["POST"])
 def apply_removals(lang_code: str) -> ResponseReturnValue:
-    """Handle derivative forms in DB but not in release: export to release or delete."""
     app: "BarsukasFlask" = current_app  # type: ignore[assignment]
     if app.config.get("READONLY", False):
         flash("Database is in read-only mode", "error")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     actions: Dict[str, str] = {}
     for key, value in request.form.items():
@@ -567,10 +499,10 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
 
     if not actions:
         flash("No actions selected", "warning")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     release_dir = _get_release_dir()
-    db_forms = _load_db_derivatives_for_lang(g.db, lang_code)
+    db_forms = _load_db_synonyms_for_lang(g.db, lang_code)
 
     exported_count = 0
     deleted_count = 0
@@ -588,22 +520,18 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
             continue
 
         if action == "export":
-            # Export DB forms to release file
             try:
-                file_path = _find_release_file_for_lemma_lang(release_dir, guid, lang_code)
+                file_path = find_release_file_for_lemma_lang(release_dir, guid, lang_code)
                 if not file_path:
-                    logger.warning(f"Could not resolve release file for {guid} lang={lang_code}")
                     error_count += 1
                     continue
-
                 form_dicts = [_db_form_to_dict(f) for f in forms]
-                _append_or_update_release_line(file_path, guid, form_dicts)
+                write_release_line_partial(file_path, guid, "synonyms", form_dicts)
                 exported_count += 1
-
                 log_operation(
                     session=g.db,
                     source="sync-release",
-                    operation_type="derivative_export",
+                    operation_type="synonym_export",
                     lemma_id=forms[0].lemma_id,
                     details={
                         "guid": guid,
@@ -611,9 +539,8 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
                         "form_count": len(forms),
                     },
                 )
-
             except Exception as e:
-                logger.error(f"Error exporting derivatives for {guid} lang={lang_code}: {e}")
+                logger.error(f"Error exporting synonyms for {guid} lang={lang_code}: {e}")
                 error_count += 1
 
         elif action == "delete":
@@ -621,11 +548,10 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
                 lemma_id = forms[0].lemma_id
                 for form in forms:
                     g.db.delete(form)
-
                 log_operation(
                     session=g.db,
                     source="sync-release",
-                    operation_type="derivative_delete",
+                    operation_type="synonym_delete",
                     lemma_id=lemma_id,
                     details={
                         "guid": guid,
@@ -634,9 +560,8 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
                     },
                 )
                 deleted_count += 1
-
             except Exception as e:
-                logger.error(f"Error deleting derivatives for {guid} lang={lang_code}: {e}")
+                logger.error(f"Error deleting synonyms for {guid} lang={lang_code}: {e}")
                 error_count += 1
 
     if deleted_count > 0 or exported_count > 0:
@@ -648,34 +573,29 @@ def apply_removals(lang_code: str) -> ResponseReturnValue:
             logger.error(f"Commit error: {e}")
 
     if exported_count > 0:
-        flash(
-            f"Exported derivative forms for {exported_count} lemma(s) to release files", "success"
-        )
+        flash(f"Exported synonyms for {exported_count} lemma(s) to release files", "success")
     if deleted_count > 0:
-        flash(f"Deleted derivative forms for {deleted_count} lemma(s) from database", "success")
+        flash(f"Deleted synonyms for {deleted_count} lemma(s) from database", "success")
     if skipped_count > 0:
         flash(f"Skipped {skipped_count} lemma(s)", "info")
     if error_count > 0:
         flash(f"Errors: {error_count}", "warning")
 
-    return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+    return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
 
 # =============================================================================
-# Apply changes (bidirectional sync of form differences)
+# Apply changes
 # =============================================================================
 
 
 @bp.route("/<lang_code>/changes/apply", methods=["POST"])
 def apply_changes(lang_code: str) -> ResponseReturnValue:
-    """Apply selected form changes (use_release or use_db) for a language."""
     app: "BarsukasFlask" = current_app  # type: ignore[assignment]
     if app.config.get("READONLY", False):
         flash("Database is in read-only mode", "error")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
-    # Parse form actions: action_{guid} = use_release | use_db | skip
-    # Each GUID gets a whole-lemma action (replace all forms for this GUID+lang)
     actions: Dict[str, str] = {}
     for key, value in request.form.items():
         if key.startswith("action_"):
@@ -684,11 +604,11 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
 
     if not actions:
         flash("No changes selected", "warning")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     release_dir = _get_release_dir()
-    release_forms = _load_release_derivatives_for_lang(release_dir, lang_code)
-    db_forms = _load_db_derivatives_for_lang(g.db, lang_code)
+    release_forms = _load_release_synonyms_for_lang(release_dir, lang_code)
+    db_forms = _load_db_synonyms_for_lang(g.db, lang_code)
     guid_to_lemma_id = _build_guid_to_lemma_id(g.db)
 
     updated_db_count = 0
@@ -703,28 +623,27 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
 
         lemma_id = guid_to_lemma_id.get(guid)
         if not lemma_id:
-            logger.warning(f"Lemma not found for GUID: {guid}")
             error_count += 1
             continue
 
         try:
             if action == "use_release":
-                # Replace DB forms with release forms
                 r_forms = release_forms.get(guid, [])
                 d_forms = db_forms.get(guid, [])
 
-                # Delete existing DB forms for this lemma+lang
                 for df in d_forms:
                     g.db.delete(df)
 
-                # Add release forms
                 for form_data in r_forms:
+                    gform = form_data.get("grammatical_form", "")
+                    if gform not in SYNONYM_GRAMMATICAL_FORMS:
+                        continue
                     df = DerivativeForm(
                         lemma_id=lemma_id,
                         language_code=lang_code,
-                        grammatical_form=form_data.get("grammatical_form", ""),
+                        grammatical_form=gform,
                         derivative_form_text=form_data.get("text", ""),
-                        is_base_form=form_data.get("is_base_form", False),
+                        is_base_form=False,
                         ipa_pronunciation=form_data.get("ipa") or None,
                         phonetic_pronunciation=form_data.get("phonetic") or None,
                         verified=False,
@@ -734,7 +653,7 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
                 log_operation(
                     session=g.db,
                     source="sync-release",
-                    operation_type="derivative_sync_use_release",
+                    operation_type="synonym_sync_use_release",
                     lemma_id=lemma_id,
                     details={
                         "guid": guid,
@@ -746,18 +665,15 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
                 updated_db_count += 1
 
             elif action == "use_db":
-                # Update release file with DB forms
                 d_forms = db_forms.get(guid, [])
                 form_dicts = [_db_form_to_dict(f) for f in d_forms]
-
-                file_path = _find_release_file_for_lemma_lang(release_dir, guid, lang_code)
+                file_path = find_release_file_for_lemma_lang(release_dir, guid, lang_code)
                 if file_path:
-                    _append_or_update_release_line(file_path, guid, form_dicts)
-
+                    write_release_line_partial(file_path, guid, "synonyms", form_dicts)
                     log_operation(
                         session=g.db,
                         source="sync-release",
-                        operation_type="derivative_sync_use_db",
+                        operation_type="synonym_sync_use_db",
                         lemma_id=lemma_id,
                         details={
                             "guid": guid,
@@ -767,38 +683,29 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
                     )
                     updated_release_count += 1
                 else:
-                    logger.warning(f"Could not find release file for GUID: {guid}")
                     error_count += 1
 
         except Exception as e:
-            logger.error(f"Error syncing derivatives for {guid} lang={lang_code}: {e}")
+            logger.error(f"Error syncing synonyms for {guid} lang={lang_code}: {e}")
             error_count += 1
 
     if updated_db_count > 0:
         try:
             g.db.commit()
-            flash(
-                f"Updated DB derivative forms for {updated_db_count} lemma(s)",
-                "success",
-            )
+            flash(f"Updated DB synonyms for {updated_db_count} lemma(s)", "success")
         except Exception as e:
             g.db.rollback()
             flash(f"Error committing DB changes: {e}", "error")
             logger.error(f"Commit error: {e}")
 
     if updated_release_count > 0:
-        flash(
-            f"Updated release files for {updated_release_count} lemma(s)",
-            "success",
-        )
-
+        flash(f"Updated release files for {updated_release_count} lemma(s)", "success")
     if skipped_count > 0:
         flash(f"Skipped {skipped_count} lemma(s)", "info")
-
     if error_count > 0:
         flash(f"Errors: {error_count}", "warning")
 
-    return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+    return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
 
 # =============================================================================
@@ -808,53 +715,41 @@ def apply_changes(lang_code: str) -> ResponseReturnValue:
 
 @bp.route("/<lang_code>/export_all", methods=["POST"])
 def export_all(lang_code: str) -> ResponseReturnValue:
-    """Export all DB derivative forms for a language to release files.
-
-    Writes every GUID that has derivative forms in the DB for this language
-    into the appropriate {lang_code}.jsonl files, creating or updating as needed.
-    """
+    """Export every DB synonym for a language to release files."""
     release_dir = _get_release_dir()
 
     if not release_dir.exists():
         flash(f"Release directory not found: {release_dir}", "error")
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
-    db_forms = _load_db_derivatives_for_lang(g.db, lang_code)
+    db_forms = _load_db_synonyms_for_lang(g.db, lang_code)
 
     if not db_forms:
-        flash(
-            f"No {LANGUAGE_NAMES.get(lang_code, lang_code)} derivative forms in database", "warning"
-        )
-        return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
+        flash(f"No {LANGUAGE_NAMES.get(lang_code, lang_code)} synonyms in database", "warning")
+        return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))
 
     exported_count = 0
     error_count = 0
 
     for guid, forms in sorted(db_forms.items()):
         try:
-            file_path = _find_release_file_for_lemma_lang(release_dir, guid, lang_code)
+            file_path = find_release_file_for_lemma_lang(release_dir, guid, lang_code)
             if not file_path:
-                logger.warning(f"Could not resolve release file for {guid} lang={lang_code}")
                 error_count += 1
                 continue
-
             form_dicts = [_db_form_to_dict(f) for f in forms]
-            _append_or_update_release_line(file_path, guid, form_dicts)
+            write_release_line_partial(file_path, guid, "synonyms", form_dicts)
             exported_count += 1
-
         except Exception as e:
-            logger.error(f"Error exporting derivatives for {guid} lang={lang_code}: {e}")
+            logger.error(f"Error exporting synonyms for {guid} lang={lang_code}: {e}")
             error_count += 1
 
     if exported_count > 0:
         log_operation(
             session=g.db,
             source="sync-release",
-            operation_type="derivative_export_all",
-            details={
-                "language_code": lang_code,
-                "guid_count": exported_count,
-            },
+            operation_type="synonym_export_all",
+            details={"language_code": lang_code, "guid_count": exported_count},
         )
         try:
             g.db.commit()
@@ -863,32 +758,11 @@ def export_all(lang_code: str) -> ResponseReturnValue:
             logger.error(f"Commit error logging export_all: {e}")
 
         flash(
-            f"Exported {lang_code} derivative forms for {exported_count} lemma(s) to release files",
+            f"Exported {lang_code} synonyms for {exported_count} lemma(s) to release files",
             "success",
         )
 
     if error_count > 0:
         flash(f"Errors: {error_count}", "warning")
 
-    return redirect(url_for("sync_derivative_release.language_detail", lang_code=lang_code))
-
-
-# =============================================================================
-# Release file write helpers
-# =============================================================================
-
-
-def _append_or_update_release_line(file_path: Path, guid: str, forms: List[Dict[str, Any]]) -> None:
-    """Write or update a GUID's ``forms`` array in a release JSONL file.
-
-    Preserves the ``synonyms`` array (if present) on the same line.
-    """
-    write_release_line_partial(file_path, guid, "forms", forms)
-
-
-def _build_guid_to_lemma_id(db_session: Any) -> Dict[str, int]:
-    """Build a GUID -> lemma_id mapping for all lemmas with GUIDs."""
-    return {
-        guid: lid
-        for lid, guid in db_session.query(Lemma.id, Lemma.guid).filter(Lemma.guid.isnot(None)).all()
-    }
+    return redirect(url_for("sync_synonym_release.language_detail", lang_code=lang_code))

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -121,6 +121,9 @@
                             <li><a class="dropdown-item" href="{{ url_for('sync_derivative_release.index') }}">
                                 <i class="bi bi-diagram-3"></i> {{ STRINGS.navigation.get('derivative_forms', 'Derivative Forms') }}
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('sync_synonym_release.index') }}">
+                                <i class="bi bi-link-45deg"></i> {{ STRINGS.navigation.get('synonyms', 'Synonyms') }}
+                            </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('sync_relation_release.index') }}">
                                 <i class="bi bi-diagram-2"></i> {{ STRINGS.navigation.get('relations', 'Relations') }}
                             </a></li>

--- a/src/barsukas/templates/sync_hub/index.html
+++ b/src/barsukas/templates/sync_hub/index.html
@@ -65,6 +65,30 @@
             </div>
         </div>
 
+        <!-- Synonyms -->
+        <div class="col-md-6 col-lg-3 mb-3">
+            <div class="card h-100">
+                <div class="card-header bg-secondary text-white">
+                    <i class="bi bi-link-45deg"></i> Synonyms
+                </div>
+                <div class="card-body">
+                    <p class="card-text">
+                        Sync per-language synonym entries managed separately from inflected forms.
+                    </p>
+                    <ul class="small">
+                        <li>synonym, synonym_near</li>
+                        <li>synonym_regional, synonym_register</li>
+                        <li>synonym_spelling, synonym_related</li>
+                    </ul>
+                </div>
+                <div class="card-footer">
+                    <a href="{{ url_for('sync_synonym_release.index') }}" class="btn btn-secondary w-100">
+                        <i class="bi bi-arrow-right"></i> Open Synonym Sync
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <!-- Relations -->
         <div class="col-md-6 col-lg-3 mb-3">
             <div class="card h-100">

--- a/src/barsukas/templates/sync_synonym_release/index.html
+++ b/src/barsukas/templates/sync_synonym_release/index.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+
+{% block title %}{{ STRINGS.sync.synonyms_title }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col">
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('sync_release.index') }}">Sync</a></li>
+                    <li class="breadcrumb-item active">Synonyms</li>
+                </ol>
+            </nav>
+            <h2><i class="bi bi-link-45deg"></i> {{ STRINGS.sync.synonyms_title }}</h2>
+            <p class="text-muted">
+                Compare per-language synonym entries (top-level <code>synonyms</code> array
+                in <code>data/release/lemmas/.../{lang}.jsonl</code>) with the working database.
+                Synonyms are stored in the same <code>DerivativeForm</code> table as inflected
+                forms but managed on this separate page.
+            </p>
+        </div>
+    </div>
+
+    {% if error %}
+    <div class="alert alert-danger">
+        <i class="bi bi-exclamation-triangle"></i> {{ error }}
+        <br><small>Path: <code>{{ release_dir }}</code></small>
+    </div>
+    {% elif not lang_counts %}
+    <div class="alert alert-warning">
+        <i class="bi bi-exclamation-triangle"></i> No synonyms found in either release files or database.
+        <br><small>Path: <code>{{ release_dir }}</code></small>
+    </div>
+    {% else %}
+    <div class="row mb-3">
+        <div class="col">
+            <div class="card">
+                <div class="card-header">
+                    <i class="bi bi-info-circle"></i> {{ STRINGS.sync.summary }}
+                </div>
+                <div class="card-body">
+                    <p class="mb-1"><strong>{{ STRINGS.sync.release_directory_label }}</strong> <code>{{ release_dir }}</code></p>
+                    <p class="mb-0"><strong>{{ STRINGS.sync.languages_with_data }}</strong> {{ lang_counts|length }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <i class="bi bi-translate"></i> {{ STRINGS.sync.per_language_status }}
+        </div>
+        <div class="card-body p-0">
+            <table class="table table-hover mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>{{ LSTR.language }}</th>
+                        <th class="text-center">{{ STRINGS.sync.release }}</th>
+                        <th class="text-center">{{ LSTR.token_database }}</th>
+                        <th class="text-center text-success">{{ STRINGS.sync.additions }}</th>
+                        <th class="text-center text-danger">{{ STRINGS.sync.removals }}</th>
+                        <th class="text-center text-warning">{{ STRINGS.sync.changes }}</th>
+                        <th class="text-center">Total Diffs</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for lc in lang_counts %}
+                    <tr>
+                        <td>
+                            <span class="badge bg-info text-dark">{{ lc.lang_code }}</span>
+                            {{ lc.lang_name }}
+                        </td>
+                        <td class="text-center">{{ lc.release_count }}</td>
+                        <td class="text-center">{{ lc.db_count }}</td>
+                        <td class="text-center">
+                            {% if lc.additions > 0 %}
+                            <span class="badge bg-success">{{ lc.additions }}</span>
+                            {% else %}
+                            <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td class="text-center">
+                            {% if lc.removals > 0 %}
+                            <span class="badge bg-danger">{{ lc.removals }}</span>
+                            {% else %}
+                            <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td class="text-center">
+                            {% if lc.changes > 0 %}
+                            <span class="badge bg-warning text-dark">{{ lc.changes }}</span>
+                            {% else %}
+                            <span class="text-muted">0</span>
+                            {% endif %}
+                        </td>
+                        <td class="text-center">
+                            {% if lc.total_diffs > 0 %}
+                            <strong>{{ lc.total_diffs }}</strong>
+                            {% else %}
+                            <span class="text-success"><i class="bi bi-check-circle"></i></span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <a href="{{ url_for('sync_synonym_release.language_detail', lang_code=lc.lang_code) }}"
+                               class="btn btn-sm {% if lc.total_diffs > 0 %}btn-primary{% else %}btn-outline-secondary{% endif %}">
+                                <i class="bi bi-arrow-right"></i> {{ STRINGS.sync.details }}
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <a href="{{ url_for('sync_release.index') }}" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left"></i> {{ STRINGS.sync.back_to_lemma_sync }}
+            </a>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/src/barsukas/templates/sync_synonym_release/language_detail.html
+++ b/src/barsukas/templates/sync_synonym_release/language_detail.html
@@ -1,0 +1,298 @@
+{% extends "base.html" %}
+
+{% block title %}Sync Synonyms - {{ lang_name }}{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row mb-4">
+        <div class="col">
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('sync_release.index') }}">Sync</a></li>
+                    <li class="breadcrumb-item"><a href="{{ url_for('sync_synonym_release.index') }}">Synonyms</a></li>
+                    <li class="breadcrumb-item active">{{ lang_name }} ({{ lang_code }})</li>
+                </ol>
+            </nav>
+            <h2>
+                <i class="bi bi-link-45deg"></i> Synonyms &mdash;
+                <span class="badge bg-info text-dark">{{ lang_code }}</span> {{ lang_name }}
+            </h2>
+        </div>
+    </div>
+
+    {% if db_count > 0 %}
+    <div class="card mb-4">
+        <div class="card-body d-flex justify-content-between align-items-center">
+            <div>
+                <strong>{{ db_count }}</strong> lemma(s) with {{ lang_name }} synonyms in DB.
+            </div>
+            <form method="post" action="{{ url_for('sync_synonym_release.export_all', lang_code=lang_code) }}"
+                  onsubmit="return confirm('Export all {{ db_count }} {{ lang_name }} lemma(s) from DB to release files?');">
+                <button type="submit" class="btn btn-outline-primary">
+                    <i class="bi bi-upload"></i> {{ STRINGS.sync.export_all_db_to_release }}
+                </button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if not additions and not removals and not changes %}
+    <div class="alert alert-success">
+        <i class="bi bi-check-circle"></i> All {{ lang_name }} synonyms are in sync!
+    </div>
+    <a href="{{ url_for('sync_synonym_release.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Back
+    </a>
+    {% else %}
+
+    {# ========== ADDITIONS (release -> DB) ========== #}
+    {% if additions %}
+    <div class="card mb-4">
+        <div class="card-header bg-success bg-opacity-10">
+            <i class="bi bi-plus-circle text-success"></i>
+            {{ STRINGS.sync.additions }} — {{ additions|length }} lemma(s) in release but not in DB
+        </div>
+        <div class="card-body">
+            <form method="post" action="{{ url_for('sync_synonym_release.apply_additions', lang_code=lang_code) }}">
+                <table class="table table-sm table-hover">
+                    <thead class="table-light">
+                        <tr>
+                            <th style="width: 40px;">
+                                <input type="checkbox" onclick="toggleAll(this, 'add_check')" checked>
+                            </th>
+                            <th>{{ STRINGS.sync.guid }}</th>
+                            <th>Lemma</th>
+                            <th>{{ STRINGS.sync.type }}</th>
+                            <th class="text-center">Synonyms</th>
+                            <th>{{ STRINGS.sync.preview }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in additions %}
+                        <tr>
+                            <td>
+                                <input type="checkbox" class="add_check"
+                                       name="selected_guids" value="{{ item.guid }}" checked>
+                            </td>
+                            <td><code>{{ item.guid }}</code></td>
+                            <td><strong>{{ item.lemma_text }}</strong></td>
+                            <td>
+                                <span class="badge bg-secondary">{{ item.pos_type }}</span>
+                                {% if item.pos_subtype %}
+                                <span class="badge bg-light text-dark">{{ item.pos_subtype }}</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-center">{{ item.form_count }}</td>
+                            <td><small class="text-muted">{{ item.forms_preview }}</small></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <button type="submit" class="btn btn-success">
+                    <i class="bi bi-download"></i> Import Selected to DB
+                </button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ========== REMOVALS (DB only - export or delete) ========== #}
+    {% if removals %}
+    <div class="card mb-4">
+        <div class="card-header bg-danger bg-opacity-10">
+            <i class="bi bi-dash-circle text-danger"></i>
+            <strong>In DB Only</strong> &mdash; {{ removals|length }} lemma(s) in DB but not in release
+        </div>
+        <div class="card-body">
+            <p class="text-muted mb-3">
+                These lemmas have {{ lang_name }} synonyms in the database but no
+                <code>synonyms</code> entry in the <code>{{ lang_code }}.jsonl</code> release file.
+                Choose to <strong>export</strong> to release or <strong>delete</strong> from DB.
+            </p>
+            <form method="post" action="{{ url_for('sync_synonym_release.apply_removals', lang_code=lang_code) }}">
+                <table class="table table-sm table-hover">
+                    <thead class="table-light">
+                        <tr>
+                            <th>{{ STRINGS.sync.guid }}</th>
+                            <th>Lemma</th>
+                            <th>{{ STRINGS.sync.type }}</th>
+                            <th class="text-center">Synonyms</th>
+                            <th>{{ STRINGS.sync.preview }}</th>
+                            <th style="width: 160px;">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for item in removals %}
+                        <tr>
+                            <td><code>{{ item.guid }}</code></td>
+                            <td>
+                                {% if item.lemma_id %}
+                                <a href="{{ url_for('lemmas.view_lemma', lemma_id=item.lemma_id) }}" target="_blank">
+                                    <strong>{{ item.lemma_text }}</strong>
+                                </a>
+                                {% else %}
+                                <strong>{{ item.lemma_text }}</strong>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <span class="badge bg-secondary">{{ item.pos_type }}</span>
+                                {% if item.pos_subtype %}
+                                <span class="badge bg-light text-dark">{{ item.pos_subtype }}</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-center">{{ item.form_count }}</td>
+                            <td><small class="text-muted">{{ item.forms_preview }}</small></td>
+                            <td>
+                                <select class="form-select form-select-sm removal-action"
+                                        name="action_{{ item.guid }}">
+                                    <option value="export" selected>Export to release</option>
+                                    <option value="skip">{{ STRINGS.sync.skip }}</option>
+                                    <option value="delete">Delete from DB</option>
+                                </select>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="d-flex gap-2">
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            onclick="setAllSelects('.removal-action', 'export')">All Export</button>
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            onclick="setAllSelects('.removal-action', 'skip')">{{ STRINGS.sync.all_skip }}</button>
+                    <div class="flex-grow-1"></div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-lg"></i> Apply
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ========== CHANGES ========== #}
+    {% if changes %}
+    <div class="card mb-4">
+        <div class="card-header bg-warning bg-opacity-10">
+            <i class="bi bi-pencil text-warning"></i>
+            {{ STRINGS.sync.changes }} — {{ changes|length }} lemma(s) with differing synonyms
+        </div>
+        <div class="card-body">
+            <form method="post" action="{{ url_for('sync_synonym_release.apply_changes', lang_code=lang_code) }}">
+                {% for item in changes %}
+                <div class="card mb-3">
+                    <div class="card-header bg-light py-2 d-flex justify-content-between align-items-center">
+                        <div>
+                            {% if item.lemma_id %}
+                            <a href="{{ url_for('lemmas.view_lemma', lemma_id=item.lemma_id) }}" target="_blank">
+                                <code>{{ item.guid }}</code>
+                            </a>
+                            {% else %}
+                            <code>{{ item.guid }}</code>
+                            {% endif %}
+                            <strong class="ms-2">{{ item.lemma_text }}</strong>
+                            <span class="badge bg-secondary ms-1">{{ item.pos_type }}</span>
+                            {% if item.pos_subtype %}
+                            <span class="badge bg-light text-dark">{{ item.pos_subtype }}</span>
+                            {% endif %}
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <span class="badge bg-warning text-dark">{{ item.diff_count }} diff{{ 's' if item.diff_count != 1 }}</span>
+                            <select class="form-select form-select-sm change-action" style="width: auto;"
+                                    name="action_{{ item.guid }}">
+                                <option value="skip">{{ STRINGS.sync.skip }}</option>
+                                <option value="use_db">{{ STRINGS.sync.use_db }}</option>
+                                <option value="use_release">{{ STRINGS.sync.use_release }}</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="card-body p-0">
+                        <table class="table table-sm table-bordered mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th style="width: 80px;">{{ LSTR.status }}</th>
+                                    <th>Grammatical Form</th>
+                                    <th>DB</th>
+                                    <th>{{ STRINGS.sync.release }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for fd in item.form_diffs %}
+                                <tr>
+                                    <td>
+                                        {% if fd.type == 'release_only' %}
+                                        <span class="badge bg-success">+release</span>
+                                        {% elif fd.type == 'db_only' %}
+                                        <span class="badge bg-danger">+db</span>
+                                        {% else %}
+                                        <span class="badge bg-warning text-dark">differs</span>
+                                        {% endif %}
+                                    </td>
+                                    <td><code>{{ fd.grammatical_form }}</code></td>
+                                    <td>
+                                        {% if fd.db_text %}
+                                        <strong>{{ fd.db_text }}</strong>
+                                        {% if fd.db_ipa %}<br><small class="text-muted">IPA: {{ fd.db_ipa }}</small>{% endif %}
+                                        {% if fd.db_phonetic %}<br><small class="text-muted">{{ fd.db_phonetic }}</small>{% endif %}
+                                        {% else %}
+                                        <span class="text-muted fst-italic">-</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if fd.release_text %}
+                                        <strong>{{ fd.release_text }}</strong>
+                                        {% if fd.release_ipa %}<br><small class="text-muted">IPA: {{ fd.release_ipa }}</small>{% endif %}
+                                        {% if fd.release_phonetic %}<br><small class="text-muted">{{ fd.release_phonetic }}</small>{% endif %}
+                                        {% else %}
+                                        <span class="text-muted fst-italic">-</span>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                {% endfor %}
+
+                <div class="d-flex gap-2 mt-3">
+                    <button type="button" class="btn btn-sm btn-outline-secondary"
+                            onclick="setAllSelects('.change-action', 'skip')">{{ STRINGS.sync.all_skip }}</button>
+                    <button type="button" class="btn btn-sm btn-outline-warning"
+                            onclick="setAllSelects('.change-action', 'use_db')">{{ STRINGS.sync.all_use_db }}</button>
+                    <button type="button" class="btn btn-sm btn-outline-primary"
+                            onclick="setAllSelects('.change-action', 'use_release')">{{ STRINGS.sync.all_use_release }}</button>
+                    <div class="flex-grow-1"></div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-lg"></i> {{ STRINGS.sync.apply_changes }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+
+    <a href="{{ url_for('sync_synonym_release.index') }}" class="btn btn-secondary">
+        <i class="bi bi-arrow-left"></i> Back to Synonym Sync
+    </a>
+    {% endif %}
+</div>
+
+<script>
+function toggleAll(source, className) {
+    document.querySelectorAll('.' + className).forEach(function(cb) {
+        cb.checked = source.checked;
+    });
+}
+
+function setAllSelects(selector, value) {
+    document.querySelectorAll(selector).forEach(function(select) {
+        for (var i = 0; i < select.options.length; i++) {
+            if (select.options[i].value === value) {
+                select.selectedIndex = i;
+                break;
+            }
+        }
+    });
+}
+</script>
+{% endblock %}

--- a/src/storage/backend/jsonl/models.py
+++ b/src/storage/backend/jsonl/models.py
@@ -151,6 +151,12 @@ class Lemma:
     derivative_forms: Dict[str, Dict[str, Any]] = field(
         default_factory=dict
     )  # lang_code -> {form_name -> form_data}
+    # synonyms: Stored as a list because the same grammatical_form (e.g. "synonym")
+    # can repeat. Each entry is a dict with grammatical_form, form, optional
+    # ipa/phonetic. Loaded from the top-level "synonyms" array in {lang}.jsonl.
+    synonyms: Dict[str, List[Dict[str, Any]]] = field(
+        default_factory=dict
+    )  # lang_code -> [{grammatical_form, form, ipa?, phonetic?}, ...]
     # base_forms: Used when no derivative_form has is_base_form=true for that language
     # Contains {form: str, ipa: str, phonetic: str} per language
     base_forms: Dict[str, Dict[str, Any]] = field(
@@ -194,6 +200,7 @@ class Lemma:
         data.setdefault("definitions", {})
         data.setdefault("difficulty_overrides", {})
         data.setdefault("derivative_forms", {})
+        data.setdefault("synonyms", {})
         data.setdefault("base_forms", {})
         data.setdefault("grammar_facts", [])
         data.setdefault("audio_hashes", {})

--- a/src/storage/backend/jsonl/session.py
+++ b/src/storage/backend/jsonl/session.py
@@ -269,6 +269,27 @@ class JSONLSession(BaseSession):
                         }
                     )
 
+            # Synonyms: stored separately in lemma.synonyms (list per lang) so
+            # that repeated grammatical_form values (e.g. multiple "synonym"
+            # entries) are preserved. Emit one DerivativeForm row per entry.
+            for lang_code, syn_list in jsonl_lemma.synonyms.items():
+                for syn in syn_list:
+                    text = syn.get("form", "")
+                    gform = syn.get("grammatical_form", "")
+                    if not text or not gform:
+                        continue
+                    derivative_forms.append(
+                        {
+                            "lemma_id": jsonl_lemma.id,
+                            "language_code": lang_code,
+                            "grammatical_form": gform,
+                            "derivative_form_text": text,
+                            "is_base_form": False,
+                            "ipa_pronunciation": syn.get("ipa"),
+                            "phonetic_pronunciation": syn.get("phonetic"),
+                        }
+                    )
+
             # Synthesize a base DerivativeForm row from lemma.base_forms for
             # any language that does not already have one in derivative_forms.
             # Without this, English lemmas like "bread" (whose base form lives

--- a/src/storage/backend/jsonl/storage.py
+++ b/src/storage/backend/jsonl/storage.py
@@ -264,6 +264,44 @@ class JSONLStorage(BaseStorage):
                         if "derivative_forms" in data:
                             lemma.derivative_forms[lang_code] = data["derivative_forms"]
 
+                        # New release format: top-level "forms" array (inflections)
+                        # and "synonyms" array. Inflections are merged into the
+                        # dict-shaped derivative_forms[lang]; synonyms get their
+                        # own list because the same grammatical_form (e.g.
+                        # "synonym") can repeat per lemma.
+                        if "forms" in data and isinstance(data["forms"], list):
+                            inflections = lemma.derivative_forms.setdefault(lang_code, {})
+                            for entry in data["forms"]:
+                                gform = entry.get("grammatical_form", "")
+                                if not gform:
+                                    continue
+                                form_record: Dict[str, Any] = {
+                                    "form": entry.get("text", ""),
+                                    "is_base_form": entry.get("is_base_form", False),
+                                }
+                                if entry.get("ipa"):
+                                    form_record["ipa"] = entry["ipa"]
+                                if entry.get("phonetic"):
+                                    form_record["phonetic"] = entry["phonetic"]
+                                inflections[gform] = form_record
+
+                        if "synonyms" in data and isinstance(data["synonyms"], list):
+                            syn_list = lemma.synonyms.setdefault(lang_code, [])
+                            for entry in data["synonyms"]:
+                                gform = entry.get("grammatical_form", "")
+                                text = entry.get("text", "")
+                                if not gform or not text:
+                                    continue
+                                syn_record: Dict[str, Any] = {
+                                    "grammatical_form": gform,
+                                    "form": text,
+                                }
+                                if entry.get("ipa"):
+                                    syn_record["ipa"] = entry["ipa"]
+                                if entry.get("phonetic"):
+                                    syn_record["phonetic"] = entry["phonetic"]
+                                syn_list.append(syn_record)
+
                         if "audio_hashes" in data:
                             lemma.audio_hashes[lang_code] = data["audio_hashes"]
 

--- a/strings/barsukas/sync/en.json
+++ b/strings/barsukas/sync/en.json
@@ -4,6 +4,7 @@
   "sentences_title": "Sync Sentences",
   "relations_title": "Sync Relations",
   "derivatives_title": "Sync Derivative Forms",
+  "synonyms_title": "Sync Synonyms",
   "summary": "Summary",
   "additions": "Additions",
   "removals": "Removals",


### PR DESCRIPTION
Split the existing /sync/derivatives page into two: derivative sync now manages only inflected forms (grammatical_form not in SYNONYM_GRAMMATICAL_FORMS), and a parallel /sync/synonyms page handles synonyms. Both pages read and write the same per-language {lang}.jsonl file but on different top-level array keys ("forms" vs "synonyms"); a shared helper preserves the other key on each write.

Also teach the JSONL release loader (golden/hosted mode) to recognize the new array shape: top-level "forms" is merged into Lemma.derivative_forms (dict) and "synonyms" into a new Lemma.synonyms list. The in-memory SQLite populator emits one DerivativeForm row per synonym entry so combined-rank queries see them. This unblocks combined ranks once a /sync/derivatives ... /export_all run materializes per-language files in data/release/.