### PR TITLE
Add Bosnian/Serbian/Macedonian/Albanian/Montenegrin language entries and mappings

### DIFF
--- a/src/storage/translation_helpers.py
+++ b/src/storage/translation_helpers.py
@@ -90,12 +90,17 @@ TIER_4_LANGUAGES = [
     "et",
     "fi",
     "ga",
-    "hr",
     "hu",
     "lv",
     "mt",
     "sk",
     "sl",
+    "bs",
+    "sr",
+    "hr",
+    "mk",
+    "sq",
+    "me",
 ]
 
 # Languages included in data/release read/write operations.
@@ -178,12 +183,17 @@ LANGUAGE_HIERARCHY = [
     "et",  # Estonian (experimental)
     "fi",  # Finnish (experimental)
     "ga",  # Irish (experimental)
-    "hr",  # Croatian (experimental)
     "hu",  # Hungarian (experimental)
     "lv",  # Latvian (experimental)
     "mt",  # Maltese (experimental)
     "sk",  # Slovak (experimental)
     "sl",  # Slovenian (experimental)
+    "bs",  # Bosnian (experimental)
+    "sr",  # Serbian (experimental, Cyrillic)
+    "hr",  # Croatian (experimental, Latin)
+    "mk",  # Macedonian (experimental)
+    "sq",  # Albanian (experimental)
+    "me",  # Montenegrin (experimental)
 ]
 
 # Language mappings
@@ -244,12 +254,17 @@ LANGUAGE_FIELDS = {
     "et": ("et", "Estonian", True),
     "fi": ("fi", "Finnish", True),
     "ga": ("ga", "Irish", True),
-    "hr": ("hr", "Croatian", True),
     "hu": ("hu", "Hungarian", True),
     "lv": ("lv", "Latvian", True),
     "mt": ("mt", "Maltese", True),
     "sk": ("sk", "Slovak", True),
     "sl": ("sl", "Slovenian", True),
+    "bs": ("bs", "Bosnian", True),
+    "sr": ("sr", "Serbian (Cyrillic)", True),
+    "hr": ("hr", "Croatian (Latin)", True),
+    "mk": ("mk", "Macedonian", True),
+    "sq": ("sq", "Albanian", True),
+    "me": ("me", "Montenegrin", True),
 }
 
 # Language display names (for use in prompts, UIs, etc.)
@@ -316,6 +331,11 @@ LLM_FIELD_TO_LANG_CODE = {
     "maltese_translation": "mt",
     "slovak_translation": "sk",
     "slovenian_translation": "sl",
+    "bosnian_translation": "bs",
+    "serbian_translation": "sr",  # Serbian (Cyrillic)
+    "macedonian_translation": "mk",
+    "albanian_translation": "sq",
+    "montenegrin_translation": "me",
 }
 
 # Reverse mapping: language codes to LLM field names


### PR DESCRIPTION
### Motivation
- Expand language coverage for Southeastern/Balkan languages and ensure they are included in translation hierarchies and LLM field mappings. 

### Description
- Add `bs`, `sr`, `mk`, `sq`, and `me` entries to `TIER_4_LANGUAGES` and `LANGUAGE_HIERARCHY`. 
- Add corresponding `LANGUAGE_FIELDS` entries for `bs`, `sr` (Serbian Cyrillic), `hr` (now labeled "Croatian (Latin)"), `mk`, `sq`, and `me` and update `LANGUAGE_NAMES` derivation accordingly. 
- Add new LLM field mappings for `bosnian_translation`, `serbian_translation`, `macedonian_translation`, `albanian_translation`, and `montenegrin_translation` and regenerate the reverse `LANG_CODE_TO_LLM_FIELD` mapping. 

### Testing
- No automated tests were added or modified for this change. 
- No automated test suite was executed as part of this rollout; please run the project's test suite and linters to validate integration with existing code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6a5a3d98832780068f3b9c6ab0e5)