### PR TITLE
Apply unknown-rank floors and link DerivativeForms in golden mode

### DIFF
--- a/src/wordfreq/frequency/combined_rank.py
+++ b/src/wordfreq/frequency/combined_rank.py
@@ -35,7 +35,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from sqlalchemy.orm import Session
 
 from storage.models.schema import Corpus, Lemma, LemmaTier
-from wordfreq.frequency.corpus import get_enabled_corpus_configs
+from wordfreq.frequency.corpus import CorpusConfig, get_enabled_corpus_configs
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +47,10 @@ YLE_TIER_RANKS: Dict[str, int] = {
     "flyers": 1200,
 }
 YLE_TIER_WEIGHT: float = 1.0
+# Rank assigned when a lemma is absent from YLE entirely. Set just past the
+# last YLE tier (flyers=1200) so non-YLE words get a mild penalty without
+# being treated as if they were rarer than C2-level vocabulary.
+YLE_UNKNOWN_RANK: int = 2000
 
 CEFR_TIER_RANKS: Dict[str, int] = {
     "A1": 800,
@@ -57,16 +61,29 @@ CEFR_TIER_RANKS: Dict[str, int] = {
     "C2": 20000,
 }
 CEFR_TIER_WEIGHT: float = 1.0
+# Rank assigned when a lemma is absent from CEFR entirely. Just past C2
+# (20000) so words outside the CEFR vocabulary get pushed below it.
+CEFR_UNKNOWN_RANK: int = 25000
 
 BASIC_ENGLISH_TIER_RANKS: Dict[str, int] = {
     "basic": 600,
     "extended": 1600,
 }
 BASIC_ENGLISH_TIER_WEIGHT: float = 1.0
+# Rank assigned when a lemma is absent from Basic English entirely. Just
+# past extended (1600); Basic English is a small curated list, so absence
+# is a weak signal but worth contributing.
+BASIC_ENGLISH_UNKNOWN_RANK: int = 2500
 
 # Lemmas are written back in batches of this size to bound the per-commit
 # transaction footprint on a large corpus.
 _BATCH_SIZE: int = 1000
+
+# Floor used when a wordfreq corpus has no entry for a lemma. Each corpus
+# can override this via ``CorpusConfig.max_unknown_rank``; when neither is
+# set, we fall back to this value (chosen to be larger than the largest
+# corpus we currently load).
+_DEFAULT_UNKNOWN_RANK: int = 20000
 
 
 def _english_lemma_ids(session: Session) -> List[int]:
@@ -129,6 +146,21 @@ def _corpus_weights(session: Session) -> Dict[str, float]:
     return weights
 
 
+def _enabled_corpus_configs_by_name() -> Dict[str, CorpusConfig]:
+    return {cfg.name: cfg for cfg in get_enabled_corpus_configs()}
+
+
+def _unknown_rank_for_corpus(cfg: CorpusConfig, corpus_size: int) -> int:
+    """Effective rank to assign when a lemma is absent from this corpus.
+
+    Mirrors ``CorpusConfig.get_effective_unknown_rank`` but uses our local
+    ``_DEFAULT_UNKNOWN_RANK`` floor. Lower of (configured cap, max(corpus
+    size, default)) so a corpus's "missing" rank is never more flattering
+    than the worst rank actually present in the corpus.
+    """
+    return cfg.get_effective_unknown_rank(corpus_size, _DEFAULT_UNKNOWN_RANK)
+
+
 def _tier_rank_for_lemma(
     tier_rows: Dict[Tuple[int, str], str],
     lemma_id: int,
@@ -188,6 +220,21 @@ def calculate_lemma_combined_ranks(
         logger.info(f"Ranking lemmas within corpus '{corpus_name}'...")
         per_corpus_ranks[corpus_name] = _build_corpus_rank_table(session, corpus_name, lemma_ids)
 
+    # Per-corpus "unknown" rank: applied when a lemma has no rollup in a given
+    # corpus. Without this floor, a word that appears only in a small corpus
+    # (e.g. "baking" in cooking) gets a deceptively high combined rank because
+    # the larger corpora silently drop out of the harmonic mean.
+    cfgs_by_name = _enabled_corpus_configs_by_name()
+    unknown_rank_by_corpus: Dict[str, int] = {}
+    for corpus_name in corpus_weights:
+        cfg = cfgs_by_name.get(corpus_name)
+        if cfg is None:
+            unknown_rank_by_corpus[corpus_name] = _DEFAULT_UNKNOWN_RANK
+        else:
+            unknown_rank_by_corpus[corpus_name] = _unknown_rank_for_corpus(
+                cfg, len(per_corpus_ranks[corpus_name])
+            )
+
     tier_rows_q = session.query(LemmaTier.lemma_id, LemmaTier.source, LemmaTier.tier_name).all()
     tier_rows: Dict[Tuple[int, str], str] = {
         (row.lemma_id, row.source): row.tier_name for row in tier_rows_q
@@ -200,21 +247,45 @@ def calculate_lemma_combined_ranks(
     for lemma_id in lemma_ids:
         contributors: List[Tuple[float, int]] = []
 
+        # Track whether this lemma had a positive signal in *any* wordfreq
+        # corpus. Only then do we apply the unknown-rank floor for the other
+        # wordfreq corpora — otherwise a lemma with zero wordfreq presence
+        # would be ranked purely from "missing everywhere" floors, which is
+        # misleading. Tier-only lemmas continue to fall through to the
+        # tier-source contributors below.
+        has_wordfreq_hit = any(
+            per_corpus_ranks[name].get(lemma_id) is not None for name in corpus_weights
+        )
+
         for corpus_name, weight in corpus_weights.items():
             rank = per_corpus_ranks[corpus_name].get(lemma_id)
             if rank is not None:
                 contributors.append((weight, rank))
                 sources_used.add(f"wordfreq_{corpus_name}")
+            elif has_wordfreq_hit:
+                contributors.append((weight, unknown_rank_by_corpus[corpus_name]))
+                sources_used.add(f"wordfreq_{corpus_name}_unknown")
 
+        # For each tier source, contribute either the lemma's tier rank or the
+        # tier's "unknown" floor if the lemma is absent. Unlike wordfreq
+        # corpora, we apply the floor unconditionally — these are curated
+        # English vocabulary lists, so "absent" is a real signal that the
+        # word is at least somewhat outside the everyday/learner core.
         yle_rank = _tier_rank_for_lemma(tier_rows, lemma_id, "cambridge_yle", YLE_TIER_RANKS)
         if yle_rank is not None:
             contributors.append((YLE_TIER_WEIGHT, yle_rank))
             sources_used.add("cambridge_yle")
+        else:
+            contributors.append((YLE_TIER_WEIGHT, YLE_UNKNOWN_RANK))
+            sources_used.add("cambridge_yle_unknown")
 
         cefr_rank = _tier_rank_for_lemma(tier_rows, lemma_id, "cefr", CEFR_TIER_RANKS)
         if cefr_rank is not None:
             contributors.append((CEFR_TIER_WEIGHT, cefr_rank))
             sources_used.add("cefr")
+        else:
+            contributors.append((CEFR_TIER_WEIGHT, CEFR_UNKNOWN_RANK))
+            sources_used.add("cefr_unknown")
 
         be_rank = _tier_rank_for_lemma(
             tier_rows, lemma_id, "basic_english", BASIC_ENGLISH_TIER_RANKS
@@ -222,6 +293,9 @@ def calculate_lemma_combined_ranks(
         if be_rank is not None:
             contributors.append((BASIC_ENGLISH_TIER_WEIGHT, be_rank))
             sources_used.add("basic_english")
+        else:
+            contributors.append((BASIC_ENGLISH_TIER_WEIGHT, BASIC_ENGLISH_UNKNOWN_RANK))
+            sources_used.add("basic_english_unknown")
 
         combined = _harmonic_mean(contributors)
         if combined is None:
@@ -270,9 +344,12 @@ def calculate_lemma_combined_ranks(
 __all__ = [
     "BASIC_ENGLISH_TIER_RANKS",
     "BASIC_ENGLISH_TIER_WEIGHT",
+    "BASIC_ENGLISH_UNKNOWN_RANK",
     "CEFR_TIER_RANKS",
     "CEFR_TIER_WEIGHT",
+    "CEFR_UNKNOWN_RANK",
     "YLE_TIER_RANKS",
     "YLE_TIER_WEIGHT",
+    "YLE_UNKNOWN_RANK",
     "calculate_lemma_combined_ranks",
 ]

--- a/src/wordfreq/golden_loader.py
+++ b/src/wordfreq/golden_loader.py
@@ -64,6 +64,62 @@ def _make_session_for_storage(storage: "JSONLStorage") -> Session:
     return factory()
 
 
+def _link_derivative_forms_to_word_tokens(session: Session) -> int:
+    """Set ``DerivativeForm.word_token_id`` for forms whose surface text matches
+    a ``WordToken``.
+
+    The JSONL backend populates DerivativeForms from release files but never
+    sets ``word_token_id`` (no WordToken loader exists). After the wordfreq
+    importer creates WordToken rows for each annotated surface form, we wire
+    every English DerivativeForm whose ``derivative_form_text`` matches a
+    WordToken token to that WordToken. Without this link,
+    ``get_lexeme_frequency`` skips every form (it filters on
+    ``word_token_id is not None``) and rolls up zero for all wordfreq
+    corpora — meaning lemma combined ranks in golden mode collapse to
+    YLE/CEFR/Basic-English signals only.
+
+    Matching is case-insensitive on the lowercased token text, since the
+    wordfreq importer normalizes everything to lowercase.
+
+    Returns the number of DerivativeForm rows updated.
+    """
+    from storage.models.schema import DerivativeForm, WordToken
+
+    tokens = session.query(WordToken).filter(WordToken.language_code == "en").all()
+    token_id_by_text: dict[str, int] = {}
+    for token in tokens:
+        # Wordfreq imports tokens already lowercased; defend against any
+        # accidentally-cased rows by normalizing here too.
+        token_id_by_text.setdefault(token.token.lower(), token.id)
+
+    if not token_id_by_text:
+        return 0
+
+    forms = (
+        session.query(DerivativeForm)
+        .filter(
+            DerivativeForm.language_code == "en",
+            DerivativeForm.word_token_id.is_(None),
+        )
+        .all()
+    )
+
+    updated = 0
+    for form in forms:
+        text = (form.derivative_form_text or "").lower()
+        if not text:
+            continue
+        token_id = token_id_by_text.get(text)
+        if token_id is None:
+            continue
+        form.word_token_id = token_id
+        updated += 1
+
+    if updated:
+        session.commit()
+    return updated
+
+
 def _ensure_corpus_rows(session: Session) -> None:
     """Insert ``Corpus`` rows from CORPUS_CONFIGS if missing.
 
@@ -106,6 +162,7 @@ def load_wordfreq_into_storage(storage: "JSONLStorage") -> dict[str, Any]:
     summary: dict[str, Any] = {
         "corpora": {},
         "tiers": {},
+        "derivative_form_links": 0,
         "combined_rank": None,
         "elapsed_seconds": 0.0,
     }
@@ -116,6 +173,21 @@ def load_wordfreq_into_storage(storage: "JSONLStorage") -> dict[str, Any]:
 
         logger.info("Golden loader: importing wordfreq corpora")
         summary["corpora"] = corpus.load_all_corpora(session)
+
+        # Wire DerivativeForms (loaded from JSONL with no word_token_id) to the
+        # WordTokens just created by the wordfreq importer. Without this, the
+        # lexeme-frequency rollup finds no matching annotations and combined
+        # ranks fall back to tier sources only.
+        logger.info("Golden loader: linking DerivativeForms to WordTokens")
+        try:
+            summary["derivative_form_links"] = _link_derivative_forms_to_word_tokens(session)
+            logger.info(
+                f"Golden loader: linked {summary['derivative_form_links']} "
+                f"DerivativeForms to WordTokens"
+            )
+        except Exception as e:
+            logger.exception("Golden loader: derivative-form linking failed")
+            summary["derivative_form_links"] = {"error": str(e)}
 
         logger.info("Golden loader: importing tier sources")
         for importer in (CambridgeYleImporter(), CefrImporter(), BasicEnglishImporter()):


### PR DESCRIPTION
Combined-rank previously dropped non-contributing sources from the harmonic mean entirely, so a word in only one small corpus (e.g. "baking" in cooking) got a deceptively low rank. Now wordfreq corpora contribute their per-corpus max_unknown_rank when a lemma is present in some other wordfreq corpus, and YLE/CEFR/Basic English always contribute an unknown floor (2000/25000/2500) when the lemma is absent.

Also wire DerivativeForm.word_token_id to matching WordTokens after wordfreq import in golden mode; without this the JSONL backend left word_token_id null and the lexeme-frequency rollup produced zero for every wordfreq corpus, collapsing combined ranks to tier signals only.