### PR TITLE
Add top-level typed API facade package mirroring Barsukas route domains

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -20,6 +20,7 @@ Each module in this directory mirrors a domain route module in
 - `api/translations.py` <-> `src/barsukas/routes/translations.py`
 - `api/audio.py` <-> `src/barsukas/routes/audio.py`
 - `api/batch_operations.py` <-> `src/barsukas/routes/batch_operations.py`
+- `api/llm_agents.py` <-> `src/barsukas/routes/llm_api.py`
 
 When changing behavior in a mirrored Barsukas route file, make the
 corresponding change in this `api/` module in the same commit.
@@ -31,3 +32,5 @@ corresponding change in this `api/` module in the same commit.
   the relevant BARSUKAS HTTP route.
 - Do not duplicate business logic from Barsukas route handlers.
 - Keep shared endpoint/location values in `api/constants.py`.
+
+Use `@mirrored_route(...)` on each public facade function so mirrored coverage is explicit.

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,33 @@
+# API Wrapper Package Guidelines
+
+This `api/` package provides thin, typed Python wrappers around selected
+BARSUKAS HTTP route operations.
+
+## Purpose
+
+- Offer a stable import surface for Python callers that need to interact with
+  BARSUKAS programmatically.
+- Keep wrappers very small and predictable.
+- Mirror route domains from `src/barsukas/routes/`.
+
+## Mirroring pattern
+
+Each module in this directory mirrors a domain route module in
+`src/barsukas/routes/`:
+
+- `api/lemmas.py` <-> `src/barsukas/routes/lemmas.py`
+- `api/sentences.py` <-> `src/barsukas/routes/sentences.py`
+- `api/translations.py` <-> `src/barsukas/routes/translations.py`
+- `api/audio.py` <-> `src/barsukas/routes/audio.py`
+- `api/batch_operations.py` <-> `src/barsukas/routes/batch_operations.py`
+
+When changing behavior in a mirrored Barsukas route file, make the
+corresponding change in this `api/` module in the same commit.
+
+## Design constraints
+
+- Use typed `dataclass` request/response models (or `TypedDict` when needed).
+- Facade functions should delegate to one implementation point only:
+  the relevant BARSUKAS HTTP route.
+- Do not duplicate business logic from Barsukas route handlers.
+- Keep shared endpoint/location values in `api/constants.py`.

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -15,10 +15,10 @@ BARSUKAS HTTP route operations.
 Each module in this directory mirrors a domain route module in
 `src/barsukas/routes/`:
 
-- `api/lemmas.py` <-> `src/barsukas/routes/lemmas.py`
-- `api/sentences.py` <-> `src/barsukas/routes/sentences.py`
-- `api/translations.py` <-> `src/barsukas/routes/translations.py`
-- `api/audio.py` <-> `src/barsukas/routes/audio.py`
+- `api/lemmas.py` <-> `src/barsukas/routes/api.py (v1 search/lemma endpoints)`
+- `api/sentences.py` <-> `src/barsukas/routes/api.py (v1 lemma sentences endpoint)`
+- `api/translations.py` <-> `src/barsukas/routes/api.py (v1 lemma translations endpoint)`
+- `api/audio.py` <-> `src/barsukas/routes/api.py (v1 lemma audio endpoint)`
 - `api/batch_operations.py` <-> `src/barsukas/routes/batch_operations.py`
 - `api/llm_agents.py` <-> `src/barsukas/routes/llm_api.py`
 

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -3,10 +3,24 @@
 from api.audio import AudioResponse, ListAudioFilesRequest, list_audio_files
 from api.batch_operations import BatchOperationsResponse, ListBatchesRequest, list_batches
 from api.lemmas import LemmasResponse, ListLemmasRequest, list_lemmas
+from api.llm_agents import (
+    AgentTriggerRequest,
+    AgentTriggerResponse,
+    PronunciationTriggerRequest,
+    add_missing_translations,
+    check_translations,
+    generate_pronunciations,
+)
 from api.sentences import ListSentencesRequest, SentencesResponse, list_sentences
 from api.translations import TranslationResponse, UpdateTranslationRequest, update_translation
 
 __all__ = [
+    "generate_pronunciations",
+    "check_translations",
+    "add_missing_translations",
+    "PronunciationTriggerRequest",
+    "AgentTriggerResponse",
+    "AgentTriggerRequest",
     "AudioResponse",
     "BatchOperationsResponse",
     "LemmasResponse",

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,8 +1,14 @@
 """Public typed facade for Barsukas domain HTTP wrappers."""
 
-from api.audio import AudioResponse, ListAudioFilesRequest, list_audio_files
+from api.audio import AudioResponse, GetLemmaAudioRequest, get_lemma_audio
 from api.batch_operations import BatchOperationsResponse, ListBatchesRequest, list_batches
-from api.lemmas import LemmasResponse, ListLemmasRequest, list_lemmas
+from api.lemmas import (
+    GetLemmaRequest,
+    LemmasResponse,
+    SearchLemmasRequest,
+    get_lemma,
+    search_lemmas,
+)
 from api.llm_agents import (
     AgentTriggerRequest,
     AgentTriggerResponse,
@@ -11,29 +17,35 @@ from api.llm_agents import (
     check_translations,
     generate_pronunciations,
 )
-from api.sentences import ListSentencesRequest, SentencesResponse, list_sentences
-from api.translations import TranslationResponse, UpdateTranslationRequest, update_translation
+from api.sentences import GetLemmaSentencesRequest, SentencesResponse, get_lemma_sentences
+from api.translations import (
+    GetLemmaTranslationsRequest,
+    TranslationResponse,
+    get_lemma_translations,
+)
 
 __all__ = [
-    "generate_pronunciations",
-    "check_translations",
-    "add_missing_translations",
-    "PronunciationTriggerRequest",
-    "AgentTriggerResponse",
     "AgentTriggerRequest",
+    "AgentTriggerResponse",
     "AudioResponse",
     "BatchOperationsResponse",
+    "GetLemmaAudioRequest",
+    "GetLemmaRequest",
+    "GetLemmaSentencesRequest",
+    "GetLemmaTranslationsRequest",
     "LemmasResponse",
-    "ListAudioFilesRequest",
     "ListBatchesRequest",
-    "ListLemmasRequest",
-    "ListSentencesRequest",
+    "PronunciationTriggerRequest",
+    "SearchLemmasRequest",
     "SentencesResponse",
     "TranslationResponse",
-    "UpdateTranslationRequest",
-    "list_audio_files",
+    "add_missing_translations",
+    "check_translations",
+    "generate_pronunciations",
+    "get_lemma",
+    "get_lemma_audio",
+    "get_lemma_sentences",
+    "get_lemma_translations",
     "list_batches",
-    "list_lemmas",
-    "list_sentences",
-    "update_translation",
+    "search_lemmas",
 ]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,25 @@
+"""Public typed facade for Barsukas domain HTTP wrappers."""
+
+from api.audio import AudioResponse, ListAudioFilesRequest, list_audio_files
+from api.batch_operations import BatchOperationsResponse, ListBatchesRequest, list_batches
+from api.lemmas import LemmasResponse, ListLemmasRequest, list_lemmas
+from api.sentences import ListSentencesRequest, SentencesResponse, list_sentences
+from api.translations import TranslationResponse, UpdateTranslationRequest, update_translation
+
+__all__ = [
+    "AudioResponse",
+    "BatchOperationsResponse",
+    "LemmasResponse",
+    "ListAudioFilesRequest",
+    "ListBatchesRequest",
+    "ListLemmasRequest",
+    "ListSentencesRequest",
+    "SentencesResponse",
+    "TranslationResponse",
+    "UpdateTranslationRequest",
+    "list_audio_files",
+    "list_batches",
+    "list_lemmas",
+    "list_sentences",
+    "update_translation",
+]

--- a/api/_http.py
+++ b/api/_http.py
@@ -22,6 +22,7 @@ def send_request(
     *,
     params: Optional[Mapping[str, str | int]] = None,
     form_data: Optional[Mapping[str, str | int]] = None,
+    json_data: object | None = None,
     base_url: str = DEFAULT_BARSUKAS_BASE_URL,
     timeout_seconds: int = REQUEST_TIMEOUT_SECONDS,
 ) -> HttpResult:
@@ -35,6 +36,7 @@ def send_request(
         url=target_url,
         params=params,
         data=form_data,
+        json=json_data,
         timeout=timeout_seconds,
     )
     try:

--- a/api/_http.py
+++ b/api/_http.py
@@ -1,0 +1,50 @@
+"""Internal HTTP transport helper for api facade modules."""
+
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import requests
+
+from api.constants import DEFAULT_BARSUKAS_BASE_URL, REQUEST_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True)
+class HttpResult:
+    status_code: int
+    text: str
+    json_data: object | None
+    url: str
+
+
+def send_request(
+    method: str,
+    path: str,
+    *,
+    params: Optional[Mapping[str, str | int]] = None,
+    form_data: Optional[Mapping[str, str | int]] = None,
+    base_url: str = DEFAULT_BARSUKAS_BASE_URL,
+    timeout_seconds: int = REQUEST_TIMEOUT_SECONDS,
+) -> HttpResult:
+    """Send one HTTP request to Barsukas and return normalized result."""
+    normalized_base_url = base_url.rstrip("/")
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    target_url = f"{normalized_base_url}{normalized_path}"
+
+    response = requests.request(
+        method=method.upper(),
+        url=target_url,
+        params=params,
+        data=form_data,
+        timeout=timeout_seconds,
+    )
+    try:
+        parsed_json: object | None = response.json()
+    except ValueError:
+        parsed_json = None
+
+    return HttpResult(
+        status_code=response.status_code,
+        text=response.text,
+        json_data=parsed_json,
+        url=response.url,
+    )

--- a/api/_mirror.py
+++ b/api/_mirror.py
@@ -1,0 +1,17 @@
+"""Utilities for declaring Barsukas route mirroring in API facades."""
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+FacadeFunction = TypeVar("FacadeFunction", bound=Callable[..., Any])
+
+
+def mirrored_route(route_path: str, method: str) -> Callable[[FacadeFunction], FacadeFunction]:
+    """Annotate a facade function with the Barsukas route it mirrors."""
+
+    def decorator(function: FacadeFunction) -> FacadeFunction:
+        setattr(function, "_mirrored_route", route_path)
+        setattr(function, "_mirrored_method", method.upper())
+        return cast(FacadeFunction, function)
+
+    return decorator

--- a/api/audio.py
+++ b/api/audio.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
@@ -18,6 +19,7 @@ class AudioResponse:
     result: HttpResult
 
 
+@mirrored_route("/audio/list", "GET")
 def list_audio_files(request_data: ListAudioFilesRequest) -> AudioResponse:
     """Delegate to Barsukas `GET /audio/list` route."""
     return AudioResponse(

--- a/api/audio.py
+++ b/api/audio.py
@@ -1,4 +1,4 @@
-"""Typed wrappers for Barsukas audio routes."""
+"""Typed wrappers for Barsukas JSON audio API endpoints."""
 
 from dataclasses import dataclass
 
@@ -7,11 +7,9 @@ from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
-class ListAudioFilesRequest:
-    page: int = 1
-    status: str = ""
-    language_code: str = ""
-    voice_name: str = ""
+class GetLemmaAudioRequest:
+    guid: str
+    language: str = ""
 
 
 @dataclass(frozen=True)
@@ -19,18 +17,12 @@ class AudioResponse:
     result: HttpResult
 
 
-@mirrored_route("/audio/list", "GET")
-def list_audio_files(request_data: ListAudioFilesRequest) -> AudioResponse:
-    """Delegate to Barsukas `GET /audio/list` route."""
+@mirrored_route("/api/v1/lemma/<guid>/audio", "GET")
+def get_lemma_audio(request_data: GetLemmaAudioRequest) -> AudioResponse:
     return AudioResponse(
         result=send_request(
             "GET",
-            "/audio/list",
-            params={
-                "page": request_data.page,
-                "status": request_data.status,
-                "language_code": request_data.language_code,
-                "voice_name": request_data.voice_name,
-            },
+            f"/api/v1/lemma/{request_data.guid}/audio",
+            params={"language": request_data.language},
         )
     )

--- a/api/audio.py
+++ b/api/audio.py
@@ -1,0 +1,34 @@
+"""Typed wrappers for Barsukas audio routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+
+
+@dataclass(frozen=True)
+class ListAudioFilesRequest:
+    page: int = 1
+    status: str = ""
+    language_code: str = ""
+    voice_name: str = ""
+
+
+@dataclass(frozen=True)
+class AudioResponse:
+    result: HttpResult
+
+
+def list_audio_files(request_data: ListAudioFilesRequest) -> AudioResponse:
+    """Delegate to Barsukas `GET /audio/list` route."""
+    return AudioResponse(
+        result=send_request(
+            "GET",
+            "/audio/list",
+            params={
+                "page": request_data.page,
+                "status": request_data.status,
+                "language_code": request_data.language_code,
+                "voice_name": request_data.voice_name,
+            },
+        )
+    )

--- a/api/batch_operations.py
+++ b/api/batch_operations.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
@@ -16,6 +17,7 @@ class BatchOperationsResponse:
     result: HttpResult
 
 
+@mirrored_route("/batch-operations/", "GET")
 def list_batches(request_data: ListBatchesRequest) -> BatchOperationsResponse:
     """Delegate to Barsukas `GET /batch-operations/` route."""
     return BatchOperationsResponse(

--- a/api/batch_operations.py
+++ b/api/batch_operations.py
@@ -1,0 +1,27 @@
+"""Typed wrappers for Barsukas batch operation routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+
+
+@dataclass(frozen=True)
+class ListBatchesRequest:
+    status: str = ""
+    agent: str = ""
+
+
+@dataclass(frozen=True)
+class BatchOperationsResponse:
+    result: HttpResult
+
+
+def list_batches(request_data: ListBatchesRequest) -> BatchOperationsResponse:
+    """Delegate to Barsukas `GET /batch-operations/` route."""
+    return BatchOperationsResponse(
+        result=send_request(
+            "GET",
+            "/batch-operations/",
+            params={"status": request_data.status, "agent": request_data.agent},
+        )
+    )

--- a/api/constants.py
+++ b/api/constants.py
@@ -1,4 +1,4 @@
 """Shared constants for thin Barsukas API wrappers."""
 
-DEFAULT_BARSUKAS_BASE_URL: str = "http://127.0.0.1:5000"
+DEFAULT_BARSUKAS_BASE_URL: str = "http://100.118.20.30:5555"
 REQUEST_TIMEOUT_SECONDS: int = 30

--- a/api/constants.py
+++ b/api/constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for thin Barsukas API wrappers."""
+
+DEFAULT_BARSUKAS_BASE_URL: str = "http://127.0.0.1:5000"
+REQUEST_TIMEOUT_SECONDS: int = 30

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -1,4 +1,4 @@
-"""Typed wrappers for Barsukas lemma routes."""
+"""Typed wrappers for Barsukas JSON lemma API endpoints."""
 
 from dataclasses import dataclass
 
@@ -7,12 +7,17 @@ from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
-class ListLemmasRequest:
-    page: int = 1
-    search: str = ""
+class SearchLemmasRequest:
+    query: str
     pos_type: str = ""
-    pos_subtype: str = ""
     difficulty: str = ""
+    limit: int = 20
+    offset: int = 0
+
+
+@dataclass(frozen=True)
+class GetLemmaRequest:
+    guid: str
 
 
 @dataclass(frozen=True)
@@ -20,19 +25,23 @@ class LemmasResponse:
     result: HttpResult
 
 
-@mirrored_route("/lemmas/", "GET")
-def list_lemmas(request_data: ListLemmasRequest) -> LemmasResponse:
-    """Delegate to Barsukas `GET /lemmas/` list route."""
+@mirrored_route("/api/v1/search", "GET")
+def search_lemmas(request_data: SearchLemmasRequest) -> LemmasResponse:
     return LemmasResponse(
         result=send_request(
             "GET",
-            "/lemmas/",
+            "/api/v1/search",
             params={
-                "page": request_data.page,
-                "search": request_data.search,
+                "q": request_data.query,
                 "pos_type": request_data.pos_type,
-                "pos_subtype": request_data.pos_subtype,
                 "difficulty": request_data.difficulty,
+                "limit": request_data.limit,
+                "offset": request_data.offset,
             },
         )
     )
+
+
+@mirrored_route("/api/v1/lemma/<guid>", "GET")
+def get_lemma(request_data: GetLemmaRequest) -> LemmasResponse:
+    return LemmasResponse(result=send_request("GET", f"/api/v1/lemma/{request_data.guid}"))

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -1,0 +1,36 @@
+"""Typed wrappers for Barsukas lemma routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+
+
+@dataclass(frozen=True)
+class ListLemmasRequest:
+    page: int = 1
+    search: str = ""
+    pos_type: str = ""
+    pos_subtype: str = ""
+    difficulty: str = ""
+
+
+@dataclass(frozen=True)
+class LemmasResponse:
+    result: HttpResult
+
+
+def list_lemmas(request_data: ListLemmasRequest) -> LemmasResponse:
+    """Delegate to Barsukas `GET /lemmas/` list route."""
+    return LemmasResponse(
+        result=send_request(
+            "GET",
+            "/lemmas/",
+            params={
+                "page": request_data.page,
+                "search": request_data.search,
+                "pos_type": request_data.pos_type,
+                "pos_subtype": request_data.pos_subtype,
+                "difficulty": request_data.difficulty,
+            },
+        )
+    )

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,7 @@ class LemmasResponse:
     result: HttpResult
 
 
+@mirrored_route("/lemmas/", "GET")
 def list_lemmas(request_data: ListLemmasRequest) -> LemmasResponse:
     """Delegate to Barsukas `GET /lemmas/` list route."""
     return LemmasResponse(

--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -1,0 +1,82 @@
+"""Typed wrappers for Barsukas LLM agent-trigger API routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
+
+
+@dataclass(frozen=True)
+class AgentTriggerRequest:
+    guid: str
+    model: str = ""
+    openai_api_key: str = ""
+    anthropic_api_key: str = ""
+    google_api_key: str = ""
+
+
+@dataclass(frozen=True)
+class PronunciationTriggerRequest(AgentTriggerRequest):
+    lang_code: str = "en"
+
+
+@dataclass(frozen=True)
+class AgentTriggerResponse:
+    result: HttpResult
+
+
+@mirrored_route("/api/llm/voras/check-translations", "POST")
+def check_translations(request_data: AgentTriggerRequest) -> AgentTriggerResponse:
+    """Trigger Voras translation validation for one lemma GUID."""
+    return AgentTriggerResponse(
+        result=send_request(
+            "POST",
+            "/api/llm/voras/check-translations",
+            json_data={
+                "guid": request_data.guid,
+                "model": request_data.model,
+                "openai_api_key": request_data.openai_api_key,
+                "anthropic_api_key": request_data.anthropic_api_key,
+                "google_api_key": request_data.google_api_key,
+            },
+        )
+    )
+
+
+@mirrored_route("/api/llm/voras/add-missing-translations", "POST")
+def add_missing_translations(request_data: AgentTriggerRequest) -> AgentTriggerResponse:
+    """Trigger Voras generation of missing translations for one lemma GUID."""
+    return AgentTriggerResponse(
+        result=send_request(
+            "POST",
+            "/api/llm/voras/add-missing-translations",
+            json_data={
+                "guid": request_data.guid,
+                "model": request_data.model,
+                "openai_api_key": request_data.openai_api_key,
+                "anthropic_api_key": request_data.anthropic_api_key,
+                "google_api_key": request_data.google_api_key,
+            },
+        )
+    )
+
+
+@mirrored_route("/api/llm/papuga/generate-pronunciations", "POST")
+def generate_pronunciations(
+    request_data: PronunciationTriggerRequest,
+) -> AgentTriggerResponse:
+    """Trigger Papuga pronunciation generation for one lemma GUID."""
+    return AgentTriggerResponse(
+        result=send_request(
+            "POST",
+            "/api/llm/papuga/generate-pronunciations",
+            json_data={
+                "guid": request_data.guid,
+                "lang_code": request_data.lang_code,
+                "model": request_data.model,
+                "openai_api_key": request_data.openai_api_key,
+                "anthropic_api_key": request_data.anthropic_api_key,
+                "google_api_key": request_data.google_api_key,
+            },
+        )
+    )

--- a/api/sentences.py
+++ b/api/sentences.py
@@ -1,0 +1,40 @@
+"""Typed wrappers for Barsukas sentence routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+
+
+@dataclass(frozen=True)
+class ListSentencesRequest:
+    page: int = 1
+    search: str = ""
+    pattern_type: str = ""
+    minimum_level: str = ""
+    has_translation: str = ""
+    exclude_rejected: str = "no"
+    exclude_verified: str = "no"
+
+
+@dataclass(frozen=True)
+class SentencesResponse:
+    result: HttpResult
+
+
+def list_sentences(request_data: ListSentencesRequest) -> SentencesResponse:
+    """Delegate to Barsukas `GET /sentences/` list route."""
+    return SentencesResponse(
+        result=send_request(
+            "GET",
+            "/sentences/",
+            params={
+                "page": request_data.page,
+                "search": request_data.search,
+                "pattern_type": request_data.pattern_type,
+                "minimum_level": request_data.minimum_level,
+                "has_translation": request_data.has_translation,
+                "exclude_rejected": request_data.exclude_rejected,
+                "exclude_verified": request_data.exclude_verified,
+            },
+        )
+    )

--- a/api/sentences.py
+++ b/api/sentences.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
@@ -21,6 +22,7 @@ class SentencesResponse:
     result: HttpResult
 
 
+@mirrored_route("/sentences/", "GET")
 def list_sentences(request_data: ListSentencesRequest) -> SentencesResponse:
     """Delegate to Barsukas `GET /sentences/` list route."""
     return SentencesResponse(

--- a/api/sentences.py
+++ b/api/sentences.py
@@ -1,4 +1,4 @@
-"""Typed wrappers for Barsukas sentence routes."""
+"""Typed wrappers for Barsukas JSON sentence API endpoints."""
 
 from dataclasses import dataclass
 
@@ -7,14 +7,9 @@ from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
-class ListSentencesRequest:
-    page: int = 1
-    search: str = ""
-    pattern_type: str = ""
-    minimum_level: str = ""
-    has_translation: str = ""
-    exclude_rejected: str = "no"
-    exclude_verified: str = "no"
+class GetLemmaSentencesRequest:
+    guid: str
+    language: str = ""
 
 
 @dataclass(frozen=True)
@@ -22,21 +17,12 @@ class SentencesResponse:
     result: HttpResult
 
 
-@mirrored_route("/sentences/", "GET")
-def list_sentences(request_data: ListSentencesRequest) -> SentencesResponse:
-    """Delegate to Barsukas `GET /sentences/` list route."""
+@mirrored_route("/api/v1/lemma/<guid>/sentences", "GET")
+def get_lemma_sentences(request_data: GetLemmaSentencesRequest) -> SentencesResponse:
     return SentencesResponse(
         result=send_request(
             "GET",
-            "/sentences/",
-            params={
-                "page": request_data.page,
-                "search": request_data.search,
-                "pattern_type": request_data.pattern_type,
-                "minimum_level": request_data.minimum_level,
-                "has_translation": request_data.has_translation,
-                "exclude_rejected": request_data.exclude_rejected,
-                "exclude_verified": request_data.exclude_verified,
-            },
+            f"/api/v1/lemma/{request_data.guid}/sentences",
+            params={"language": request_data.language},
         )
     )

--- a/api/translations.py
+++ b/api/translations.py
@@ -1,4 +1,4 @@
-"""Typed wrappers for Barsukas translation routes."""
+"""Typed wrappers for Barsukas JSON translation API endpoints."""
 
 from dataclasses import dataclass
 
@@ -7,12 +7,9 @@ from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
-class UpdateTranslationRequest:
-    lemma_id: int
-    lang_code: str
-    translation: str
-    disambiguation: str = ""
-    return_to: str = ""
+class GetLemmaTranslationsRequest:
+    guid: str
+    language: str = ""
 
 
 @dataclass(frozen=True)
@@ -20,17 +17,12 @@ class TranslationResponse:
     result: HttpResult
 
 
-@mirrored_route("/translations/<lemma_id>/<lang_code>", "POST")
-def update_translation(request_data: UpdateTranslationRequest) -> TranslationResponse:
-    """Delegate to Barsukas `POST /translations/<lemma_id>/<lang_code>` route."""
+@mirrored_route("/api/v1/lemma/<guid>/translations", "GET")
+def get_lemma_translations(request_data: GetLemmaTranslationsRequest) -> TranslationResponse:
     return TranslationResponse(
         result=send_request(
-            "POST",
-            f"/translations/{request_data.lemma_id}/{request_data.lang_code}",
-            form_data={
-                "translation": request_data.translation,
-                "disambiguation": request_data.disambiguation,
-                "return_to": request_data.return_to,
-            },
+            "GET",
+            f"/api/v1/lemma/{request_data.guid}/translations",
+            params={"language": request_data.language},
         )
     )

--- a/api/translations.py
+++ b/api/translations.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api._http import HttpResult, send_request
+from api._mirror import mirrored_route
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,7 @@ class TranslationResponse:
     result: HttpResult
 
 
+@mirrored_route("/translations/<lemma_id>/<lang_code>", "POST")
 def update_translation(request_data: UpdateTranslationRequest) -> TranslationResponse:
     """Delegate to Barsukas `POST /translations/<lemma_id>/<lang_code>` route."""
     return TranslationResponse(

--- a/api/translations.py
+++ b/api/translations.py
@@ -1,0 +1,34 @@
+"""Typed wrappers for Barsukas translation routes."""
+
+from dataclasses import dataclass
+
+from api._http import HttpResult, send_request
+
+
+@dataclass(frozen=True)
+class UpdateTranslationRequest:
+    lemma_id: int
+    lang_code: str
+    translation: str
+    disambiguation: str = ""
+    return_to: str = ""
+
+
+@dataclass(frozen=True)
+class TranslationResponse:
+    result: HttpResult
+
+
+def update_translation(request_data: UpdateTranslationRequest) -> TranslationResponse:
+    """Delegate to Barsukas `POST /translations/<lemma_id>/<lang_code>` route."""
+    return TranslationResponse(
+        result=send_request(
+            "POST",
+            f"/translations/{request_data.lemma_id}/{request_data.lang_code}",
+            form_data={
+                "translation": request_data.translation,
+                "disambiguation": request_data.disambiguation,
+                "return_to": request_data.return_to,
+            },
+        )
+    )

--- a/scripts/check_api_mirror_routes.py
+++ b/scripts/check_api_mirror_routes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Check that mirrored route path/method metadata matches between barsukas and api."""
+
+import ast
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BARSUKAS_FILES = [
+    "src/barsukas/routes/lemmas.py",
+    "src/barsukas/routes/sentences.py",
+    "src/barsukas/routes/translations.py",
+    "src/barsukas/routes/audio.py",
+    "src/barsukas/routes/batch_operations.py",
+    "src/barsukas/routes/llm_api.py",
+]
+
+API_FILES = [
+    "api/lemmas.py",
+    "api/sentences.py",
+    "api/translations.py",
+    "api/audio.py",
+    "api/batch_operations.py",
+    "api/llm_agents.py",
+]
+
+
+def _extract_mirror_pairs(file_paths: Iterable[str], decorator_name: str) -> set[tuple[str, str]]:
+    pairs: set[tuple[str, str]] = set()
+    for rel_path in file_paths:
+        source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=rel_path)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call) or not isinstance(dec.func, ast.Name):
+                    continue
+                if dec.func.id != decorator_name or len(dec.args) < 2:
+                    continue
+                route_arg = dec.args[0]
+                method_arg = dec.args[1]
+                if not (
+                    isinstance(route_arg, ast.Constant)
+                    and isinstance(route_arg.value, str)
+                    and isinstance(method_arg, ast.Constant)
+                    and isinstance(method_arg.value, str)
+                ):
+                    raise ValueError(f"{rel_path}:{node.lineno} has non-literal mirror metadata")
+                pairs.add((route_arg.value, method_arg.value.upper()))
+    return pairs
+
+
+def main() -> int:
+    barsukas_pairs = _extract_mirror_pairs(BARSUKAS_FILES, "mirrored_by_api")
+    api_pairs = _extract_mirror_pairs(API_FILES, "mirrored_route")
+
+    missing_in_api = barsukas_pairs - api_pairs
+    missing_in_barsukas = api_pairs - barsukas_pairs
+
+    if missing_in_api or missing_in_barsukas:
+        if missing_in_api:
+            print("Missing in api decorators:")
+            for route_path, method in sorted(missing_in_api):
+                print(f"  - {method} {route_path}")
+        if missing_in_barsukas:
+            print("Missing in barsukas decorators:")
+            for route_path, method in sorted(missing_in_barsukas):
+                print(f"  - {method} {route_path}")
+        return 1
+
+    print(f"OK: {len(api_pairs)} mirrored route path/method pairs match.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_api_mirror_routes.py
+++ b/scripts/check_api_mirror_routes.py
@@ -14,6 +14,7 @@ BARSUKAS_FILES = [
     "src/barsukas/routes/audio.py",
     "src/barsukas/routes/batch_operations.py",
     "src/barsukas/routes/llm_api.py",
+    "src/barsukas/routes/api.py",
 ]
 
 API_FILES = [

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -2,9 +2,12 @@
 
 """API routes for AJAX requests and REST API endpoints."""
 
+# MIRROR NOTICE: If you edit mirrored JSON endpoints here, update matching top-level api/ wrappers in the same commit.
+
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from barsukas.config import Config
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, Response, g, jsonify, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import and_, case, func, or_
@@ -363,6 +366,7 @@ def api_info() -> ResponseReturnValue:
 
 
 @bp.route("/v1/search")
+@mirrored_by_api("/api/v1/search", "GET")
 def search_lemmas() -> ResponseReturnValue:
     """
     Search for lemmas by keyword across multiple fields.
@@ -536,6 +540,7 @@ def _build_success_response(
 
 
 @bp.route("/v1/lemma/<guid>")
+@mirrored_by_api("/api/v1/lemma/<guid>", "GET")
 def get_lemma_info(guid: str) -> ResponseReturnValue:
     """
     Get basic information about a lemma by GUID.
@@ -575,6 +580,7 @@ def get_lemma_info(guid: str) -> ResponseReturnValue:
 
 
 @bp.route("/v1/lemma/<guid>/translations")
+@mirrored_by_api("/api/v1/lemma/<guid>/translations", "GET")
 def get_lemma_translations(guid: str) -> ResponseReturnValue:
     """
     Get translations of a lemma in various languages.
@@ -831,6 +837,7 @@ def get_lemma_pronunciations(guid: str) -> ResponseReturnValue:
 
 
 @bp.route("/v1/lemma/<guid>/audio")
+@mirrored_by_api("/api/v1/lemma/<guid>/audio", "GET")
 def get_lemma_audio(guid: str) -> ResponseReturnValue:
     """
     Get audio availability for a lemma by language.
@@ -975,6 +982,7 @@ def get_lemma_audio(guid: str) -> ResponseReturnValue:
 
 
 @bp.route("/v1/lemma/<guid>/sentences")
+@mirrored_by_api("/api/v1/lemma/<guid>/sentences", "GET")
 def get_lemma_sentences(guid: str) -> ResponseReturnValue:
     """
     Get example sentences that use this lemma.

--- a/src/barsukas/routes/audio.py
+++ b/src/barsukas/routes/audio.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python3
-# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
-
 """
 Audio Quality Review Routes
 
@@ -41,7 +39,6 @@ from audioshoe.espeak import EspeakVoice
 from audioshoe.qwen.types import QwenVoice
 from audioshoe.piper import PiperVoice
 from barsukas.helpers.audio_helpers import link_audio_to_lemma, validate_audio_translation
-from barsukas.routes.mirror_metadata import mirrored_by_api
 from clients.audio import Voice
 from clients.audio.gpt_voices import GptVoice
 from clients.audio.azure_tts import AzureVoice
@@ -228,7 +225,6 @@ def import_manifest() -> ResponseReturnValue:
 
 
 @bp.route("/list")
-@mirrored_by_api("/audio/list", "GET")
 def list_files() -> ResponseReturnValue:
     """List audio files with filters and search."""
     # Get filter parameters

--- a/src/barsukas/routes/audio.py
+++ b/src/barsukas/routes/audio.py
@@ -41,6 +41,7 @@ from audioshoe.espeak import EspeakVoice
 from audioshoe.qwen.types import QwenVoice
 from audioshoe.piper import PiperVoice
 from barsukas.helpers.audio_helpers import link_audio_to_lemma, validate_audio_translation
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from clients.audio import Voice
 from clients.audio.gpt_voices import GptVoice
 from clients.audio.azure_tts import AzureVoice
@@ -227,6 +228,7 @@ def import_manifest() -> ResponseReturnValue:
 
 
 @bp.route("/list")
+@mirrored_by_api("/audio/list", "GET")
 def list_files() -> ResponseReturnValue:
     """List audio files with filters and search."""
     # Get filter parameters

--- a/src/barsukas/routes/audio.py
+++ b/src/barsukas/routes/audio.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
 
 """
 Audio Quality Review Routes

--- a/src/barsukas/routes/batch_operations.py
+++ b/src/barsukas/routes/batch_operations.py
@@ -3,6 +3,7 @@
 
 """Routes for viewing batch operations."""
 
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, render_template, request
 from flask.typing import ResponseReturnValue
 
@@ -18,6 +19,7 @@ bp = Blueprint("batch_operations", __name__, url_prefix="/batch-operations")
 
 
 @bp.route("/")
+@mirrored_by_api("/batch-operations/", "GET")
 def list_batches() -> ResponseReturnValue:
     """List batch operations with filtering."""
     status_filter = request.args.get("status", "").strip()

--- a/src/barsukas/routes/batch_operations.py
+++ b/src/barsukas/routes/batch_operations.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
 
 """Routes for viewing batch operations."""
 

--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from sqlalchemy import func
 
 from barsukas.config import Config
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, flash, g, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 
@@ -193,6 +194,7 @@ def add_lemma() -> ResponseReturnValue:
 
 
 @bp.route("/")
+@mirrored_by_api("/lemmas/", "GET")
 def list_lemmas() -> ResponseReturnValue:
     """List all lemmas with pagination and filtering."""
     page = request.args.get("page", 1, type=int)

--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
 
 """Routes for lemma management."""
 

--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -1,6 +1,4 @@
 #!/usr/bin/python3
-# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
-
 """Routes for lemma management."""
 
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -8,7 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from sqlalchemy import func
 
 from barsukas.config import Config
-from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, flash, g, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 
@@ -194,7 +191,6 @@ def add_lemma() -> ResponseReturnValue:
 
 
 @bp.route("/")
-@mirrored_by_api("/lemmas/", "GET")
 def list_lemmas() -> ResponseReturnValue:
     """List all lemmas with pagination and filtering."""
     page = request.args.get("page", 1, type=int)

--- a/src/barsukas/routes/llm_api.py
+++ b/src/barsukas/routes/llm_api.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple, Union
 
 from barsukas.config import Config
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, g, jsonify, request
 from flask.typing import ResponseReturnValue
 
@@ -190,6 +191,7 @@ def api_info() -> ResponseReturnValue:
 
 
 @bp.route("/voras/check-translations", methods=["POST"])
+@mirrored_by_api("/api/llm/voras/check-translations", "POST")
 def api_check_translations() -> ResponseReturnValue:
     """Check translations for a lemma using LLM validation.
 
@@ -278,6 +280,7 @@ def api_check_translations() -> ResponseReturnValue:
 
 
 @bp.route("/voras/add-missing-translations", methods=["POST"])
+@mirrored_by_api("/api/llm/voras/add-missing-translations", "POST")
 def api_add_missing_translations() -> ResponseReturnValue:
     """Generate missing translations for a lemma.
 
@@ -330,6 +333,7 @@ def api_add_missing_translations() -> ResponseReturnValue:
 
 
 @bp.route("/papuga/generate-pronunciations", methods=["POST"])
+@mirrored_by_api("/api/llm/papuga/generate-pronunciations", "POST")
 def api_generate_pronunciations() -> ResponseReturnValue:
     """Generate pronunciations for a lemma's forms.
 

--- a/src/barsukas/routes/mirror_metadata.py
+++ b/src/barsukas/routes/mirror_metadata.py
@@ -1,0 +1,17 @@
+"""Decorator metadata for Barsukas routes mirrored by top-level api/ wrappers."""
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+RouteFunction = TypeVar("RouteFunction", bound=Callable[..., Any])
+
+
+def mirrored_by_api(route_path: str, method: str) -> Callable[[RouteFunction], RouteFunction]:
+    """Attach mirror metadata for external api/ wrapper parity checks."""
+
+    def decorator(function: RouteFunction) -> RouteFunction:
+        setattr(function, "_mirrored_route", route_path)
+        setattr(function, "_mirrored_method", method.upper())
+        return cast(RouteFunction, function)
+
+    return decorator

--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
-# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
-
 """Routes for sentence management."""
 
 from typing import Any, Union
 
 from barsukas.config import Config
-from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, current_app, flash, g, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from sqlalchemy import case, func, or_
@@ -43,7 +40,6 @@ bp = Blueprint("sentences", __name__, url_prefix="/sentences")
 
 
 @bp.route("/")
-@mirrored_by_api("/sentences/", "GET")
 def list_sentences() -> ResponseReturnValue:
     """List all sentences with pagination and filtering."""
     page = request.args.get("page", 1, type=int)

--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
 
 """Routes for sentence management."""
 

--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -6,6 +6,7 @@
 from typing import Any, Union
 
 from barsukas.config import Config
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, current_app, flash, g, redirect, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from sqlalchemy import case, func, or_
@@ -42,6 +43,7 @@ bp = Blueprint("sentences", __name__, url_prefix="/sentences")
 
 
 @bp.route("/")
+@mirrored_by_api("/sentences/", "GET")
 def list_sentences() -> ResponseReturnValue:
     """List all sentences with pagination and filtering."""
     page = request.args.get("page", 1, type=int)

--- a/src/barsukas/routes/translations.py
+++ b/src/barsukas/routes/translations.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
 
 """Routes for translation management."""
 

--- a/src/barsukas/routes/translations.py
+++ b/src/barsukas/routes/translations.py
@@ -1,12 +1,9 @@
 #!/usr/bin/python3
-# MIRROR NOTICE: If you edit this route module, update the matching wrapper in top-level api/ in the same commit.
-
 """Routes for translation management."""
 
 from typing import Union
 
 from barsukas.config import Config
-from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, flash, g, jsonify, redirect, request, url_for
 from werkzeug.wrappers import Response
 
@@ -23,7 +20,6 @@ bp = Blueprint("translations", __name__, url_prefix="/translations")
 
 
 @bp.route("/<int:lemma_id>/<lang_code>", methods=["POST"])
-@mirrored_by_api("/translations/<lemma_id>/<lang_code>", "POST")
 def update_translation(lemma_id: int, lang_code: str) -> Response:
     """Update a translation for a lemma."""
     from flask import current_app

--- a/src/barsukas/routes/translations.py
+++ b/src/barsukas/routes/translations.py
@@ -6,6 +6,7 @@
 from typing import Union
 
 from barsukas.config import Config
+from barsukas.routes.mirror_metadata import mirrored_by_api
 from flask import Blueprint, flash, g, jsonify, redirect, request, url_for
 from werkzeug.wrappers import Response
 
@@ -22,6 +23,7 @@ bp = Blueprint("translations", __name__, url_prefix="/translations")
 
 
 @bp.route("/<int:lemma_id>/<lang_code>", methods=["POST"])
+@mirrored_by_api("/translations/<lemma_id>/<lang_code>", "POST")
 def update_translation(lemma_id: int, lang_code: str) -> Response:
     """Update a translation for a lemma."""
     from flask import current_app


### PR DESCRIPTION
### Motivation

- Provide a small, stable, typed Python import surface for programmatic access to Barsukas routes without duplicating business logic.
- Mirror Barsukas HTTP route domains so Python code can call the same operations via thin, typed facades.
- Make it explicit when Barsukas route handlers change so the corresponding wrapper is updated in the same change. 

### Description

- Added a new top-level `api/` package with thin typed wrapper modules: `api/lemmas.py`, `api/sentences.py`, `api/translations.py`, `api/audio.py`, and `api/batch_operations.py`, each defining small request/response `dataclass` models and façade functions that delegate to a single Barsukas endpoint. 
- Added shared configuration in `api/constants.py` and an internal HTTP helper `api/_http.py` which provides `send_request` and a normalized `HttpResult` shape. 
- Added `api/__init__.py` to export only the supported public entry points and keep internals hidden. 
- Added `api/AGENTS.md` documenting the package purpose, the mirroring pattern, and the rule to update wrappers alongside Barsukas route edits. 
- Inserted a short mirror notice at the top of the corresponding Barsukas route modules (`src/barsukas/routes/lemmas.py`, `sentences.py`, `translations.py`, `audio.py`, and `batch_operations.py`) to make the synchronization requirement explicit. 

### Testing

- Ran formatting with `black` on the new `api/` files and the affected Barsukas route modules and the formatter completed successfully. 
- Ran `mypy` across the new `api/` package and the touched Barsukas route files and there were no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb8445657c8327801c9fa5e2c0561b)