### PR TITLE
Add API support for lemma difficulty updates and exact difficulty metadata filter

### DIFF
--- a/api/_http.py
+++ b/api/_http.py
@@ -96,3 +96,35 @@ def post_json(
         raise BarsukasAPIError(response.status_code, message)
 
     return response.json()
+
+
+def patch_json(
+    path: str,
+    body: Optional[Mapping[str, Any]] = None,
+    *,
+    base_url: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Any:
+    """PATCH ``path`` with ``body`` as JSON and return parsed JSON."""
+    if not path.startswith("/"):
+        raise ValueError(f"path must start with '/': {path!r}")
+
+    cleaned_body = {key: value for key, value in body.items() if value is not None} if body else {}
+
+    url = (base_url.rstrip("/") if base_url else BASE_URL) + path
+    response = requests.patch(
+        url,
+        json=cleaned_body,
+        timeout=timeout,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/json"},
+    )
+
+    if not response.ok:
+        try:
+            payload = response.json()
+            message = payload.get("error") or response.text
+        except ValueError:
+            message = response.text
+        raise BarsukasAPIError(response.status_code, message)
+
+    return response.json()

--- a/api/batch_operations.py
+++ b/api/batch_operations.py
@@ -23,11 +23,12 @@ def get_word_metadata(
     *,
     language: Optional[str] = None,
     max_difficulty: Optional[int] = None,
+    difficulty: Optional[int] = None,
 ) -> Any:
     """Per-language lemma counts and metadata coverage."""
     return get_json(
         f"{API_V1_PREFIX}/metadata/words",
-        {"language": language, "max_difficulty": max_difficulty},
+        {"language": language, "max_difficulty": max_difficulty, "difficulty": difficulty},
     )
 
 

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, TypedDict, cast
 
 from api._mirror import mirrored_route
-from api._http import get_json
+from api._http import get_json, patch_json, post_json
 from api.constants import API_V1_PREFIX
 
 
@@ -131,6 +131,24 @@ def search(
 def get_lemma(guid: str) -> Any:
     """Basic lemma details."""
     return get_json(f"{API_V1_PREFIX}/lemma/{guid}")
+
+
+@mirrored_route("/api/v1/lemma/<guid>", "POST")
+def set_lemma_difficulty(guid: str, difficulty_level: Optional[int]) -> Any:
+    """Set or clear Barsukas difficulty level for a lemma."""
+    return post_json(
+        f"{API_V1_PREFIX}/lemma/{guid}",
+        {"difficulty_level": difficulty_level},
+    )
+
+
+@mirrored_route("/api/v1/lemma/<guid>", "PATCH")
+def patch_lemma_difficulty(guid: str, difficulty_level: Optional[int]) -> Any:
+    """PATCH Barsukas difficulty level for a lemma."""
+    return patch_json(
+        f"{API_V1_PREFIX}/lemma/{guid}",
+        {"difficulty_level": difficulty_level},
+    )
 
 
 @mirrored_route("/api/v1/lemma/<guid>/translations", "GET")

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -16,6 +16,9 @@ Base prefix: `/api`.
 
 - `GET /api/v1/lemma/<guid>`
   - Basic lemma details.
+- `POST /api/v1/lemma/<guid>` or `PATCH /api/v1/lemma/<guid>`
+  - Update mutable lemma fields.
+  - Body: `{"difficulty_level": <int|null>}`.
 
 - `GET /api/v1/lemma/<guid>/translations[?language=<code>]`
   - Translations keyed by language code.
@@ -45,7 +48,7 @@ Base prefix: `/api`.
 
 ## Metadata endpoints (for aggregate counting)
 
-- `GET /api/v1/metadata/words[?language=<code>][&max_difficulty=<int>]`
+- `GET /api/v1/metadata/words[?language=<code>][&max_difficulty=<int>][&difficulty=<int>]`
 
 Returns per-language aggregate counts with this shape:
 
@@ -64,6 +67,8 @@ Returns per-language aggregate counts with this shape:
 - `max_difficulty`: if supplied, restricts to words whose effective difficulty
   (`COALESCE(lemma_difficulty_overrides.difficulty_level, lemma.difficulty_level)` for the
   requested language) is between 1 and `max_difficulty` inclusive (excludes -1 / NULL)
+- `difficulty`: if supplied, restricts to words whose effective difficulty exactly equals
+  that value
 
 - `GET /api/v1/metadata/sentences[?language=<code>][&max_difficulty=<int>]`
 

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -584,6 +584,57 @@ def get_lemma_info(guid: str) -> ResponseReturnValue:
     return _build_success_response(data)
 
 
+@bp.route("/v1/lemma/<guid>", methods=["POST", "PATCH"])
+@mirrored_facade("/api/v1/lemma/<guid>", "POST")
+@mirrored_facade("/api/v1/lemma/<guid>", "PATCH")
+def update_lemma_info(guid: str) -> ResponseReturnValue:
+    """Update mutable lemma fields.
+
+    Supports:
+      - ``difficulty_level``: integer in configured range, ``-1`` to exclude,
+        or ``null`` to unset.
+    """
+    lemma = get_lemma_by_guid(g.db, guid)
+    if not lemma:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+
+    payload = request.get_json(silent=True) or {}
+    if "difficulty_level" not in payload:
+        return _build_error_response("JSON body must include 'difficulty_level'", 400)
+
+    difficulty_value = payload["difficulty_level"]
+    if difficulty_value is None:
+        new_difficulty_level: Optional[int] = None
+    else:
+        try:
+            new_difficulty_level = int(difficulty_value)
+        except (TypeError, ValueError):
+            return _build_error_response("difficulty_level must be an integer or null", 400)
+
+        if new_difficulty_level != Config.EXCLUDE_DIFFICULTY_LEVEL and (
+            new_difficulty_level < Config.MIN_DIFFICULTY_LEVEL
+            or new_difficulty_level > Config.MAX_DIFFICULTY_LEVEL
+        ):
+            return _build_error_response(
+                f"difficulty_level must be between {Config.MIN_DIFFICULTY_LEVEL} and "
+                f"{Config.MAX_DIFFICULTY_LEVEL}, or {Config.EXCLUDE_DIFFICULTY_LEVEL}",
+                400,
+            )
+
+    old_difficulty_level = lemma.difficulty_level
+    lemma.difficulty_level = new_difficulty_level
+    g.db.commit()
+
+    return _build_success_response(
+        {
+            "guid": lemma.guid,
+            "difficulty_level": _serialize_value(lemma.difficulty_level),
+            "previous_difficulty_level": _serialize_value(old_difficulty_level),
+            "updated": old_difficulty_level != lemma.difficulty_level,
+        }
+    )
+
+
 @bp.route("/v1/lemma/<guid>/translations")
 @mirrored_facade("/api/v1/lemma/<guid>/translations", "GET")
 def get_lemma_translations(guid: str) -> ResponseReturnValue:
@@ -1117,15 +1168,24 @@ def get_word_metadata() -> ResponseReturnValue:
       max_difficulty=<int>  Only count words whose effective difficulty (COALESCE of
                             per-language override and base lemma difficulty) is between
                             1 and max_difficulty inclusive (excludes -1 / unset).
+      difficulty=<int>      Only count words whose effective difficulty exactly equals this
+                            value.
     """
     requested_language = request.args.get("language", "").strip().lower()
     max_difficulty_param = request.args.get("max_difficulty", "").strip()
+    difficulty_param = request.args.get("difficulty", "").strip()
     max_difficulty: Optional[int] = None
+    exact_difficulty: Optional[int] = None
     if max_difficulty_param:
         try:
             max_difficulty = int(max_difficulty_param)
         except ValueError:
             return _build_error_response("max_difficulty must be an integer", 400)
+    if difficulty_param:
+        try:
+            exact_difficulty = int(difficulty_param)
+        except ValueError:
+            return _build_error_response("difficulty must be an integer", 400)
 
     translation_languages = {
         row[0]
@@ -1198,6 +1258,19 @@ def get_word_metadata() -> ResponseReturnValue:
                 effective_difficulty >= 1,
                 effective_difficulty <= max_difficulty,
             )
+        elif exact_difficulty is not None:
+            effective_difficulty = case(
+                (
+                    LemmaDifficultyOverride.difficulty_level.isnot(None),
+                    LemmaDifficultyOverride.difficulty_level,
+                ),
+                else_=Lemma.difficulty_level,
+            )
+            base_query = base_query.outerjoin(
+                LemmaDifficultyOverride,
+                (LemmaDifficultyOverride.lemma_id == Lemma.id)
+                & (LemmaDifficultyOverride.language_code == current_language),
+            ).filter(effective_difficulty == exact_difficulty)
 
         base_subquery = base_query.subquery()
 
@@ -1278,6 +1351,8 @@ def get_word_metadata() -> ResponseReturnValue:
         metadata["requested_language"] = requested_language
     if max_difficulty is not None:
         metadata["max_difficulty"] = max_difficulty
+    if exact_difficulty is not None:
+        metadata["difficulty"] = exact_difficulty
 
     return _build_success_response(summary_data, metadata)
 


### PR DESCRIPTION
### Motivation
- Provide a programmatic way to change a lemma's Barsukas difficulty level via the HTTP API (needed for automation/agents). 
- Make the `/api/v1/metadata/words` aggregate more useful for level-specific queries by adding an exact `difficulty` filter alongside `max_difficulty`.

### Description
- Added writable endpoint `POST`/`PATCH /api/v1/lemma/<guid>` in `src/barsukas/routes/api.py` to update `difficulty_level`, with validation against `Config.MIN_DIFFICULTY_LEVEL`/`Config.MAX_DIFFICULTY_LEVEL` and support for `null` to unset, returning previous/new values. 
- Implemented matching facades in `api/lemmas.py` (`POST` + `PATCH` helpers) and added an internal `patch_json()` transport helper to `api/_http.py`. 
- Extended `src/barsukas/routes/api.py` `GET /v1/metadata/words` to accept `difficulty=<int>` and filter by the effective difficulty (`COALESCE` of override and base difficulty) for exact-match counts, and mirrored the new `difficulty` parameter in `api/batch_operations.py`. 
- Updated API documentation `src/barsukas/routes/API.md` to list the new endpoints/parameter and ensured mirrored-route annotations remain consistent.

### Testing
- Ran code formatter: `black src/barsukas/routes/api.py api/lemmas.py api/batch_operations.py api/_http.py` and it completed successfully. 
- Type-checked with `mypy src/barsukas/routes/api.py api/lemmas.py api/batch_operations.py api/_http.py` with no errors. 
- Verified mirror parity with `PYTHONPATH=src python scripts/check_api_mirror_routes.py`, which reported OK for mirrored routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb945fa4e0832795af2b2b0e1824bd)