### PR TITLE
Add language-scoped filter to Voras add-missing-translations endpoint

### DIFF
--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -12,7 +12,7 @@ genuinely requires a per-call key, do not add it here.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 from api._http import get_json, post_json
 from api._mirror import mirrored_route
@@ -34,17 +34,20 @@ def check_translations(guid: str, *, model: Optional[str] = None) -> Any:
 
 
 @mirrored_route("/api/llm/voras/add-missing-translations", "POST")
-def add_missing_translations(guid: str, *, model: Optional[str] = None) -> Any:
-    """Generate missing translations for a lemma across all configured languages.
+def add_missing_translations(
+    guid: str,
+    *,
+    model: Optional[str] = None,
+    languages: Optional[List[str]] = None,
+) -> Any:
+    """Generate missing translations for a lemma.
 
-    The Barsukas route currently has no per-call language filter; it fills in
-    every translation language Voras is configured for. If you need
-    "translate into these specific languages only", that capability has to
-    be added on the Barsukas side first.
+    When ``languages`` is omitted/None, Voras fills all configured generation
+    languages. When provided, Voras fills only the requested language codes.
     """
     return post_json(
         "/api/llm/voras/add-missing-translations",
-        {"guid": guid, "model": model},
+        {"guid": guid, "model": model, "languages": languages},
     )
 
 

--- a/src/barsukas/routes/llm_api.py
+++ b/src/barsukas/routes/llm_api.py
@@ -23,7 +23,7 @@ the matching facade in the same commit. See ``api/AGENTS.md``.
 """
 
 import logging
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from barsukas.config import Config
 from barsukas.routes._mirror import mirrored_facade
@@ -292,6 +292,8 @@ def api_add_missing_translations() -> ResponseReturnValue:
 
     Request body (JSON):
         guid: Required. GUID of the lemma (e.g., 'N03_003')
+        languages: Optional list of language codes (e.g., ["hr", "bs"]).
+            When omitted/null, uses all configured Voras generation languages.
         model: Optional. LLM model to use
         openai_api_key: Optional. OpenAI API key
         anthropic_api_key: Optional. Anthropic API key
@@ -308,17 +310,49 @@ def api_add_missing_translations() -> ResponseReturnValue:
     if not guid:
         return _build_error_response("guid is required")
 
+    languages_raw = data.get("languages")
+    languages: Optional[List[str]]
+    if languages_raw is None:
+        languages = None
+    else:
+        if not isinstance(languages_raw, list) or not all(
+            isinstance(language_code, str) for language_code in languages_raw
+        ):
+            return _build_error_response("languages must be a list of language code strings")
+        languages = languages_raw
+
     lemma, error = _get_lemma_or_error(guid)
     if error:
         return error
     assert lemma is not None  # Type narrowing for mypy
 
     try:
+        from storage.translation_helpers import get_tier_1_and_tier_2_languages
+
+        allowed_languages = set(get_tier_1_and_tier_2_languages())
+        if languages is not None:
+            unknown_languages = sorted(
+                language_code
+                for language_code in languages
+                if language_code not in allowed_languages
+            )
+            if unknown_languages:
+                return _build_error_response(
+                    "Unknown language codes: "
+                    + ", ".join(unknown_languages)
+                    + ". Allowed codes: "
+                    + ", ".join(sorted(allowed_languages))
+                )
+
         config = _get_config_from_request(data)
         agent = VorasAgent(config=config)
 
         # Use the agent's fix_missing_translations method with the specific lemma
-        result = agent.fix_missing_translations(lemmas=[lemma], dry_run=False)
+        result = agent.fix_missing_translations(
+            language_code=languages,
+            lemmas=[lemma],
+            dry_run=False,
+        )
 
         g.db.commit()
 


### PR DESCRIPTION
### Motivation
- Allow callers to restrict Voras translation generation to a specific set of language codes per-request instead of always operating over all configured generation languages.
- Keep existing behavior when no per-call filter is provided and ensure the mirrored `api/` facade exposes the new per-call option.

### Description
- Added an optional `languages` JSON field to `POST /api/llm/voras/add-missing-translations` in `src/barsukas/routes/llm_api.py` with validation that it is a `list[str]` when provided and returns HTTP 400 for invalid input.
- Validate requested codes against the configured generation set using `get_tier_1_and_tier_2_languages()` and return a clear 400 error for unknown codes; when `languages` is omitted/null the previous behavior (all configured languages) is preserved.
- Pass the filter through to `VorasAgent.fix_missing_translations` via `language_code=...` and keep the response shape unchanged while `by_language` naturally reflects the requested languages.
- Updated the root-level facade `api/llm_agents.py` to accept `languages: Optional[List[str]] = None`, forward it in the POST body, and adjusted the docstring to reflect per-call filtering support.

### Testing
- Ran formatter: `black src/barsukas/routes/llm_api.py api/llm_agents.py`, which completed successfully.
- Ran static typing: `mypy src/barsukas/routes/llm_api.py api/llm_agents.py`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9502044c8327b87cc4a67ecae9aa)