### PR TITLE
Add mirrored lemma wordfreq API endpoint

### DIFF
--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -102,6 +102,20 @@ class SentenceEntry(TypedDict, total=False):
     word_info: List[SentenceWordInfo]
 
 
+class WordfreqCorpusEntry(TypedDict):
+    total_frequency: Optional[float]
+    best_rank: Optional[int]
+
+
+class WordfreqLanguageEntry(TypedDict):
+    corpora: Dict[str, WordfreqCorpusEntry]
+
+
+class WordfreqResponse(TypedDict):
+    data: Dict[str, Dict[str, WordfreqCorpusEntry]]
+    metadata: Dict[str, Optional[int]]
+
+
 @mirrored_route("/api/v1/search", "GET")
 def search(
     query: str,
@@ -194,6 +208,12 @@ def get_audio(guid: str, *, language: Optional[str] = None) -> Any:
         f"{API_V1_PREFIX}/lemma/{guid}/audio",
         {"language": language},
     )
+
+
+@mirrored_route("/api/v1/lemma/<guid>/wordfreq", "GET")
+def get_wordfreq(guid: str) -> WordfreqResponse:
+    """Wordfreq corpus rollups and best ranks for a lemma by language."""
+    return cast(WordfreqResponse, get_json(f"{API_V1_PREFIX}/lemma/{guid}/wordfreq"))
 
 
 @mirrored_route("/api/v1/lemma/<guid>/sentences", "GET")

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -19,6 +19,7 @@ from sqlalchemy import and_, case, func, or_
 
 from storage.crud.grammar_fact import get_grammar_facts
 from storage.crud.lemma import get_lemma_by_guid
+from storage.lexeme import get_lexeme
 from storage.models import (
     DerivativeForm,
     GrammarFact,
@@ -28,7 +29,11 @@ from storage.models import (
     SentenceTranslation,
     SentenceWord,
 )
-from storage.models.schema import AudioQualityReview, LemmaDifficultyOverride
+from storage.models.schema import (
+    AudioQualityReview,
+    ExternalLexemeAnnotation,
+    LemmaDifficultyOverride,
+)
 from storage.queries.lemma import build_lemma_search_query
 from storage.translation_helpers import (
     LANGUAGE_HIERARCHY,
@@ -345,6 +350,12 @@ def api_info() -> ResponseReturnValue:
                     "description": "Filter to specific language code (e.g., 'en', 'lt', 'fr')",
                 }
             ],
+        },
+        {
+            "path": "/api/v1/lemma/<guid>/wordfreq",
+            "method": "GET",
+            "description": "Get per-language wordfreq corpus rollups and best ranks for a lemma",
+            "parameters": [],
         },
         {
             "path": "/api/v1/lemma/<guid>/sentences",
@@ -1038,6 +1049,62 @@ def get_lemma_audio(guid: str) -> ResponseReturnValue:
         metadata["is_populated"] = language_filter in audio_data
 
     return _build_success_response(audio_data, metadata)
+
+
+@bp.route("/v1/lemma/<guid>/wordfreq")
+@mirrored_facade("/api/v1/lemma/<guid>/wordfreq", "GET")
+def get_lemma_wordfreq(guid: str) -> ResponseReturnValue:
+    """Get wordfreq rollups and best ranks across enabled corpora for lemma lexemes."""
+    lemma = get_lemma_by_guid(g.db, guid)
+    if not lemma:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+
+    from wordfreq.frequency.corpus import get_enabled_corpus_configs
+    from wordfreq.lexeme_frequency import get_lexeme_frequencies_all_corpora
+
+    enabled_corpora = {cfg.name for cfg in get_enabled_corpus_configs()}
+    language_wordfreq: Dict[str, Dict[str, Dict[str, Optional[Union[float, int]]]]] = {}
+
+    for translation in lemma.translations:
+        language_code = translation.language_code
+        lexeme = get_lexeme(g.db, lemma.id, language_code)
+        if not lexeme:
+            continue
+
+        all_rollups = get_lexeme_frequencies_all_corpora(g.db, lexeme)
+        form_token_ids = [
+            form.word_token_id for form in lexeme.forms if form.word_token_id is not None
+        ]
+        corpus_data: Dict[str, Dict[str, Optional[Union[float, int]]]] = {}
+        for corpus_name in sorted(enabled_corpora):
+            rollup = all_rollups.get(corpus_name)
+            total_frequency: Optional[float] = None
+            if rollup is not None:
+                total_frequency = float(rollup.total_frequency)
+
+            best_rank: Optional[int] = None
+            if form_token_ids:
+                source_name = f"wordfreq_{corpus_name}"
+                rank_row = (
+                    g.db.query(func.min(ExternalLexemeAnnotation.ordinal_rank))
+                    .filter(
+                        ExternalLexemeAnnotation.word_token_id.in_(form_token_ids),
+                        ExternalLexemeAnnotation.source == source_name,
+                        ExternalLexemeAnnotation.ordinal_rank.isnot(None),
+                    )
+                    .scalar()
+                )
+                best_rank = int(rank_row) if rank_row is not None else None
+
+            corpus_data[corpus_name] = {
+                "total_frequency": total_frequency,
+                "best_rank": best_rank,
+            }
+
+        language_wordfreq[language_code] = corpus_data
+
+    metadata = {"frequency_rank": lemma.frequency_rank}
+    return _build_success_response(language_wordfreq, metadata)
 
 
 @bp.route("/v1/lemma/<guid>/sentences")


### PR DESCRIPTION
### Motivation
- Provide a read-only API to expose per-language word frequency rollups and best per-corpus ranks for a lemma so clients can display wordfreq data alongside lemma details.
- Keep the `api/` facade mirrored and typed so external consumers can call the new endpoint without importing server internals.

### Description
- Added a new Barsukas route `GET /api/v1/lemma/<guid>/wordfreq` implemented in `src/barsukas/routes/api.py` that returns per-language, per-enabled-corpus `total_frequency` and `best_rank` and includes the lemma's combined `frequency_rank` in `metadata`.
- The route uses `get_lexeme`, `get_lexeme_frequencies_all_corpora`, and queries `ExternalLexemeAnnotation` to compute `best_rank`, and registers the route in the `/api/v1` `endpoints` listing.
- Added the mirrored client in `api/lemmas.py` with typed `TypedDict`s `WordfreqCorpusEntry`, `WordfreqLanguageEntry`, and `WordfreqResponse` and a `get_wordfreq(guid: str)` facade decorated with `@mirrored_route`.
- Updated imports and kept the mirroring decorator pair aligned so the route/facade checker continues to succeed.

### Testing
- Ran `black src/barsukas/routes/api.py api/lemmas.py` and formatting was successful.
- Ran `mypy src/barsukas/routes/api.py api/lemmas.py` and there were no type issues reported.
- Ran `python scripts/check_api_mirror_routes.py` and the mirrored route path/method pairs matched successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9728fcac8327b0f34b51ad9a7b9f)