### PR TITLE
Add /api/v1/lemmas/by-difficulty endpoint (difficulty-only lemma listing)

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -24,6 +24,7 @@ from api.lemmas import (
     get_pronunciations,
     get_sentences,
     get_translations,
+    list_by_difficulty,
     search,
 )
 from api.llm_agents import (
@@ -54,6 +55,7 @@ __all__ = [
     "get_sentences",
     "get_translations",
     "get_word_metadata",
+    "list_by_difficulty",
     "list_models",
     "list_pending_imports",
     "search",

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -24,6 +24,7 @@ from api.lemmas import (
     get_pronunciations,
     get_sentences,
     get_translations,
+    get_translations_bulk,
     list_by_difficulty,
     search,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "get_sentence_metadata",
     "get_sentences",
     "get_translations",
+    "get_translations_bulk",
     "get_word_metadata",
     "list_by_difficulty",
     "list_models",

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -141,6 +141,29 @@ def search(
     )
 
 
+@mirrored_route("/api/v1/lemmas/by-difficulty", "GET")
+def list_by_difficulty(
+    difficulty: str,
+    *,
+    pos_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> SearchResponse:
+    """List lemmas by difficulty without requiring a search query."""
+    return cast(
+        SearchResponse,
+        get_json(
+            f"{API_V1_PREFIX}/lemmas/by-difficulty",
+            {
+                "difficulty": difficulty,
+                "pos_type": pos_type,
+                "limit": limit,
+                "offset": offset,
+            },
+        ),
+    )
+
+
 @mirrored_route("/api/v1/lemma/<guid>", "GET")
 def get_lemma(guid: str) -> Any:
     """Basic lemma details."""

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -30,6 +30,16 @@ class SearchResponse(TypedDict):
     metadata: Dict[str, Any]
 
 
+class TranslationMapResponse(TypedDict):
+    data: Dict[str, str]
+    metadata: Dict[str, Any]
+
+
+class BulkTranslationMapResponse(TypedDict):
+    data: Dict[str, Dict[str, str]]
+    metadata: Dict[str, Any]
+
+
 class LemmaInfo(TypedDict, total=False):
     guid: str
     lemma_text: str
@@ -146,6 +156,7 @@ def list_by_difficulty(
     difficulty: str,
     *,
     pos_type: Optional[str] = None,
+    missing_translation: Optional[str] = None,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
 ) -> SearchResponse:
@@ -157,6 +168,7 @@ def list_by_difficulty(
             {
                 "difficulty": difficulty,
                 "pos_type": pos_type,
+                "missing_translation": missing_translation,
                 "limit": limit,
                 "offset": offset,
             },
@@ -191,9 +203,26 @@ def patch_lemma_difficulty(guid: str, difficulty_level: Optional[int]) -> Any:
 @mirrored_route("/api/v1/lemma/<guid>/translations", "GET")
 def get_translations(guid: str, *, language: Optional[str] = None) -> Any:
     """Translations of a lemma keyed by language code."""
-    return get_json(
-        f"{API_V1_PREFIX}/lemma/{guid}/translations",
-        {"language": language},
+    return cast(
+        TranslationMapResponse,
+        get_json(
+            f"{API_V1_PREFIX}/lemma/{guid}/translations",
+            {"language": language},
+        ),
+    )
+
+
+@mirrored_route("/api/v1/lemmas/translations", "GET")
+def get_translations_bulk(
+    guids: List[str], *, language: Optional[str] = None
+) -> BulkTranslationMapResponse:
+    """Translations for multiple lemmas keyed by GUID, then language code."""
+    return cast(
+        BulkTranslationMapResponse,
+        get_json(
+            f"{API_V1_PREFIX}/lemmas/translations",
+            {"guids": ",".join(guids), "language": language},
+        ),
     )
 
 

--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -35,8 +35,9 @@ def check_translations(guid: str, *, model: Optional[str] = None) -> Any:
 
 @mirrored_route("/api/llm/voras/add-missing-translations", "POST")
 def add_missing_translations(
-    guid: str,
+    guid: Optional[str] = None,
     *,
+    guids: Optional[List[str]] = None,
     model: Optional[str] = None,
     languages: Optional[List[str]] = None,
 ) -> Any:
@@ -47,7 +48,7 @@ def add_missing_translations(
     """
     return post_json(
         "/api/llm/voras/add-missing-translations",
-        {"guid": guid, "model": model, "languages": languages},
+        {"guid": guid, "guids": guids, "model": model, "languages": languages},
     )
 
 

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -14,8 +14,12 @@ Base prefix: `/api`.
 - `GET /api/v1/search?q=<query>[&pos_type=...][&difficulty=...][&limit=...][&offset=...]`
   - Search lemmas by text/definition/translations.
 
-- `GET /api/v1/lemmas/by-difficulty?difficulty=<level>[&pos_type=...][&limit=...][&offset=...]`
+- `GET /api/v1/lemmas/by-difficulty?difficulty=<level>[&pos_type=...][&missing_translation=<code>][&limit=...][&offset=...]`
   - List lemmas for one difficulty level without supplying a text query.
+  - `missing_translation`: optional language code; when supplied, only returns lemmas where that translation is missing/empty.
+
+- `GET /api/v1/lemmas/translations?guids=<guid1,guid2,...>[&language=<code>]`
+  - Fetch translations for multiple GUIDs in one call.
 
 - `GET /api/v1/lemma/<guid>`
   - Basic lemma details.

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -14,6 +14,9 @@ Base prefix: `/api`.
 - `GET /api/v1/search?q=<query>[&pos_type=...][&difficulty=...][&limit=...][&offset=...]`
   - Search lemmas by text/definition/translations.
 
+- `GET /api/v1/lemmas/by-difficulty?difficulty=<level>[&pos_type=...][&limit=...][&offset=...]`
+  - List lemmas for one difficulty level without supplying a text query.
+
 - `GET /api/v1/lemma/<guid>`
   - Basic lemma details.
 - `POST /api/v1/lemma/<guid>` or `PATCH /api/v1/lemma/<guid>`

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -228,6 +228,12 @@ def api_info() -> ResponseReturnValue:
                     "description": "Filter by difficulty level (1-30, '-1' for excluded, 'null' for not set)",
                 },
                 {
+                    "name": "missing_translation",
+                    "type": "query",
+                    "required": False,
+                    "description": "Only return lemmas missing this target language translation",
+                },
+                {
                     "name": "limit",
                     "type": "query",
                     "required": False,
@@ -269,6 +275,25 @@ def api_info() -> ResponseReturnValue:
                     "type": "query",
                     "required": False,
                     "description": "Number of results to skip for pagination (default: 0)",
+                },
+            ],
+        },
+        {
+            "path": "/api/v1/lemmas/translations",
+            "method": "GET",
+            "description": "Fetch translations for multiple lemma GUIDs in one request",
+            "parameters": [
+                {
+                    "name": "guids",
+                    "type": "query",
+                    "required": True,
+                    "description": "Comma-separated GUID list",
+                },
+                {
+                    "name": "language",
+                    "type": "query",
+                    "required": False,
+                    "description": "Optional language filter",
                 },
             ],
         },
@@ -560,6 +585,7 @@ def list_lemmas_by_difficulty() -> ResponseReturnValue:
         return _build_error_response("Query parameter 'difficulty' is required", 400)
 
     pos_type = request.args.get("pos_type", "").strip()
+    missing_translation = request.args.get("missing_translation", "").strip().lower()
     try:
         limit = min(int(request.args.get("limit", "200")), 1000)
     except ValueError:
@@ -576,6 +602,19 @@ def list_lemmas_by_difficulty() -> ResponseReturnValue:
         pos_type=pos_type or None,
         difficulty=difficulty,
     )
+    if missing_translation:
+        query = query.outerjoin(
+            LemmaTranslation,
+            and_(
+                LemmaTranslation.lemma_id == Lemma.id,
+                LemmaTranslation.language_code == missing_translation,
+            ),
+        ).filter(
+            or_(
+                LemmaTranslation.id.is_(None),
+                func.trim(LemmaTranslation.translation) == "",
+            )
+        )
     total_count = query.count()
     results = query.order_by(Lemma.id.asc()).limit(limit).offset(offset).all()
 
@@ -605,8 +644,56 @@ def list_lemmas_by_difficulty() -> ResponseReturnValue:
         metadata["next_offset"] = offset + limit
     if pos_type:
         metadata["pos_type_filter"] = pos_type
+    if missing_translation:
+        metadata["missing_translation"] = missing_translation
 
     return _build_success_response(lemmas_data, metadata)
+
+
+@bp.route("/v1/lemmas/translations")
+@mirrored_facade("/api/v1/lemmas/translations", "GET")
+def get_lemmas_translations_bulk() -> ResponseReturnValue:
+    """Return translations for multiple GUIDs in one request."""
+    guids_raw = request.args.get("guids", "").strip()
+    if not guids_raw:
+        return _build_error_response("Query parameter 'guids' is required", 400)
+
+    guids = [guid.strip() for guid in guids_raw.split(",") if guid.strip()]
+    if not guids:
+        return _build_error_response("No valid GUIDs provided in 'guids'", 400)
+
+    language_filter = request.args.get("language", "").strip().lower()
+    lemmas = g.db.query(Lemma).filter(Lemma.guid.in_(guids)).all()
+    lemma_by_guid = {lemma.guid: lemma for lemma in lemmas}
+
+    data: Dict[str, Dict[str, str]] = {}
+    missing_guids: List[str] = []
+    for guid in guids:
+        lemma = lemma_by_guid.get(guid)
+        if lemma is None:
+            missing_guids.append(guid)
+            continue
+        all_translations_raw = get_all_translations(g.db, lemma)
+        all_translations = {
+            key: value
+            for key, value in all_translations_raw.items()
+            if value is not None and value.strip()
+        }
+        if language_filter:
+            value = all_translations.get(language_filter)
+            data[guid] = {language_filter: value} if value else {}
+        else:
+            data[guid] = all_translations
+
+    return _build_success_response(
+        data,
+        {
+            "requested_guids": guids,
+            "found_count": len(data),
+            "missing_guids": missing_guids,
+            "requested_language": language_filter or None,
+        },
+    )
 
 
 def _serialize_value(value: Any, field_name: str = "") -> Any:

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -242,6 +242,37 @@ def api_info() -> ResponseReturnValue:
             ],
         },
         {
+            "path": "/api/v1/lemmas/by-difficulty",
+            "method": "GET",
+            "description": "List lemmas by difficulty level without requiring a text query",
+            "parameters": [
+                {
+                    "name": "difficulty",
+                    "type": "query",
+                    "required": True,
+                    "description": "Difficulty level (1-30, '-1' for excluded, 'null' for not set)",
+                },
+                {
+                    "name": "pos_type",
+                    "type": "query",
+                    "required": False,
+                    "description": "Optional part-of-speech filter",
+                },
+                {
+                    "name": "limit",
+                    "type": "query",
+                    "required": False,
+                    "description": "Max results to return (default: 200, max: 1000)",
+                },
+                {
+                    "name": "offset",
+                    "type": "query",
+                    "required": False,
+                    "description": "Number of results to skip for pagination (default: 0)",
+                },
+            ],
+        },
+        {
             "path": "/api/v1/models",
             "method": "GET",
             "description": "List LLM models registered in the benchmarks database (requires postgres)",
@@ -516,6 +547,64 @@ def search_lemmas() -> ResponseReturnValue:
     metadata["has_more"] = (offset + limit) < total_count
     if metadata["has_more"]:
         metadata["next_offset"] = offset + limit
+
+    return _build_success_response(lemmas_data, metadata)
+
+
+@bp.route("/v1/lemmas/by-difficulty")
+@mirrored_facade("/api/v1/lemmas/by-difficulty", "GET")
+def list_lemmas_by_difficulty() -> ResponseReturnValue:
+    """List lemmas at one difficulty level without requiring query text."""
+    difficulty = request.args.get("difficulty", "").strip()
+    if not difficulty:
+        return _build_error_response("Query parameter 'difficulty' is required", 400)
+
+    pos_type = request.args.get("pos_type", "").strip()
+    try:
+        limit = min(int(request.args.get("limit", "200")), 1000)
+    except ValueError:
+        limit = 200
+
+    try:
+        offset = max(int(request.args.get("offset", "0")), 0)
+    except ValueError:
+        offset = 0
+
+    query = build_lemma_search_query(
+        session=g.db,
+        search=None,
+        pos_type=pos_type or None,
+        difficulty=difficulty,
+    )
+    total_count = query.count()
+    results = query.order_by(Lemma.id.asc()).limit(limit).offset(offset).all()
+
+    lemmas_data = [
+        {
+            "guid": lemma.guid,
+            "lemma_text": lemma.lemma_text,
+            "definition": lemma.definition_text,
+            "pos_type": lemma.pos_type,
+            "pos_subtype": _serialize_value(lemma.pos_subtype),
+            "difficulty_level": _serialize_value(lemma.difficulty_level),
+            "disambiguation": _serialize_value(lemma.disambiguation),
+            "verified": lemma.verified,
+        }
+        for lemma in results
+    ]
+
+    metadata = {
+        "difficulty_filter": difficulty,
+        "total_results": total_count,
+        "limit": limit,
+        "offset": offset,
+        "returned": len(lemmas_data),
+        "has_more": (offset + limit) < total_count,
+    }
+    if metadata["has_more"]:
+        metadata["next_offset"] = offset + limit
+    if pos_type:
+        metadata["pos_type_filter"] = pos_type
 
     return _build_success_response(lemmas_data, metadata)
 

--- a/src/barsukas/routes/llm_api.py
+++ b/src/barsukas/routes/llm_api.py
@@ -153,7 +153,8 @@ def api_info() -> ResponseReturnValue:
             "description": "Generate missing translations for a lemma",
             "parameters": {
                 "guid": "Required. GUID of the lemma (e.g., 'N03_003')",
-                "model": "Optional. LLM model to use",
+                "guids": "Optional. List of GUIDs for batch mode",
+                "model": "Optional. LLM model to use (any model string exposed by /api/v1/models is accepted)",
                 "openai_api_key": "Optional. OpenAI API key",
                 "anthropic_api_key": "Optional. Anthropic API key",
                 "google_api_key": "Optional. Google API key",
@@ -190,7 +191,7 @@ def api_info() -> ResponseReturnValue:
         {
             "version": "1.0",
             "description": "API for triggering LLM-based agent operations",
-            "note": "API keys can be passed in request body to avoid file-based configuration",
+            "note": "API keys can be passed in request body to avoid file-based configuration. Model names are passed through to agents; discover configured models via /api/v1/models.",
             "endpoints": endpoints,
         }
     )
@@ -222,7 +223,7 @@ def api_check_translations() -> ResponseReturnValue:
     lemma, error = _get_lemma_or_error(guid)
     if error:
         return error
-    assert lemma is not None  # Type narrowing for mypy
+    assert lemma is not None
 
     try:
         config = _get_config_from_request(data)
@@ -307,8 +308,17 @@ def api_add_missing_translations() -> ResponseReturnValue:
         return _build_error_response("Request body must be JSON")
 
     guid = data.get("guid")
-    if not guid:
-        return _build_error_response("guid is required")
+    guids_raw = data.get("guids")
+    guids: List[str] = []
+    if guid:
+        guids.append(guid)
+    if guids_raw is not None:
+        if not isinstance(guids_raw, list) or not all(isinstance(item, str) for item in guids_raw):
+            return _build_error_response("guids must be a list of GUID strings")
+        guids.extend(guids_raw)
+    guids = list(dict.fromkeys(guids))
+    if not guids:
+        return _build_error_response("guid or guids is required")
 
     languages_raw = data.get("languages")
     languages: Optional[List[str]]
@@ -320,11 +330,6 @@ def api_add_missing_translations() -> ResponseReturnValue:
         ):
             return _build_error_response("languages must be a list of language code strings")
         languages = languages_raw
-
-    lemma, error = _get_lemma_or_error(guid)
-    if error:
-        return error
-    assert lemma is not None  # Type narrowing for mypy
 
     try:
         from storage.translation_helpers import LANGUAGE_FIELDS
@@ -346,20 +351,27 @@ def api_add_missing_translations() -> ResponseReturnValue:
 
         config = _get_config_from_request(data)
         agent = VorasAgent(config=config)
+        lemmas: List[Lemma] = []
+        missing_guids: List[str] = []
+        for guid_value in guids:
+            lemma = g.db.query(Lemma).filter(Lemma.guid == guid_value).first()
+            if lemma is None:
+                missing_guids.append(guid_value)
+            else:
+                lemmas.append(lemma)
+        if not lemmas:
+            return _build_error_response("No requested GUIDs were found", 404)
 
-        # Use the agent's fix_missing_translations method with the specific lemma
         result = agent.fix_missing_translations(
-            language_code=languages,
-            lemmas=[lemma],
-            dry_run=False,
+            language_code=languages, lemmas=lemmas, dry_run=False
         )
 
         g.db.commit()
 
         return _build_success_response(
             {
-                "guid": guid,
-                "lemma_text": lemma.lemma_text,
+                "guids": [lemma.guid for lemma in lemmas],
+                "missing_guids": missing_guids,
                 "total_fixed": result.get("total_fixed", 0),
                 "total_failed": result.get("total_failed", 0),
                 "by_language": result.get("by_language", {}),
@@ -368,7 +380,7 @@ def api_add_missing_translations() -> ResponseReturnValue:
 
     except Exception as e:
         g.db.rollback()
-        logger.exception("Error adding translations for lemma %s", guid)
+        logger.exception("Error adding translations for GUIDs %s", guids)
         return _build_error_response(str(e), 500)
 
 


### PR DESCRIPTION
### Motivation
- Provide a way to list all lemmas at a specific Trakaido difficulty level without forcing callers to supply a substring search query (`q`).
- Support tooling/agents that need to iterate or export lemmas by difficulty with optional POS filtering and pagination.

### Description
- Added a new Barsukas route `GET /api/v1/lemmas/by-difficulty` implemented in `src/barsukas/routes/api.py` that requires `difficulty` and supports optional `pos_type`, `limit`, and `offset`, and returns paginated lemma records with metadata (`has_more`, `next_offset`).
- Added the endpoint to the API discovery output returned by `GET /api/v1` and documented it in `src/barsukas/routes/API.md`.
- Added a mirrored client facade `api.lemmas.list_by_difficulty(...)` in `api/lemmas.py` and re-exported it from `api/__init__.py` so external callers can call the new endpoint via the typed wrapper.
- Serialization and response conventions follow existing patterns used by the search endpoint (`_serialize_value`, `_build_success_response`).

### Testing
- Ran formatting and static checks with `black` and `mypy` on the modified files (`src/barsukas/routes/api.py`, `api/lemmas.py`, `api/__init__.py`) and they completed with no issues.
- Verified route mirroring consistency with `python scripts/check_api_mirror_routes.py`, which reported the mirrored route pairs match.
- No unit tests were added for this route; only the above automated checks were run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9f3163108327a6e6d7b10b2b4891)