### PR TITLE
Track and expose LLM query cost for Voras translation flows

### DIFF
--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -12,10 +12,42 @@ genuinely requires a per-call key, do not add it here.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict, cast
 
 from api._http import get_json, post_json
 from api._mirror import mirrored_route
+
+
+class SuccessResponse(TypedDict):
+    """Standard success envelope returned by LLM API routes."""
+
+    success: bool
+
+
+class AddMissingTranslationsLanguageStats(TypedDict):
+    """Per-language statistics for generated translations."""
+
+    language_name: str
+    total_missing: int
+    fixed: int
+    failed: int
+
+
+class AddMissingTranslationsData(TypedDict):
+    """Payload returned by ``/api/llm/voras/add-missing-translations``."""
+
+    guids: List[str]
+    missing_guids: List[str]
+    total_fixed: int
+    total_failed: int
+    by_language: Dict[str, AddMissingTranslationsLanguageStats]
+    llm_cost_usd: float
+
+
+class AddMissingTranslationsResponse(SuccessResponse):
+    """Response envelope for add-missing-translations."""
+
+    data: AddMissingTranslationsData
 
 
 @mirrored_route("/api/llm/info", "GET")
@@ -40,15 +72,22 @@ def add_missing_translations(
     guids: Optional[List[str]] = None,
     model: Optional[str] = None,
     languages: Optional[List[str]] = None,
-) -> Any:
-    """Generate missing translations for a lemma.
+) -> AddMissingTranslationsResponse:
+    """Generate missing translations for one or more lemmas.
 
     When ``languages`` is omitted/None, Voras fills all configured generation
     languages. When provided, Voras fills only the requested language codes.
+
+    Returns:
+        A typed response envelope with aggregate counts, per-language stats,
+        and ``llm_cost_usd`` for the request.
     """
-    return post_json(
-        "/api/llm/voras/add-missing-translations",
-        {"guid": guid, "guids": guids, "model": model, "languages": languages},
+    return cast(
+        AddMissingTranslationsResponse,
+        post_json(
+            "/api/llm/voras/add-missing-translations",
+            {"guid": guid, "guids": guids, "model": model, "languages": languages},
+        ),
     )
 
 

--- a/src/agents/voras/agent.py
+++ b/src/agents/voras/agent.py
@@ -481,6 +481,7 @@ class VorasAgent:
             "total_translations_added": 0,
             "total_failed": 0,
             "batch_requests_queued": 0,
+            "llm_cost_usd": 0.0,
             "by_language": {
                 lang_code: {
                     "language_name": get_language_name(lang_code),
@@ -649,6 +650,7 @@ class VorasAgent:
         results: Dict[str, Any] = {
             "total_fixed": 0,
             "total_failed": 0,
+            "llm_cost_usd": 0.0,
             "by_language": {
                 lang_code: {
                     "language_name": get_language_name(lang_code),
@@ -783,6 +785,8 @@ class VorasAgent:
                             pos_subtype=lemma.pos_subtype,
                             languages=missing_lang_codes,
                         )
+                        query_cost_usd = float(getattr(client.client, "_last_query_cost_usd", 0.0))
+                        results["llm_cost_usd"] += query_cost_usd
 
                         if not success or not llm_translations:
                             logger.warning(f"Failed to get translations for '{lemma.lemma_text}'")

--- a/src/barsukas/routes/llm_api.py
+++ b/src/barsukas/routes/llm_api.py
@@ -375,6 +375,7 @@ def api_add_missing_translations() -> ResponseReturnValue:
                 "total_fixed": result.get("total_fixed", 0),
                 "total_failed": result.get("total_failed", 0),
                 "by_language": result.get("by_language", {}),
+                "llm_cost_usd": result.get("llm_cost_usd", 0.0),
             }
         )
 

--- a/src/wordfreq/translation/translations.py
+++ b/src/wordfreq/translation/translations.py
@@ -137,6 +137,9 @@ def query_translations(
         response = client.generate_chat(
             prompt=prompt, model=model, json_schema=schema, context=context
         )
+        setattr(
+            client, "_last_query_cost_usd", float(response.usage.cost) if response.usage else 0.0
+        )
 
         # Log successful query
         session = get_session_func()
@@ -160,5 +163,6 @@ def query_translations(
             return {}, False
 
     except Exception as e:
+        setattr(client, "_last_query_cost_usd", 0.0)
         logger.error(f"Error generating translations for '{english_word}': {type(e).__name__}: {e}")
         return {}, False


### PR DESCRIPTION
### Motivation
- Surface LLM usage cost for translation-generation flows so callers can see per-request billing impact.
- Propagate the cost from the low-level LLM client through the translation generation logic to API responses.
- Add type information for the `/api/llm/voras/add-missing-translations` response to improve correctness and IDE support.

### Description
- Added `SuccessResponse`, `AddMissingTranslationsLanguageStats`, `AddMissingTranslationsData`, and `AddMissingTranslationsResponse` `TypedDict`s and updated `add_missing_translations` to return a typed envelope in `api/llm_agents.py` and cast the `post_json` result to that type.
- Plumbed `llm_cost_usd` into Voras agent result structures in `src/agents/voras/agent.py` and accumulate per-query cost by reading `client.client._last_query_cost_usd` after LLM calls.
- Recorded `llm_cost_usd` into the Barsukas HTTP API response in `src/barsukas/routes/llm_api.py` so the endpoint includes the aggregated cost.
- Updated `src/wordfreq/translation/translations.py` to set `client._last_query_cost_usd` from the LLM `response.usage.cost` on success and to set it to `0.0` on exceptions.

### Testing
- Ran the test suite with `pytest -q` and the tests completed successfully.
- Ran static typing checks with `mypy` and no new type errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba324e148832788ec6a5ed418a25b)