### PR TITLE
docs(api): document lemma wordfreq endpoint response shape

### DIFF
--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -30,6 +30,10 @@ Base prefix: `/api`.
 - `GET /api/v1/lemma/<guid>/translations[?language=<code>]`
   - Translations keyed by language code.
 
+- `GET /api/v1/lemma/<guid>/wordfreq`
+  - Word frequency rollups nested by `language_code -> corpus_name -> {total_frequency, best_rank}`.
+  - `total_frequency` is the corpus rollup value for the lemma lexeme; `best_rank` is the best (lowest) available form rank in that corpus.
+
 - `GET /api/v1/lemma/<guid>/forms[?language=<code>]`
   - Derivative forms for a lemma.
 


### PR DESCRIPTION
### Motivation
- Ensure the API reference documents the existing `GET /api/v1/lemma/<guid>/wordfreq` endpoint so callers know the exact response shape and field names used by the implementation.

### Description
- Added a brief entry to `src/barsukas/routes/API.md` describing the response nesting as `language_code -> corpus_name -> {total_frequency, best_rank}` and clarifying the semantics of `total_frequency` and `best_rank`.

### Testing
- Documentation-only change; no automated tests were modified or required and no test suite was run, and a local commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc93a425948327b2a183f89c028a9c)