### PR TITLE
Add agent task endpoints and batch-capable workqueue handlers for lemma tasks

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -11,6 +11,16 @@ from __future__ import annotations
 
 from api._http import BarsukasAPIError
 from api.audio import get_audio
+from api.agent_tasks import (
+    check_definition,
+    check_disambiguation,
+    check_pronunciations,
+    check_translations,
+    queue_add_missing_translations,
+    queue_generate_forms,
+    queue_generate_pronunciations,
+    queue_generate_synonyms,
+)
 from api.batch_operations import (
     find_pending_import_duplicates,
     get_word_metadata,
@@ -30,9 +40,6 @@ from api.lemmas import (
 )
 from api.llm_agents import (
     add_missing_translations,
-    check_definition,
-    check_disambiguation,
-    check_translations,
     generate_pronunciations,
     get_llm_info,
 )
@@ -43,6 +50,7 @@ __all__ = [
     "add_missing_translations",
     "check_definition",
     "check_disambiguation",
+    "check_pronunciations",
     "check_translations",
     "find_pending_import_duplicates",
     "generate_pronunciations",
@@ -60,5 +68,9 @@ __all__ = [
     "list_by_difficulty",
     "list_models",
     "list_pending_imports",
+    "queue_add_missing_translations",
+    "queue_generate_forms",
+    "queue_generate_pronunciations",
+    "queue_generate_synonyms",
     "search",
 ]

--- a/api/agent_tasks.py
+++ b/api/agent_tasks.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict, cast
+
+from api._http import post_json
+from api._mirror import mirrored_route
+
+
+class CheckData(TypedDict):
+    status: str
+    issues: List[Any]
+    confidence_summary: Dict[str, Any]
+
+
+class CheckResponse(TypedDict):
+    data: CheckData
+    metadata: Dict[str, Any]
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/add-missing-translations", "POST")
+def queue_add_missing_translations(
+    guid: str,
+    *,
+    model: str,
+    batch: bool = False,
+    batch_window_minutes: int = 10,
+) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(
+            f"/api/v1/agents/lemma/{guid}/add-missing-translations",
+            {
+                "model": model,
+                "batch": batch,
+                "batch_window_minutes": batch_window_minutes,
+            },
+        ),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/generate-pronunciations", "POST")
+def queue_generate_pronunciations(
+    guid: str,
+    *,
+    model: str,
+    lang_code: str = "en",
+    batch: bool = False,
+    batch_window_minutes: int = 10,
+) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(
+            f"/api/v1/agents/lemma/{guid}/generate-pronunciations",
+            {
+                "model": model,
+                "lang_code": lang_code,
+                "batch": batch,
+                "batch_window_minutes": batch_window_minutes,
+            },
+        ),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/generate-forms", "POST")
+def queue_generate_forms(
+    guid: str,
+    *,
+    model: str,
+    lang_code: str = "lt",
+    batch: bool = False,
+    batch_window_minutes: int = 10,
+) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(
+            f"/api/v1/agents/lemma/{guid}/generate-forms",
+            {
+                "model": model,
+                "lang_code": lang_code,
+                "batch": batch,
+                "batch_window_minutes": batch_window_minutes,
+            },
+        ),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/generate-synonyms", "POST")
+def queue_generate_synonyms(
+    guid: str,
+    *,
+    model: str,
+    lang_code: str = "en",
+    batch: bool = False,
+    batch_window_minutes: int = 10,
+) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(
+            f"/api/v1/agents/lemma/{guid}/generate-synonyms",
+            {
+                "model": model,
+                "lang_code": lang_code,
+                "batch": batch,
+                "batch_window_minutes": batch_window_minutes,
+            },
+        ),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/check-definition", "POST")
+def check_definition(guid: str, *, model: str) -> CheckResponse:
+    return cast(
+        CheckResponse, post_json(f"/api/v1/agents/lemma/{guid}/check-definition", {"model": model})
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/check-disambiguation", "POST")
+def check_disambiguation(guid: str, *, model: str) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(f"/api/v1/agents/lemma/{guid}/check-disambiguation", {"model": model}),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/check-translations", "POST")
+def check_translations(guid: str, *, model: str) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(f"/api/v1/agents/lemma/{guid}/check-translations", {"model": model}),
+    )
+
+
+@mirrored_route("/api/v1/agents/lemma/<guid>/check-pronunciations", "POST")
+def check_pronunciations(guid: str, *, model: str) -> CheckResponse:
+    return cast(
+        CheckResponse,
+        post_json(f"/api/v1/agents/lemma/{guid}/check-pronunciations", {"model": model}),
+    )

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -57,6 +57,27 @@ Base prefix: `/api`.
   - Returns array of `{codename, displayname, model_path, model_type, lmstudio_model_name, launch_date, license_name}`.
   - Returns HTTP 503 if benchmarks database is not configured.
 
+## Agent task + LLM check endpoints (GUID-based)
+
+All LLM-invoking endpoints below require JSON body with `"model": "<model-name>"`.
+
+- `POST /api/v1/agents/lemma/<guid>/add-missing-translations`
+- `POST /api/v1/agents/lemma/<guid>/generate-pronunciations` (optional `lang_code`)
+- `POST /api/v1/agents/lemma/<guid>/generate-forms` (optional `lang_code`)
+- `POST /api/v1/agents/lemma/<guid>/generate-synonyms` (optional `lang_code`)
+
+- `POST /api/v1/agents/lemma/<guid>/check-definition`
+- `POST /api/v1/agents/lemma/<guid>/check-disambiguation`
+- `POST /api/v1/agents/lemma/<guid>/check-translations`
+- `POST /api/v1/agents/lemma/<guid>/check-pronunciations`
+
+Check endpoints return:
+
+- `data.status`: `"ok"` or `"issues_found"`
+- `data.issues`: list of issues/suggestions
+- `data.confidence_summary`: aggregate confidence/check metadata
+- `metadata.guid`, `metadata.model`
+
 ## Metadata endpoints (for aggregate counting)
 
 - `GET /api/v1/metadata/words[?language=<code>][&max_difficulty=<int>][&difficulty=<int>]`

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -9,6 +9,8 @@ route's path, query params, or response shape MUST be made in the matching
 facade in the same commit. See ``api/AGENTS.md`` for the mirroring contract.
 """
 
+from datetime import datetime, timedelta
+import json
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from barsukas.config import Config
@@ -33,6 +35,7 @@ from storage.models.schema import (
     AudioQualityReview,
     ExternalLexemeAnnotation,
     LemmaDifficultyOverride,
+    BarsukasTask,
 )
 from storage.queries.lemma import build_lemma_search_query
 from storage.translation_helpers import (
@@ -40,6 +43,7 @@ from storage.translation_helpers import (
     get_all_translations,
     get_translation_pronunciations,
 )
+from workqueue.task_queue import TaskStatus, TaskType, enqueue_task
 
 bp = Blueprint("api", __name__, url_prefix="/api")
 
@@ -729,6 +733,323 @@ def _build_success_response(
     if metadata:
         response["metadata"] = metadata
     return jsonify(response)
+
+
+def _require_model() -> Tuple[Optional[str], Optional[ResponseReturnValue]]:
+    payload = request.get_json(silent=True) or {}
+    model = payload.get("model")
+    if not isinstance(model, str) or not model.strip():
+        return None, _build_error_response("model is required and must be a non-empty string")
+    return model.strip(), None
+
+
+@bp.route("/v1/agents/lemma/<guid>/add-missing-translations", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/add-missing-translations", "POST")
+def queue_add_missing_translations(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    return _queue_task_for_guid_with_optional_batch(
+        guid,
+        TaskType.ADD_MISSING_TRANSLATIONS,
+        {"model": model},
+        dedup_key=f"{TaskType.ADD_MISSING_TRANSLATIONS}:{{lemma_id}}",
+        batch_dedup_prefix=str(TaskType.ADD_MISSING_TRANSLATIONS),
+    )
+
+
+def _queue_task_for_guid(
+    guid: str, task_type: str, payload: Dict[str, Any], dedup_key: str
+) -> ResponseReturnValue:
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+    result = enqueue_task(
+        g.db,
+        task_type=task_type,
+        target_type="lemma",
+        target_id=lemma.id,
+        payload={"lemma_id": lemma.id, **payload},
+        dedup_key=dedup_key.format(lemma_id=lemma.id),
+    )
+    return _build_success_response({"queued": result.created}, {"guid": guid, **payload})
+
+
+def _queue_task_for_guid_with_optional_batch(
+    guid: str,
+    task_type: str,
+    payload: Dict[str, Any],
+    *,
+    dedup_key: str,
+    batch_dedup_prefix: str,
+) -> ResponseReturnValue:
+    request_payload = request.get_json(silent=True) or {}
+    use_batch = bool(request_payload.get("batch", False))
+    batch_window_minutes = int(request_payload.get("batch_window_minutes", 10))
+    if batch_window_minutes < 1 or batch_window_minutes > 10:
+        return _build_error_response("batch_window_minutes must be between 1 and 10")
+    if not use_batch:
+        return _queue_task_for_guid(guid, task_type, payload, dedup_key)
+
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+
+    window_index = int(datetime.utcnow().timestamp() // (batch_window_minutes * 60))
+    model_name = str(payload.get("model", ""))
+    lang_code = str(payload.get("lang_code", ""))
+    batch_dedup_key = (
+        f"{batch_dedup_prefix}:{window_index}:{batch_window_minutes}:{model_name}:{lang_code}"
+    )
+    existing = (
+        g.db.query(BarsukasTask)
+        .filter(
+            BarsukasTask.dedup_key == batch_dedup_key,
+            BarsukasTask.status.in_(TaskStatus.ACTIVE),
+            BarsukasTask.created_at >= datetime.utcnow() - timedelta(minutes=batch_window_minutes),
+        )
+        .order_by(BarsukasTask.created_at.desc())
+        .first()
+    )
+    if existing:
+        existing_payload = json.loads(existing.payload or "{}")
+        lemma_ids = set(existing_payload.get("lemma_ids", []))
+        lemma_ids.add(lemma.id)
+        existing_payload["lemma_ids"] = sorted(lemma_ids)
+        existing.payload = json.dumps(existing_payload)
+        g.db.flush()
+        return _build_success_response(
+            {"queued": False, "batched": True},
+            {
+                "guid": guid,
+                **payload,
+                "batch": True,
+                "batch_window_minutes": batch_window_minutes,
+                "batch_task_id": existing.id,
+            },
+        )
+
+    result = enqueue_task(
+        g.db,
+        task_type=task_type,
+        target_type="batch",
+        target_id=None,
+        payload={**payload, "lemma_ids": [lemma.id], "batch": True},
+        dedup_key=batch_dedup_key,
+    )
+    return _build_success_response(
+        {"queued": result.created, "batched": True},
+        {
+            "guid": guid,
+            **payload,
+            "batch": True,
+            "batch_window_minutes": batch_window_minutes,
+            "batch_task_id": result.task.id,
+        },
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/generate-pronunciations", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/generate-pronunciations", "POST")
+def queue_generate_pronunciations(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    payload = request.get_json(silent=True) or {}
+    lang_code = payload.get("lang_code", "en")
+    assert model is not None
+    return _queue_task_for_guid_with_optional_batch(
+        guid,
+        TaskType.GENERATE_PRONUNCIATIONS,
+        {"lang_code": lang_code, "model": model},
+        dedup_key=f"{TaskType.GENERATE_PRONUNCIATIONS}:{{lemma_id}}:{lang_code}",
+        batch_dedup_prefix=str(TaskType.GENERATE_PRONUNCIATIONS),
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/generate-forms", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/generate-forms", "POST")
+def queue_generate_forms(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    payload = request.get_json(silent=True) or {}
+    lang_code = payload.get("lang_code", "lt")
+    assert model is not None
+    return _queue_task_for_guid_with_optional_batch(
+        guid,
+        TaskType.GENERATE_FORMS,
+        {"lang_code": lang_code, "model": model},
+        dedup_key=f"{TaskType.GENERATE_FORMS}:{{lemma_id}}:{lang_code}",
+        batch_dedup_prefix=str(TaskType.GENERATE_FORMS),
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/generate-synonyms", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/generate-synonyms", "POST")
+def queue_generate_synonyms(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    payload = request.get_json(silent=True) or {}
+    lang_code = payload.get("lang_code", "en")
+    assert model is not None
+    return _queue_task_for_guid_with_optional_batch(
+        guid,
+        TaskType.GENERATE_SYNONYMS,
+        {"lang_code": lang_code, "model": model},
+        dedup_key=f"{TaskType.GENERATE_SYNONYMS}:{{lemma_id}}:{lang_code}",
+        batch_dedup_prefix=str(TaskType.GENERATE_SYNONYMS),
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/check-definition", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/check-definition", "POST")
+def check_definition_by_guid(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    from agents.lokys import LokysAgent
+    from storage.backend.config import BackendType, DataSourceConfig
+
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+    agent = LokysAgent(
+        config=DataSourceConfig(
+            backend_type=BackendType.SQLITE,
+            sqlite_path=Config.DB_PATH,
+            model=model,
+            debug=Config.DEBUG,
+        )
+    )
+    result = agent.check_single_definition(lemma, session=g.db)
+    status = (
+        "ok"
+        if bool(result.get("is_valid")) and float(result.get("confidence", 0)) >= 0.7
+        else "issues_found"
+    )
+    return _build_success_response(
+        {
+            "status": status,
+            "issues": result.get("issues", []),
+            "confidence_summary": {"confidence": result.get("confidence", 0)},
+        },
+        {"guid": guid, "model": model},
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/check-disambiguation", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/check-disambiguation", "POST")
+def check_disambiguation_by_guid(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    from agents.lokys import LokysAgent
+    from storage.backend.config import BackendType, DataSourceConfig
+
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+    agent = LokysAgent(
+        config=DataSourceConfig(
+            backend_type=BackendType.SQLITE,
+            sqlite_path=Config.DB_PATH,
+            model=model,
+            debug=Config.DEBUG,
+        )
+    )
+    result = agent.check_single_disambiguation(lemma, session=g.db)
+    issues = [] if not result.get("needs_disambiguation") else [result]
+    return _build_success_response(
+        {
+            "status": "ok" if not issues else "issues_found",
+            "issues": issues,
+            "confidence_summary": {"duplicate_count": result.get("duplicate_count", 0)},
+        },
+        {"guid": guid, "model": model},
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/check-translations", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/check-translations", "POST")
+def check_translations_by_guid(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    from agents.voras.agent import VorasAgent
+    from storage.backend.config import BackendType, DataSourceConfig
+    from storage.translation_helpers import LANGUAGE_FIELDS
+    from wordfreq.tools.llm_validators import validate_all_translations_for_word
+
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+    agent = VorasAgent(
+        config=DataSourceConfig(
+            backend_type=BackendType.SQLITE,
+            sqlite_path=Config.DB_PATH,
+            model=model,
+            debug=Config.DEBUG,
+        )
+    )
+    translations = {
+        lc: t for lc in LANGUAGE_FIELDS.keys() if (t := agent.get_translation(g.db, lemma, lc))
+    }
+    validation_results = validate_all_translations_for_word(
+        lemma.lemma_text, translations, lemma.pos_type, model
+    )
+    issues = [
+        value
+        for value in validation_results.values()
+        if (not value["is_correct"] or not value["is_lemma_form"]) and value["confidence"] >= 0.7
+    ]
+    return _build_success_response(
+        {
+            "status": "ok" if not issues else "issues_found",
+            "issues": issues,
+            "confidence_summary": {"translations_checked": len(translations)},
+        },
+        {"guid": guid, "model": model},
+    )
+
+
+@bp.route("/v1/agents/lemma/<guid>/check-pronunciations", methods=["POST"])
+@mirrored_facade("/api/v1/agents/lemma/<guid>/check-pronunciations", "POST")
+def check_pronunciations_by_guid(guid: str) -> ResponseReturnValue:
+    model, error = _require_model()
+    if error is not None:
+        return error
+    from wordfreq.tools.llm_validators import validate_pronunciation
+
+    lemma = get_lemma_by_guid(g.db, guid)
+    if lemma is None:
+        return _build_error_response(f"Lemma with GUID '{guid}' not found", 404)
+    forms = g.db.query(DerivativeForm).filter(DerivativeForm.lemma_id == lemma.id).all()
+    issues: List[Dict[str, Any]] = []
+    confidences: List[float] = []
+    assert model is not None
+    for form in forms:
+        result = validate_pronunciation(
+            form.derivative_form_text,
+            form.ipa_pronunciation,
+            form.phonetic_pronunciation,
+            lemma.pos_type,
+            definition=lemma.definition_text,
+            model=model,
+        )
+        confidences.append(float(result.get("confidence", 0)))
+        if result.get("needs_update") and float(result.get("confidence", 0)) >= 0.7:
+            issues.append(result)
+    avg_conf = sum(confidences) / len(confidences) if confidences else 0.0
+    return _build_success_response(
+        {
+            "status": "ok" if not issues else "issues_found",
+            "issues": issues,
+            "confidence_summary": {"forms_checked": len(forms), "average_confidence": avg_conf},
+        },
+        {"guid": guid, "model": model},
+    )
 
 
 @bp.route("/v1/lemma/<guid>")
@@ -1495,6 +1816,7 @@ def get_word_metadata() -> ResponseReturnValue:
             )
             base_query = base_query.outerjoin(
                 LemmaDifficultyOverride,
+                BarsukasTask,
                 (LemmaDifficultyOverride.lemma_id == Lemma.id)
                 & (LemmaDifficultyOverride.language_code == current_language),
             ).filter(
@@ -1511,6 +1833,7 @@ def get_word_metadata() -> ResponseReturnValue:
             )
             base_query = base_query.outerjoin(
                 LemmaDifficultyOverride,
+                BarsukasTask,
                 (LemmaDifficultyOverride.lemma_id == Lemma.id)
                 & (LemmaDifficultyOverride.language_code == current_language),
             ).filter(effective_difficulty == exact_difficulty)

--- a/src/tests/barsukas/test_api_agents_batch.py
+++ b/src/tests/barsukas/test_api_agents_batch.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from storage.models.schema import BarsukasTask, Lemma
+
+
+def test_add_missing_translations_batch_aggregates_three_requests(client, app) -> None:
+    engine = create_engine(f"sqlite:///{app.config['DB_PATH']}")
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        lemma3 = Lemma(
+            lemma_text="run",
+            definition_text="to move quickly",
+            pos_type="verb",
+            guid="V01_003",
+            verified=True,
+        )
+        session.add(lemma3)
+        session.commit()
+
+    payload = {"model": "gpt-5.4-mini", "batch": True, "batch_window_minutes": 10}
+    response1 = client.post("/api/v1/agents/lemma/V01_001/add-missing-translations", json=payload)
+    response2 = client.post("/api/v1/agents/lemma/N01_001/add-missing-translations", json=payload)
+    response3 = client.post("/api/v1/agents/lemma/V01_003/add-missing-translations", json=payload)
+
+    assert response1.status_code == 200
+    assert response2.status_code == 200
+    assert response3.status_code == 200
+
+    with session_factory() as session:
+        tasks = (
+            session.query(BarsukasTask)
+            .filter(
+                BarsukasTask.target_type == "batch", BarsukasTask.task_type == "words.translations"
+            )
+            .all()
+        )
+        assert len(tasks) == 1
+        batch_payload = json.loads(tasks[0].payload or "{}")
+        lemma_ids = sorted(batch_payload.get("lemma_ids", []))
+        assert len(lemma_ids) == 3

--- a/src/workqueue/handlers/words/forms.py
+++ b/src/workqueue/handlers/words/forms.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from workqueue.handlers.vilkas import generate_forms_for_lemma
 from workqueue.tools import get_lemma_or_raise, workqueue_payload_handler
@@ -28,11 +28,25 @@ def do_generate_forms(
 @workqueue_payload_handler()
 def handle_words_forms(
     session: Any,
-    lemma_id: int,
+    lemma_id: Optional[int] = None,
+    lemma_ids: Optional[list[int]] = None,
     lang_code: str = "lt",
     language_code: str | None = None,
 ) -> str:
     """Workqueue wrapper for form generation."""
+    if lemma_ids:
+        results = [
+            do_generate_forms(
+                session=session,
+                lemma_id=queued_lemma_id,
+                lang_code=lang_code,
+                language_code=language_code,
+            )
+            for queued_lemma_id in lemma_ids
+        ]
+        return f"Batch completed for {len(lemma_ids)} lemmas: " + "; ".join(results)
+    if lemma_id is None:
+        raise ValueError("lemma_id or lemma_ids is required")
     return do_generate_forms(
         session=session,
         lemma_id=lemma_id,

--- a/src/workqueue/handlers/words/pronunciations.py
+++ b/src/workqueue/handlers/words/pronunciations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from workqueue.handlers.papuga import generate_pronunciations_for_lemma
 from workqueue.tools import get_lemma_or_raise, workqueue_payload_handler
@@ -35,11 +35,25 @@ def do_generate_pronunciations(
 @workqueue_payload_handler()
 def handle_words_pronunciations(
     session: Any,
-    lemma_id: int,
+    lemma_id: Optional[int] = None,
+    lemma_ids: Optional[list[int]] = None,
     lang_code: str = "en",
     all_forms_pronunciation: bool = False,
 ) -> str:
     """Workqueue wrapper for pronunciation generation."""
+    if lemma_ids:
+        results = [
+            do_generate_pronunciations(
+                session=session,
+                lemma_id=queued_lemma_id,
+                lang_code=lang_code,
+                all_forms_pronunciation=all_forms_pronunciation,
+            )
+            for queued_lemma_id in lemma_ids
+        ]
+        return f"Batch completed for {len(lemma_ids)} lemmas: " + "; ".join(results)
+    if lemma_id is None:
+        raise ValueError("lemma_id or lemma_ids is required")
     return do_generate_pronunciations(
         session=session,
         lemma_id=lemma_id,

--- a/src/workqueue/handlers/words/synonyms.py
+++ b/src/workqueue/handlers/words/synonyms.py
@@ -37,11 +37,25 @@ def do_generate_synonyms(
 @workqueue_payload_handler()
 def handle_words_synonyms(
     session: Any,
-    lemma_id: int,
-    lang_code: str,
+    lemma_id: Optional[int] = None,
+    lemma_ids: Optional[list[int]] = None,
+    lang_code: str = "en",
     form_type: Optional[str] = None,
 ) -> str:
     """Workqueue wrapper for synonym generation."""
+    if lemma_ids:
+        results = [
+            do_generate_synonyms(
+                session=session,
+                lemma_id=queued_lemma_id,
+                lang_code=lang_code,
+                form_type=form_type,
+            )
+            for queued_lemma_id in lemma_ids
+        ]
+        return f"Batch completed for {len(lemma_ids)} lemmas: " + "; ".join(results)
+    if lemma_id is None:
+        raise ValueError("lemma_id or lemma_ids is required")
     return do_generate_synonyms(
         session=session,
         lemma_id=lemma_id,

--- a/src/workqueue/handlers/words/translations.py
+++ b/src/workqueue/handlers/words/translations.py
@@ -179,9 +179,24 @@ def do_regenerate_translations(session: Any, lemma_id: int, **_: Any) -> str:
 
 @workqueue_payload_handler()
 def handle_words_translations(
-    session: Any, lemma_id: int, languages: Optional[List[str]] = None
+    session: Any,
+    lemma_id: Optional[int] = None,
+    lemma_ids: Optional[List[int]] = None,
+    languages: Optional[List[str]] = None,
 ) -> str:
     """Workqueue wrapper for missing translation generation."""
+    if lemma_ids:
+        results = [
+            do_generate_missing_translations(
+                session=session,
+                lemma_id=queued_lemma_id,
+                languages=languages,
+            )
+            for queued_lemma_id in lemma_ids
+        ]
+        return f"Batch completed for {len(lemma_ids)} lemmas: " + "; ".join(results)
+    if lemma_id is None:
+        raise ValueError("lemma_id or lemma_ids is required")
     return do_generate_missing_translations(session=session, lemma_id=lemma_id, languages=languages)
 
 


### PR DESCRIPTION
### Motivation

- Expose LLM-driven agent operations (checks and generation tasks) over the HTTP API so remote clients can invoke them with a typed client wrapper.
- Support batching/deduplication for high-volume agent tasks so multiple requests within a window aggregate into a single workqueue batch job.

### Description

- Added a typed client facade `api/agent_tasks.py` and exported the new functions from `api/__init__.py` to provide programmatic wrappers for agent endpoints such as `queue_add_missing_translations`, `queue_generate_pronunciations`, `queue_generate_forms`, `queue_generate_synonyms`, `check_definition`, `check_disambiguation`, `check_translations`, and `check_pronunciations`.
- Implemented new API routes in `src/barsukas/routes/api.py` including `_require_model`, queue endpoints for each agent task, check endpoints that call local agents, and batching/dedup logic using `BarsukasTask`, `enqueue_task`, and a time-windowed dedup key implemented in `_queue_task_for_guid_with_optional_batch`.
- Updated the public API docs `src/barsukas/routes/API.md` to document the new agent task and LLM check endpoints and their response shapes.
- Extended workqueue handlers to accept batch payloads by adding `lemma_ids` to `src/workqueue/handlers/words/{forms,pronunciations,synonyms,translations}.py` and implemented batch processing paths that iterate the per-lemma handlers when `lemma_ids` is present.
- Added an integration-style test `src/tests/barsukas/test_api_agents_batch.py` that posts three `add-missing-translations` batched requests and asserts they aggregate into a single batch `BarsukasTask` containing three lemma ids.

### Testing

- Ran the new test `pytest src/tests/barsukas/test_api_agents_batch.py`, which passed and verified that three batched API calls are aggregated into one batch task with three lemma ids.
- Existing unit tests related to the changed handlers were exercised as part of local test runs and did not reveal regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc981d9a288327a3c41e1280959c82)