### PR TITLE
Add mirrored voice-discovery and bulk audio-generation APIs

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,7 +10,7 @@ the ``BARSUKAS_API_URL`` environment variable; see :mod:`api.constants`.
 from __future__ import annotations
 
 from api._http import BarsukasAPIError
-from api.audio import get_audio
+from api.audio import get_audio, list_voices
 from api.agent_tasks import (
     check_definition,
     check_disambiguation,
@@ -40,6 +40,7 @@ from api.lemmas import (
 )
 from api.llm_agents import (
     add_missing_translations,
+    generate_audio,
     generate_pronunciations,
     get_llm_info,
 )
@@ -54,7 +55,9 @@ __all__ = [
     "check_translations",
     "find_pending_import_duplicates",
     "generate_pronunciations",
+    "generate_audio",
     "get_audio",
+    "list_voices",
     "get_forms",
     "get_grammar",
     "get_lemma",

--- a/api/audio.py
+++ b/api/audio.py
@@ -10,6 +10,32 @@ response shape there must be reflected here in the same commit.
 
 from __future__ import annotations
 
+from typing import Any, Dict, List, Optional, TypedDict, cast
+
+from api._http import get_json
+from api._mirror import mirrored_route
+from api.constants import API_V1_PREFIX
 from api.lemmas import get_audio
 
-__all__ = ["get_audio"]
+
+class VoiceEntry(TypedDict):
+    voice_name: str
+    display_voice: str
+    backend: str
+    language_code: str
+    gender: Optional[str]
+    sample_url: Optional[str]
+
+
+class VoicesResponse(TypedDict):
+    data: List[VoiceEntry]
+    metadata: Dict[str, Any]
+
+
+@mirrored_route("/api/v1/audio/voices", "GET")
+def list_voices(*, language: Optional[str] = None) -> VoicesResponse:
+    """List available voices for one language or all languages."""
+    return cast(VoicesResponse, get_json(f"{API_V1_PREFIX}/audio/voices", {"language": language}))
+
+
+__all__ = ["get_audio", "list_voices"]

--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -50,6 +50,33 @@ class AddMissingTranslationsResponse(SuccessResponse):
     data: AddMissingTranslationsData
 
 
+class GenerateAudioResult(TypedDict, total=False):
+    status: str
+    audio_url: str
+    manifest_md5: str
+    error: str
+
+
+class GenerateAudioData(TypedDict):
+    guids: List[str]
+    missing_guids: List[str]
+    language: str
+    voice: Optional[str]
+    agent: str
+    include_forms: bool
+    force: bool
+    total: int
+    generated: int
+    skipped_existing: int
+    failed: int
+    by_guid: Dict[str, GenerateAudioResult]
+    tts_cost_usd: float
+
+
+class GenerateAudioResponse(SuccessResponse):
+    data: GenerateAudioData
+
+
 @mirrored_route("/api/llm/info", "GET")
 def get_llm_info() -> Any:
     """List the LLM agent endpoints exposed by Barsukas."""
@@ -120,4 +147,30 @@ def check_disambiguation(guid: str, *, model: Optional[str] = None) -> Any:
     return post_json(
         "/api/llm/lokys/check-disambiguation",
         {"guid": guid, "model": model},
+    )
+
+
+@mirrored_route("/api/llm/<agent>/generate-audio", "POST")
+def generate_audio(
+    agent: str,
+    *,
+    guids: List[str],
+    language: str,
+    voice: Optional[str] = None,
+    include_forms: bool = False,
+    force: bool = False,
+) -> GenerateAudioResponse:
+    """Generate audio for a list of GUIDs with a selected audio agent."""
+    return cast(
+        GenerateAudioResponse,
+        post_json(
+            f"/api/llm/{agent}/generate-audio",
+            {
+                "guids": guids,
+                "language": language,
+                "voice": voice,
+                "include_forms": include_forms,
+                "force": force,
+            },
+        ),
     )

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -45,6 +45,9 @@ Base prefix: `/api`.
 
 - `GET /api/v1/lemma/<guid>/audio[?language=<code>]`
   - Audio availability by language with `has_lemma_audio`, `form_audio_count`, and `audio_files` (includes `manifest_md5` and URL pointers).
+- `GET /api/v1/audio/voices[?language=<code>]`
+  - Lists voice options by backend for discovery before generation.
+  - Response entries include: `voice_name`, `display_voice`, `backend`, `language_code`, `gender`, `sample_url`.
 
 - `GET /api/v1/lemma/<guid>/sentences[?language=<code>]`
   - Example sentences using the lemma.
@@ -70,6 +73,9 @@ All LLM-invoking endpoints below require JSON body with `"model": "<model-name>"
 - `POST /api/v1/agents/lemma/<guid>/check-disambiguation`
 - `POST /api/v1/agents/lemma/<guid>/check-translations`
 - `POST /api/v1/agents/lemma/<guid>/check-pronunciations`
+- `POST /api/llm/<agent>/generate-audio`
+  - Bulk lemma audio generation (currently supports `agent=vieversys` and `agent=strazdas`).
+  - Body: `{"guids": [...], "language": "bs", "voice": "...", "include_forms": false, "force": false}`.
 
 Check endpoints return:
 

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -15,9 +15,17 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from barsukas.config import Config
 from barsukas.routes._mirror import mirrored_facade
+from clients.audio.azure_tts import AzureVoice
+from clients.audio.google_tts import GoogleTtsVoice
+from clients.audio.gpt_voices import GptVoice
+from clients.audio.polly_tts import PollyVoice
 from flask import Blueprint, Response, g, jsonify, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import and_, case, func, or_
+from audioshoe.coqui.types import CoquiVoice
+from audioshoe.espeak.types import EspeakVoice
+from audioshoe.piper.types import PiperVoice
+from audioshoe.qwen.types import QwenVoice
 
 from storage.crud.grammar_fact import get_grammar_facts
 from storage.crud.lemma import get_lemma_by_guid
@@ -408,6 +416,19 @@ def api_info() -> ResponseReturnValue:
                     "type": "query",
                     "required": False,
                     "description": "Filter to specific language code (e.g., 'en', 'lt', 'fr')",
+                }
+            ],
+        },
+        {
+            "path": "/api/v1/audio/voices",
+            "method": "GET",
+            "description": "List available TTS voices by backend and language",
+            "parameters": [
+                {
+                    "name": "language",
+                    "type": "query",
+                    "required": False,
+                    "description": "Filter to specific language code (e.g., 'bs')",
                 }
             ],
         },
@@ -1546,6 +1567,96 @@ def get_lemma_audio(guid: str) -> ResponseReturnValue:
         metadata["is_populated"] = language_filter in audio_data
 
     return _build_success_response(audio_data, metadata)
+
+
+@bp.route("/v1/audio/voices")
+@mirrored_facade("/api/v1/audio/voices", "GET")
+def list_audio_voices() -> ResponseReturnValue:
+    """List available voices across supported TTS backends."""
+    language_filter = request.args.get("language", type=str)
+    voice_entries: List[Dict[str, Any]] = []
+
+    def append_voice(
+        voice_name: str, display_voice: str, backend: str, language_code: str, gender: Optional[str]
+    ) -> None:
+        if language_filter and language_code != language_filter:
+            return
+        voice_entries.append(
+            {
+                "voice_name": voice_name,
+                "display_voice": display_voice,
+                "backend": backend,
+                "language_code": language_code,
+                "gender": gender,
+                "sample_url": None,
+            }
+        )
+
+    for language_code in LANGUAGE_HIERARCHY:
+        for openai_voice in GptVoice.get_default_voices_for_language(language_code):
+            append_voice(openai_voice.path_name, openai_voice.ui_name, "openai", language_code, None)
+        for espeak_voice in EspeakVoice.get_voices_for_language(language_code):
+            append_voice(
+                espeak_voice.name,
+                str(getattr(espeak_voice, "ui_name", espeak_voice.name)),
+                "espeak",
+                language_code,
+                getattr(espeak_voice, "gender", None),
+            )
+        for qwen_voice in QwenVoice.get_voices_for_language(language_code):
+            append_voice(
+                qwen_voice.name,
+                str(getattr(qwen_voice, "ui_name", qwen_voice.name)),
+                "qwen",
+                language_code,
+                getattr(qwen_voice, "gender", None),
+            )
+        for piper_voice in PiperVoice.get_voices_for_language(language_code):
+            append_voice(
+                piper_voice.name,
+                str(getattr(piper_voice, "ui_name", piper_voice.name)),
+                "piper",
+                language_code,
+                getattr(piper_voice, "gender", None),
+            )
+        for coqui_voice in CoquiVoice.get_voices_for_language(language_code):
+            append_voice(
+                coqui_voice.name,
+                str(getattr(coqui_voice, "ui_name", coqui_voice.name)),
+                "coqui",
+                language_code,
+                getattr(coqui_voice, "gender", None),
+            )
+        for polly_voice in PollyVoice.get_voices_for_language(language_code):
+            voice_key = str(getattr(polly_voice, "id", polly_voice.name))
+            append_voice(
+                voice_key,
+                str(getattr(polly_voice, "name", voice_key)),
+                "polly",
+                language_code,
+                getattr(polly_voice, "gender", None),
+            )
+        for azure_voice in AzureVoice.get_voices_for_language(language_code):
+            voice_key = str(getattr(azure_voice, "short_name", getattr(azure_voice, "name", "")))
+            append_voice(
+                voice_key,
+                str(getattr(azure_voice, "display_name", getattr(azure_voice, "name", voice_key))),
+                "azure",
+                language_code,
+                getattr(azure_voice, "gender", None),
+            )
+        for google_voice in GoogleTtsVoice.get_voices_for_language(language_code):
+            append_voice(
+                google_voice.name,
+                str(getattr(google_voice, "display_name", google_voice.name)),
+                "google",
+                language_code,
+                getattr(google_voice, "gender", None),
+            )
+
+    return _build_success_response(
+        voice_entries, {"language": language_filter, "total": len(voice_entries)}
+    )
 
 
 @bp.route("/v1/lemma/<guid>/wordfreq")

--- a/src/barsukas/routes/llm_api.py
+++ b/src/barsukas/routes/llm_api.py
@@ -33,6 +33,8 @@ from flask.typing import ResponseReturnValue
 import constants
 from agents.lokys import LokysAgent
 from agents.papuga import PapugaAgent
+from agents.strazdas import StrazdasAgent
+from agents.vieversys import VieversysAgent
 from agents.voras.agent import VorasAgent
 from storage.backend.config import BackendType, DataSourceConfig
 from storage.models.schema import Lemma
@@ -171,6 +173,18 @@ def api_info() -> ResponseReturnValue:
                 "openai_api_key": "Optional. OpenAI API key",
                 "anthropic_api_key": "Optional. Anthropic API key",
                 "google_api_key": "Optional. Google API key",
+            },
+        },
+        {
+            "path": "/api/llm/<agent>/generate-audio",
+            "method": "POST",
+            "description": "Generate lemma audio in bulk using the selected audio agent (vieversys/strazdas)",
+            "parameters": {
+                "guids": "Required. List of lemma GUIDs",
+                "language": "Required. Language code (e.g., 'bs')",
+                "voice": "Optional. Voice name for the selected backend/agent",
+                "include_forms": "Optional bool. Reserved for form-level generation (currently base lemma only)",
+                "force": "Optional bool. Reserved for overwrite behavior (currently skipped if manifest already exists)",
             },
         },
         {
@@ -446,6 +460,87 @@ def api_generate_pronunciations() -> ResponseReturnValue:
     except Exception as e:
         g.db.rollback()
         logger.exception("Error generating pronunciations for lemma %s", guid)
+        return _build_error_response(str(e), 500)
+
+
+@bp.route("/<agent>/generate-audio", methods=["POST"])
+@mirrored_facade("/api/llm/<agent>/generate-audio", "POST")
+def api_generate_audio(agent: str) -> ResponseReturnValue:
+    """Generate lemma audio for a batch of GUIDs via a selected audio agent."""
+    data = request.get_json()
+    if not data:
+        return _build_error_response("Request body must be JSON")
+
+    guids = data.get("guids")
+    language_code = data.get("language")
+    voice_name = data.get("voice")
+    include_forms = bool(data.get("include_forms", False))
+    force = bool(data.get("force", False))
+    if not isinstance(guids, list) or not all(isinstance(guid_value, str) for guid_value in guids):
+        return _build_error_response("guids is required and must be a list of strings")
+    if not isinstance(language_code, str) or not language_code:
+        return _build_error_response("language is required")
+
+    lemmas = g.db.query(Lemma).filter(Lemma.guid.in_(guids)).all()
+    found_guid_set = {lemma.guid for lemma in lemmas}
+    missing_guids = [guid_value for guid_value in guids if guid_value not in found_guid_set]
+
+    if not lemmas:
+        return _build_error_response("No requested GUIDs were found", 404)
+
+    try:
+        config = _get_config_from_request(data)
+        if agent == "vieversys":
+            vieversys_agent = VieversysAgent(config=config)
+            result = vieversys_agent.generate_batch(
+                language_code=language_code,
+                lemmas=lemmas,
+                cloud_voice_names=(
+                    [voice_name] if isinstance(voice_name, str) and voice_name else None
+                ),
+            )
+        elif agent == "strazdas":
+            strazdas_agent = StrazdasAgent(config=config)
+            result = strazdas_agent.generate_batch(language_code=language_code, lemmas=lemmas)
+        else:
+            return _build_error_response(
+                "Unsupported audio agent. Use 'vieversys' or 'strazdas'", 400
+            )
+
+        by_guid: Dict[str, Dict[str, Any]] = {}
+        for lemma_result in result.get("lemmas", []):
+            guid_value = lemma_result.get("guid")
+            if not isinstance(guid_value, str):
+                continue
+            if lemma_result.get("success"):
+                by_guid[guid_value] = {"status": "generated"}
+            else:
+                by_guid[guid_value] = {"status": "failed", "error": lemma_result.get("error")}
+
+        generated = int(result.get("success_count", 0))
+        failed = int(result.get("error_count", 0))
+        total = len(guids)
+        skipped_existing = max(total - generated - failed, 0)
+
+        return _build_success_response(
+            {
+                "guids": guids,
+                "missing_guids": missing_guids,
+                "language": language_code,
+                "voice": voice_name,
+                "agent": agent,
+                "include_forms": include_forms,
+                "force": force,
+                "total": total,
+                "generated": generated,
+                "skipped_existing": skipped_existing,
+                "failed": failed,
+                "by_guid": by_guid,
+                "tts_cost_usd": 0.0,
+            }
+        )
+    except Exception as e:
+        logger.exception("Error generating audio with agent=%s", agent)
         return _build_error_response(str(e), 500)
 
 


### PR DESCRIPTION
### Motivation
- Provide a machine-friendly way to discover available TTS voices (by backend and language) so callers can pick a working Bosnian voice before running large jobs.
- Provide a single-shot bulk audio-generation endpoint that mirrors agent CLI behavior so batches of lemmas can be synthesized in one request with an aggregate cost/result summary.
- Keep the `api/` facades in sync with Barsukas routes so external automation can call these endpoints via the typed Python wrappers.

### Description
- Added a read-only endpoint `GET /api/v1/audio/voices` in `src/barsukas/routes/api.py` which enumerates voices across supported backends (`openai`/GPT voices, eSpeak, Qwen, Piper, Coqui, Polly, Azure, Google) and supports `?language=<code>` filtering, returning entries shaped like `VoiceEntry` (`voice_name`, `display_voice`, `backend`, `language_code`, `gender`, `sample_url`).
- Added a bulk audio-generation LLM API `POST /api/llm/<agent>/generate-audio` in `src/barsukas/routes/llm_api.py` that validates `guids`/`language`, dispatches to the selected audio agent (`vieversys` or `strazdas`), and returns aggregated counters and a per-guid `by_guid` map echoing `generated|failed` statuses and `tts_cost_usd` (currently `0.0`).
- Implemented matching typed facades in `api/` including `api.audio.list_voices` with `VoiceEntry`/`VoicesResponse`, and `api.llm_agents.generate_audio` with `GenerateAudioData`/`GenerateAudioResponse`, and exported them from `api.__init__` so callers can import `list_voices` and `generate_audio` from the top-level `api` package.
- Updated API discovery docs `src/barsukas/routes/API.md` to include the new endpoints and sample request/response guidance, and used the existing mirroring decorators so the facade/route contract remains checkable.

### Testing
- Ran `black` on the modified Python files and the formatter completed successfully.
- Ran `mypy` on the modified Python files and type checks passed with no errors.
- Verified the new endpoints are mirrored in the `api/` facades and the changes are reflected in `src/barsukas/routes/API.md` for automated discovery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce2951f088327a9cc35c7b7c48e1c)