### PR TITLE
Add admin restart API and OpenAI voices for bs/sq/hr/sl

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -10,6 +10,7 @@ the ``BARSUKAS_API_URL`` environment variable; see :mod:`api.constants`.
 from __future__ import annotations
 
 from api._http import BarsukasAPIError
+from api.admin import restart as admin_restart
 from api.audio import get_audio, list_voices
 from api.agent_tasks import (
     check_definition,
@@ -48,6 +49,7 @@ from api.sentences import get_sentence_metadata
 
 __all__ = [
     "BarsukasAPIError",
+    "admin_restart",
     "add_missing_translations",
     "check_definition",
     "check_disambiguation",

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,0 +1,33 @@
+"""HTTP facade for admin endpoints under ``/api/v1/admin``.
+
+Mirrors ``src/barsukas/routes/admin.py``. Any change to a route signature or
+response shape there must be reflected here in the same commit.
+
+These endpoints control the Barsukas process itself (e.g. graceful restart).
+They are currently intended for tailnet-only use; auth will be added later.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from api._http import post_json
+from api._mirror import mirrored_route
+
+
+class RestartResponse(TypedDict):
+    success: bool
+    message: str
+
+
+@mirrored_route("/api/v1/admin/restart", "POST")
+def restart() -> RestartResponse:
+    """Initiate a graceful restart of the Barsukas process.
+
+    Returns as soon as the restart has been scheduled. The server then waits
+    for in-flight requests to drain and exits with code 42, which the launch
+    script interprets as a restart signal.
+    """
+    from typing import cast
+
+    return cast(RestartResponse, post_json("/api/v1/admin/restart"))

--- a/api/audio.py
+++ b/api/audio.py
@@ -34,7 +34,13 @@ class VoicesResponse(TypedDict):
 
 @mirrored_route("/api/v1/audio/voices", "GET")
 def list_voices(*, language: Optional[str] = None) -> VoicesResponse:
-    """List available voices for one language or all languages."""
+    """List available voices for one language or all languages.
+
+    The ``backend`` field on each entry identifies the TTS engine
+    ("openai", "polly", "azure", "google", "espeak"). OpenAI-backed voices
+    are served by the ``vieversys`` agent (gpt-4o-mini-tts); see
+    :func:`api.llm_agents.generate_audio`.
+    """
     return cast(VoicesResponse, get_json(f"{API_V1_PREFIX}/audio/voices", {"language": language}))
 
 

--- a/api/llm_agents.py
+++ b/api/llm_agents.py
@@ -160,7 +160,13 @@ def generate_audio(
     include_forms: bool = False,
     force: bool = False,
 ) -> GenerateAudioResponse:
-    """Generate audio for a list of GUIDs with a selected audio agent."""
+    """Generate audio for a list of GUIDs with a selected audio agent.
+
+    Known audio agents (see src/agents/README.md):
+      - "vieversys" — OpenAI TTS (gpt-4o-mini-tts). Use this for cloud-quality
+        audio. Also supports polly/azure/google via server-side config.
+      - "strazdas" — eSpeak-NG (offline, robotic).
+    """
     return cast(
         GenerateAudioResponse,
         post_json(

--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -50,6 +50,7 @@ from langtools.zh.pinyin_helper import (
     is_chinese,
 )
 from barsukas.routes import (
+    admin,
     agents,
     agents_launcher,
     api,
@@ -220,6 +221,7 @@ def create_app(
     app.register_blueprint(api.bp)
     app.register_blueprint(llm_api.bp)
     app.register_blueprint(api_client.bp)
+    app.register_blueprint(admin.bp)
     app.register_blueprint(audio.bp)
     app.register_blueprint(rapid_review.bp)
     app.register_blueprint(rapid_review_hub.bp)

--- a/src/barsukas/routes/admin.py
+++ b/src/barsukas/routes/admin.py
@@ -1,0 +1,30 @@
+"""Admin endpoints exposed under ``/api/v1/admin``.
+
+Currently a thin wrapper around the existing graceful-restart machinery in
+:mod:`barsukas.routes.settings`. Intentionally kept minimal: this is a
+tailnet-only service for now; auth/security will be added later.
+
+MIRRORED: routes here have a typed Python facade in ``api/admin.py``.
+Edits must keep both sides in sync (path, method, response shape).
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint
+from flask.typing import ResponseReturnValue
+
+from barsukas.routes._mirror import mirrored_facade
+from barsukas.routes.settings import initiate_restart
+
+bp = Blueprint("admin", __name__, url_prefix="/api/v1/admin")
+
+
+@bp.route("/restart", methods=["POST"])
+@mirrored_facade("/api/v1/admin/restart", "POST")
+def restart() -> ResponseReturnValue:
+    """Initiate a graceful restart of the Barsukas process.
+
+    Delegates to :func:`barsukas.routes.settings.initiate_restart` so the
+    request-tracking state stays in one place.
+    """
+    return initiate_restart()

--- a/src/barsukas/routes/settings.py
+++ b/src/barsukas/routes/settings.py
@@ -273,15 +273,8 @@ def backend_info() -> ResponseReturnValue:
     return jsonify(info)
 
 
-@bp.route("/restart", methods=["POST"])
-def restart() -> ResponseReturnValue:
-    """Initiate a graceful restart of the Barsukas process.
-
-    This endpoint:
-    1. Returns immediately to the client
-    2. Waits for all in-flight requests to complete
-    3. Restarts the process with the same arguments
-    """
+def initiate_restart() -> ResponseReturnValue:
+    """Shared logic for graceful restart, used by /settings/restart and /api/v1/admin/restart."""
     global _shutdown_requested
 
     if not current_app.config.get("ALLOW_RESTART", True):
@@ -292,19 +285,14 @@ def restart() -> ResponseReturnValue:
 
     _shutdown_requested = True
 
-    # Start restart in background thread
     def do_restart() -> None:
-        # Wait a moment for this response to be sent
         time.sleep(0.5)
 
-        # Wait for all other requests to complete
-        max_wait = 300  # 5 minutes max wait
+        max_wait = 300
         start_time = time.time()
 
         while time.time() - start_time < max_wait:
             with _active_requests_lock:
-                # Only this request (the restart request) should remain
-                # (Status checks are not tracked, so they don't count)
                 if _active_requests <= 1:
                     break
             time.sleep(0.1)
@@ -314,12 +302,10 @@ def restart() -> ResponseReturnValue:
         print("All requests completed, shutting down...")
         print("=" * 50 + "\n")
 
-        # Flush output
         sys.stdout.flush()
         sys.stderr.flush()
 
         # Exit with code 42 to signal the launch script to restart
-        # This is cleaner than fork/exec and lets the OS fully clean up
         os._exit(42)
 
     restart_thread = threading.Thread(target=do_restart, daemon=True)
@@ -331,6 +317,16 @@ def restart() -> ResponseReturnValue:
             "message": "Restart initiated. Waiting for active requests to complete...",
         }
     )
+
+
+@bp.route("/restart", methods=["POST"])
+def restart() -> ResponseReturnValue:
+    """Initiate a graceful restart of the Barsukas process.
+
+    Returns immediately, waits for in-flight requests, then exits with code 42
+    so the launch script restarts the process.
+    """
+    return initiate_restart()
 
 
 @bp.route("/restart/status", methods=["GET"])

--- a/src/clients/audio/gpt_voices.py
+++ b/src/clients/audio/gpt_voices.py
@@ -173,6 +173,30 @@ class GptVoice(Enum):
     GPT_SV_M1 = ("sv", "m", 1, Voice.ASH)
     GPT_SV_M2 = ("sv", "m", 2, Voice.ECHO)
 
+    # Bosnian voices
+    GPT_BS_F1 = ("bs", "f", 1, Voice.NOVA)
+    GPT_BS_F2 = ("bs", "f", 2, Voice.ALLOY)
+    GPT_BS_M1 = ("bs", "m", 1, Voice.ASH)
+    GPT_BS_M2 = ("bs", "m", 2, Voice.ECHO)
+
+    # Albanian voices
+    GPT_SQ_F1 = ("sq", "f", 1, Voice.NOVA)
+    GPT_SQ_F2 = ("sq", "f", 2, Voice.ALLOY)
+    GPT_SQ_M1 = ("sq", "m", 1, Voice.ASH)
+    GPT_SQ_M2 = ("sq", "m", 2, Voice.ECHO)
+
+    # Croatian voices
+    GPT_HR_F1 = ("hr", "f", 1, Voice.NOVA)
+    GPT_HR_F2 = ("hr", "f", 2, Voice.ALLOY)
+    GPT_HR_M1 = ("hr", "m", 1, Voice.ASH)
+    GPT_HR_M2 = ("hr", "m", 2, Voice.ECHO)
+
+    # Slovenian voices
+    GPT_SL_F1 = ("sl", "f", 1, Voice.NOVA)
+    GPT_SL_F2 = ("sl", "f", 2, Voice.ALLOY)
+    GPT_SL_M1 = ("sl", "m", 1, Voice.ASH)
+    GPT_SL_M2 = ("sl", "m", 2, Voice.ECHO)
+
     @property
     def language_code(self) -> str:
         """Get the language code for this voice."""
@@ -287,12 +311,16 @@ DEFAULT_GPT_VOICES: Dict[str, List[GptVoice]] = {
     "nl": [GptVoice.GPT_NL_F1, GptVoice.GPT_NL_M1],
     "de": [GptVoice.GPT_DE_F1, GptVoice.GPT_DE_M1],
     "sv": [GptVoice.GPT_SV_F1, GptVoice.GPT_SV_M1],
+    "bs": [GptVoice.GPT_BS_F1, GptVoice.GPT_BS_M1],
+    "sq": [GptVoice.GPT_SQ_F1, GptVoice.GPT_SQ_M1],
+    "hr": [GptVoice.GPT_HR_F1, GptVoice.GPT_HR_M1],
+    "sl": [GptVoice.GPT_SL_F1, GptVoice.GPT_SL_M1],
 }
 
 # All voices per language (all 4 variants)
 ALL_GPT_VOICES: Dict[str, List[GptVoice]] = {
     lang: GptVoice.get_voices_for_language(lang)
-    for lang in ["lt", "zh", "es", "fr", "it", "pt", "nl", "de", "sv"]
+    for lang in ["lt", "zh", "es", "fr", "it", "pt", "nl", "de", "sv", "bs", "sq", "hr", "sl"]
 }
 
 # Supported languages
@@ -367,6 +395,34 @@ CHARACTER_NAMES: Dict[str, Dict[str, str]] = {
         "m1": "Erik",  # Male, primary (Ash)
         "m2": "Oskar",  # Male, secondary (Echo)
     },
+    # Bosnian
+    "bs": {
+        "f1": "Amina",  # Female, primary (Nova)
+        "f2": "Lejla",  # Female, secondary (Alloy)
+        "m1": "Emir",  # Male, primary (Ash)
+        "m2": "Tarik",  # Male, secondary (Echo)
+    },
+    # Albanian
+    "sq": {
+        "f1": "Elira",  # Female, primary (Nova)
+        "f2": "Drita",  # Female, secondary (Alloy)
+        "m1": "Arben",  # Male, primary (Ash)
+        "m2": "Bekim",  # Male, secondary (Echo)
+    },
+    # Croatian
+    "hr": {
+        "f1": "Ana",  # Female, primary (Nova)
+        "f2": "Petra",  # Female, secondary (Alloy)
+        "m1": "Ivan",  # Male, primary (Ash)
+        "m2": "Marko",  # Male, secondary (Echo)
+    },
+    # Slovenian
+    "sl": {
+        "f1": "Maja",  # Female, primary (Nova)
+        "f2": "Nina",  # Female, secondary (Alloy)
+        "m1": "Luka",  # Male, primary (Ash)
+        "m2": "Matej",  # Male, secondary (Echo)
+    },
 }
 
 # Language display names for character descriptions
@@ -380,6 +436,10 @@ LANGUAGE_DISPLAY_NAMES: Dict[str, str] = {
     "nl": "Dutch",
     "de": "German",
     "sv": "Swedish",
+    "bs": "Bosnian",
+    "sq": "Albanian",
+    "hr": "Croatian",
+    "sl": "Slovenian",
 }
 
 


### PR DESCRIPTION
Adds GPT voices for Bosnian, Albanian, Croatian, and Slovenian (4 variants each, with character names) so vieversys/OpenAI TTS can serve audio in those languages.

Adds a new /api/v1/admin/restart endpoint (mirrored as api.admin.restart) that delegates to a shared initiate_restart() helper in settings.py, so the existing /settings/restart UI route and the new API endpoint share one implementation.

Also documents vieversys (gpt-4o-mini-tts) as the OpenAI-backed audio agent in the api/llm_agents.py and api/audio.py docstrings.