### PR TITLE
Add POS subtype and level-distribution metadata endpoints

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -24,9 +24,11 @@ from api.agent_tasks import (
 )
 from api.batch_operations import (
     find_pending_import_duplicates,
+    get_level_distribution_by_pos,
     get_word_metadata,
     list_models,
     list_pending_imports,
+    list_pos_subtypes,
 )
 from api.lemmas import (
     get_forms,
@@ -69,10 +71,12 @@ __all__ = [
     "get_sentences",
     "get_translations",
     "get_translations_bulk",
+    "get_level_distribution_by_pos",
     "get_word_metadata",
     "list_by_difficulty",
     "list_models",
     "list_pending_imports",
+    "list_pos_subtypes",
     "queue_add_missing_translations",
     "queue_generate_forms",
     "queue_generate_pronunciations",

--- a/api/batch_operations.py
+++ b/api/batch_operations.py
@@ -1,7 +1,7 @@
 """HTTP facade for bulk/aggregate Barsukas endpoints.
 
 Covers per-language word-metadata aggregates, the LLM model registry, and the
-pending-imports listing/duplicate-detection endpoints. Mirrors
+pending-imports listing/duplicate-detection endpoints, plus POS metadata helpers. Mirrors
 ``src/barsukas/routes/api.py`` and ``src/barsukas/routes/pending_imports.py``.
 Any change to a route signature or response shape there must be reflected
 here in the same commit.
@@ -29,6 +29,21 @@ def get_word_metadata(
     return get_json(
         f"{API_V1_PREFIX}/metadata/words",
         {"language": language, "max_difficulty": max_difficulty, "difficulty": difficulty},
+    )
+
+
+@mirrored_route("/api/v1/metadata/pos-subtypes", "GET")
+def list_pos_subtypes(*, pos_type: Optional[str] = None) -> Any:
+    """List POS subtypes, optionally filtered by a POS type."""
+    return get_json(f"{API_V1_PREFIX}/metadata/pos-subtypes", {"pos_type": pos_type})
+
+
+@mirrored_route("/api/v1/metadata/levels/by-pos", "GET")
+def get_level_distribution_by_pos(*, pos_type: str, pos_subtype: str) -> Any:
+    """Get difficulty-level distribution for one POS type/subtype bucket."""
+    return get_json(
+        f"{API_V1_PREFIX}/metadata/levels/by-pos",
+        {"pos_type": pos_type, "pos_subtype": pos_subtype},
     )
 
 

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -86,6 +86,14 @@ Check endpoints return:
 
 ## Metadata endpoints (for aggregate counting)
 
+- `GET /api/v1/metadata/pos-subtypes[?pos_type=<type>]`
+  - List distinct POS subtypes present in lemmas.
+  - `pos_type`: optional exact POS filter (e.g. `noun`, `verb`).
+
+- `GET /api/v1/metadata/levels/by-pos?pos_type=<type>&pos_subtype=<subtype>`
+  - Return difficulty-level distribution for lemmas in one POS bucket.
+  - Response `data` is a map of difficulty level string to count (uses `"null"` for unset levels).
+
 - `GET /api/v1/metadata/words[?language=<code>][&max_difficulty=<int>][&difficulty=<int>]`
 
 Returns per-language aggregate counts with this shape:

--- a/src/barsukas/routes/api.py
+++ b/src/barsukas/routes/api.py
@@ -336,6 +336,38 @@ def api_info() -> ResponseReturnValue:
             ],
         },
         {
+            "path": "/api/v1/metadata/pos-subtypes",
+            "method": "GET",
+            "description": "List available POS subtypes, optionally filtered by POS type",
+            "parameters": [
+                {
+                    "name": "pos_type",
+                    "type": "query",
+                    "required": False,
+                    "description": "Optional part-of-speech filter (e.g., noun, verb)",
+                }
+            ],
+        },
+        {
+            "path": "/api/v1/metadata/levels/by-pos",
+            "method": "GET",
+            "description": "Get word difficulty-level distribution for a POS type + subtype",
+            "parameters": [
+                {
+                    "name": "pos_type",
+                    "type": "query",
+                    "required": True,
+                    "description": "Part-of-speech type (e.g., noun, verb)",
+                },
+                {
+                    "name": "pos_subtype",
+                    "type": "query",
+                    "required": True,
+                    "description": "Part-of-speech subtype (e.g., physical_object)",
+                },
+            ],
+        },
+        {
             "path": "/api/v1/metadata/sentences",
             "method": "GET",
             "description": "Get per-language sentence counts and metadata coverage (audio, verification, pattern types)",
@@ -1594,7 +1626,9 @@ def list_audio_voices() -> ResponseReturnValue:
 
     for language_code in LANGUAGE_HIERARCHY:
         for openai_voice in GptVoice.get_default_voices_for_language(language_code):
-            append_voice(openai_voice.path_name, openai_voice.ui_name, "openai", language_code, None)
+            append_voice(
+                openai_voice.path_name, openai_voice.ui_name, "openai", language_code, None
+            )
         for espeak_voice in EspeakVoice.get_voices_for_language(language_code):
             append_voice(
                 espeak_voice.name,
@@ -2032,6 +2066,61 @@ def get_word_metadata() -> ResponseReturnValue:
         metadata["difficulty"] = exact_difficulty
 
     return _build_success_response(summary_data, metadata)
+
+
+@bp.route("/v1/metadata/pos-subtypes")
+@mirrored_facade("/api/v1/metadata/pos-subtypes", "GET")
+def list_pos_subtypes() -> ResponseReturnValue:
+    """List distinct POS subtypes, optionally filtered by POS type."""
+    pos_type = request.args.get("pos_type", "").strip()
+    subtype_query = g.db.query(Lemma.pos_subtype).filter(
+        Lemma.pos_subtype.isnot(None),
+        Lemma.pos_subtype != "",
+    )
+    if pos_type:
+        subtype_query = subtype_query.filter(Lemma.pos_type == pos_type)
+
+    subtypes = sorted({row[0] for row in subtype_query.distinct().all()})
+    metadata: Dict[str, Any] = {
+        "count": len(subtypes),
+    }
+    if pos_type:
+        metadata["pos_type"] = pos_type
+    return _build_success_response(subtypes, metadata)
+
+
+@bp.route("/v1/metadata/levels/by-pos")
+@mirrored_facade("/api/v1/metadata/levels/by-pos", "GET")
+def get_level_distribution_by_pos() -> ResponseReturnValue:
+    """Return difficulty distribution for lemmas in one POS type/subtype bucket."""
+    pos_type = request.args.get("pos_type", "").strip()
+    pos_subtype = request.args.get("pos_subtype", "").strip()
+    if not pos_type:
+        return _build_error_response("pos_type is required", 400)
+    if not pos_subtype:
+        return _build_error_response("pos_subtype is required", 400)
+
+    rows = (
+        g.db.query(Lemma.difficulty_level, func.count().label("count"))
+        .filter(Lemma.pos_type == pos_type, Lemma.pos_subtype == pos_subtype)
+        .group_by(Lemma.difficulty_level)
+        .order_by(Lemma.difficulty_level)
+        .all()
+    )
+    distribution = {
+        "null" if row.difficulty_level is None else str(row.difficulty_level): row.count
+        for row in rows
+    }
+    total_words = sum(row.count for row in rows)
+
+    return _build_success_response(
+        distribution,
+        {
+            "pos_type": pos_type,
+            "pos_subtype": pos_subtype,
+            "total_words": total_words,
+        },
+    )
 
 
 @bp.route("/v1/metadata/sentences")


### PR DESCRIPTION
### Motivation
- Provide an API and client support for querying POS subtypes and the difficulty-level distribution for a given POS type + subtype so automation and agents can aggregate vocabulary-level statistics per grammatical category.
- Expose these as machine-friendly metadata endpoints documented in the `/api/v1` discovery payload so clients can discover and call them programmatically.

### Description
- Added two Flask routes in `src/barsukas/routes/api.py`: `GET /api/v1/metadata/pos-subtypes` which returns distinct POS subtypes (optional `pos_type` filter) and `GET /api/v1/metadata/levels/by-pos` which returns a difficulty-level → count distribution for a required `pos_type` + `pos_subtype` pair using SQLAlchemy aggregation and grouping (uses `"null"` as the key for unset difficulty values).
- Updated the `/api/v1` discovery payload in `src/barsukas/routes/api.py` and the API reference `src/barsukas/routes/API.md` to advertise both new endpoints and describe their parameters/response shape.
- Added client facades in `api/batch_operations.py` with `@mirrored_route` wrappers: `list_pos_subtypes(...)` and `get_level_distribution_by_pos(...)`, and re-exported them from `api/__init__.py` so the `api` package surface includes the new helpers.
- Kept the mirroring contract by annotating facade and route sides with `mirrored_route` / `mirrored_facade` and formatted code with `black` and type-checked with `mypy`.

### Testing
- Ran `black` on modified files which reformatted as needed and completed successfully.
- Ran `mypy` with `PYTHONPATH=src` on the modified modules which returned no issues.
- Ran the mirror consistency check `python scripts/check_api_mirror_routes.py` which passed (all mirrored route path/method pairs matched).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd339d53948327aea39a1527956d77)