### PR TITLE
docs(langtools): clarify dispatcher architecture and add core language status matrix

### DIFF
--- a/src/langtools/LANGUAGE_MODULE_FORMAT.md
+++ b/src/langtools/LANGUAGE_MODULE_FORMAT.md
@@ -1,0 +1,114 @@
+# Language Module Format (Contract for `src/langtools/<lang>/`)
+
+This document defines the **directory and file contract** each language module
+should follow so top-level conditional/dynamic imports remain stable.
+
+It is intentionally stricter than `README.md` and `STRUCTURE.md`: this is the
+compatibility reference for module naming and callable entrypoints.
+
+## 1) Required directory shape
+
+Each language must live in:
+
+- `src/langtools/<lang>/`
+
+Where `<lang>` is the canonical language code used by dispatcher call sites.
+
+Minimum required files for language participation in form generation:
+
+- `__init__.py`
+- `llm_forms.py`
+- `types.py`
+
+Recommended for registry-driven form support:
+
+- `forms_config.py`
+
+## 2) Standard file purposes
+
+Use these filenames consistently across languages.
+
+### `__init__.py`
+
+- Marks the package.
+- May re-export high-value functions/types.
+- Should avoid heavy import side effects.
+
+### `types.py`
+
+- Holds typed models/enums/dataclasses used by the language implementation.
+- Keep form-slot names and structured outputs here when language-specific.
+
+### `forms_config.py` (optional but preferred)
+
+- Declarative form-axis definitions for registry-based form generation.
+- Consumed by `src/langtools/form_registry.py` pattern expansion.
+
+### `llm_forms.py`
+
+- Main per-language adapter for form-query generation.
+- Exposes language-specific query functions expected by callers.
+- Should route shared mechanics through common infrastructure where possible.
+
+### `conjugation.py` (optional)
+
+- Deterministic verb conjugation logic for languages that support it.
+- May be called directly by dispatcher or from `llm_forms.py` fast paths.
+
+### `grammatical_words.py` (optional)
+
+- Language-specific grammatical/function-word inventories.
+
+### `directions.py` (optional)
+
+- Additional language notes/instructions used during prompt construction.
+
+### `utils.py` (optional)
+
+- Language-local normalization/helpers that do not belong in shared modules.
+
+### `tokenizer.py` (optional)
+
+- Language-local tokenization behavior when shared tokenization is insufficient.
+
+### Script-specific helpers (optional)
+
+- CJK and other script-heavy languages may include helpers like
+  `pinyin_helper.py`, `romaji_helper.py`, `hangul_helper.py`, etc.
+
+## 3) Dispatcher compatibility rules
+
+Top-level `src/langtools/*.py` dispatchers rely on stable naming. To preserve
+conditional imports and dynamic loading behavior:
+
+1. Keep standard filenames unchanged (`llm_forms.py`, `types.py`, etc.).
+2. Prefer additive changes over renames/removals.
+3. When introducing a new capability, first define a shared dispatcher contract
+   and then implement that capability file/function in each core language where
+   meaningful.
+4. If a language does not support a capability, leave the module absent or make
+   the unsupported status explicit in that module (do not silently no-op).
+
+## 4) Core callable surface (cross-language target)
+
+Not all languages implement all capabilities, but callable contracts should be
+consistent where implemented:
+
+1. collation-key generation
+2. grammatical-word classification
+3. verb conjugation
+4. grammatical-form generation/query
+5. prompt direction notes
+6. tokenization/splitting hooks
+7. script/romanization conversion helpers
+8. registry-based LLM form adapters
+
+## 5) Practical change checklist
+
+When editing a language directory:
+
+1. Keep/restore standard filenames.
+2. Ensure imports used by top-level dispatchers still resolve.
+3. Update `LANGUAGE_STATUS.md` for core languages when capability presence
+   changes.
+4. If adding a new shared contract, document it in `STRUCTURE.md` and this file.

--- a/src/langtools/LANGUAGE_MODULE_FORMAT.md
+++ b/src/langtools/LANGUAGE_MODULE_FORMAT.md
@@ -1,7 +1,8 @@
 # Language Module Format (Contract for `src/langtools/<lang>/`)
 
-This document defines the **directory and file contract** each language module
-should follow so top-level conditional/dynamic imports remain stable.
+This document defines the **directory, module, and callable contract** each
+language module should follow so top-level conditional/dynamic imports remain
+stable.
 
 It is intentionally stricter than `README.md` and `STRUCTURE.md`: this is the
 compatibility reference for module naming and callable entrypoints.
@@ -24,7 +25,51 @@ Recommended for registry-driven form support:
 
 - `forms_config.py`
 
-## 2) Standard file purposes
+## 2) Canonical top-level dispatcher signatures
+
+These are the stable shared entrypoints in `src/langtools/*.py` that language
+modules are expected to satisfy.
+
+```python
+# src/langtools/collation.py
+
+def generate_latin_sort_key(lang_code: str, text: str) -> Optional[str]: ...
+
+# src/langtools/directions.py
+
+def get_language_direction_note(language_code: str) -> str: ...
+
+# src/langtools/verb_forms.py
+
+def get_language_verb_forms_config(language_code: str) -> Dict[str, Any]: ...
+
+# src/langtools/noun_declensions.py
+
+def get_mechanical_noun_decliner(language_code: str) -> Optional[DeclineFunc]: ...
+
+# src/langtools/pronouns.py
+
+def strip_pronoun_or_raise(language_code: str, text: str) -> str: ...
+def strip_pronoun(language_code: str, text: str) -> str: ...
+
+# src/langtools/grammatical_words.py
+
+def is_grammatical_word(word: str, language_code: str) -> bool: ...
+def is_function_word(word: str, language_code: str) -> bool: ...
+
+# src/langtools/tokenizer.py
+
+def tokenize(text: str, language_code: str) -> List[str]: ...
+```
+
+Notes:
+
+- Some historical functions are language-first and some are `language_code`
+  second; cleanup should converge toward language-first for new APIs.
+- Language modules should preserve compatibility with current dispatchers until
+  a coordinated API migration lands.
+
+## 3) Standard file purposes + expected callable signatures
 
 Use these filenames consistently across languages.
 
@@ -41,33 +86,92 @@ Use these filenames consistently across languages.
 
 ### `forms_config.py` (optional but preferred)
 
+Expected exports:
+
+```python
+# Pattern: declarative POS config constants consumed by form_registry.
+# Names can vary, but values must be machine-readable by form_registry.
+
+# Example shape (illustrative):
+# FORM_CONFIGS: Dict[str, Dict[str, Any]]
+```
+
 - Declarative form-axis definitions for registry-based form generation.
 - Consumed by `src/langtools/form_registry.py` pattern expansion.
 
 ### `llm_forms.py`
 
-- Main per-language adapter for form-query generation.
-- Exposes language-specific query functions expected by callers.
-- Should route shared mechanics through common infrastructure where possible.
+Expected callable patterns (language code replaced by actual `<lang>`):
+
+```python
+# Required generic adapter (preferred):
+# def query_<lang>_forms(..., pos_type: str, ...) -> Dict[str, str]: ...
+
+# Common explicit adapters (if used by call sites):
+# def query_<lang>_noun_forms(...) -> Dict[str, str]: ...
+# def query_<lang>_verb_forms(...) -> Dict[str, str]: ...
+# def query_<lang>_adjective_forms(...) -> Dict[str, str]: ...
+```
+
+Contract expectations:
+
+- Return normalized `Dict[str, str]` form slots for shared pipelines.
+- Delegate shared schema/prompt/LLM mechanics to common infrastructure where
+  possible.
+- Keep function names stable once consumed by external call sites.
 
 ### `conjugation.py` (optional)
+
+Expected callable pattern:
+
+```python
+# def mechanically_conjugate_<lang>_verb(lemma: str, ...) -> Optional[Dict[str, str]]: ...
+```
 
 - Deterministic verb conjugation logic for languages that support it.
 - May be called directly by dispatcher or from `llm_forms.py` fast paths.
 
 ### `grammatical_words.py` (optional)
 
-- Language-specific grammatical/function-word inventories.
+Expected exports:
+
+```python
+# PERSONAL_PRONOUNS: set[str] | frozenset[str]
+# GRAMMATICAL_WORDS: set[str] | frozenset[str]
+# FUNCTION_WORDS: set[str] | frozenset[str]
+# NON_PERSONAL_PRONOUNS: set[str] | frozenset[str]
+```
+
+- Language-specific grammatical/function-word inventories used by shared
+  classifier dispatchers.
 
 ### `directions.py` (optional)
+
+Expected callable:
+
+```python
+def get_directions() -> str: ...
+```
 
 - Additional language notes/instructions used during prompt construction.
 
 ### `utils.py` (optional)
 
+Expected optional callable for pronoun stripping compatibility:
+
+```python
+# def strip_pronoun(text: str) -> str: ...
+```
+
 - Language-local normalization/helpers that do not belong in shared modules.
 
 ### `tokenizer.py` (optional)
+
+Expected callable:
+
+```python
+def tokenize(text: str) -> List[str]: ...
+```
 
 - Language-local tokenization behavior when shared tokenization is insufficient.
 
@@ -76,7 +180,7 @@ Use these filenames consistently across languages.
 - CJK and other script-heavy languages may include helpers like
   `pinyin_helper.py`, `romaji_helper.py`, `hangul_helper.py`, etc.
 
-## 3) Dispatcher compatibility rules
+## 4) Dispatcher compatibility rules
 
 Top-level `src/langtools/*.py` dispatchers rely on stable naming. To preserve
 conditional imports and dynamic loading behavior:
@@ -89,7 +193,7 @@ conditional imports and dynamic loading behavior:
 4. If a language does not support a capability, leave the module absent or make
    the unsupported status explicit in that module (do not silently no-op).
 
-## 4) Core callable surface (cross-language target)
+## 5) Core callable surface (cross-language target)
 
 Not all languages implement all capabilities, but callable contracts should be
 consistent where implemented:
@@ -103,7 +207,7 @@ consistent where implemented:
 7. script/romanization conversion helpers
 8. registry-based LLM form adapters
 
-## 5) Practical change checklist
+## 6) Practical change checklist
 
 When editing a language directory:
 

--- a/src/langtools/LANGUAGE_STATUS.md
+++ b/src/langtools/LANGUAGE_STATUS.md
@@ -1,0 +1,40 @@
+# Langtools Per-Language Status (Core Set)
+
+This file tracks architecture status only for the current core languages:
+
+- CJK: `zh`, `ja`, `ko`
+- FIGS + additional core: `fr`, `it`, `de`, `es`, `pt`, `nl`, `sv`, `lt`
+
+Legend:
+
+- ✅ present
+- ◐ present via shared/top-level mechanism (not language-local)
+- ⭕ not currently present in language directory (may be intentional)
+
+## Capability checklist
+
+| Language | `llm_forms.py` | `forms_config.py` | `conjugation.py` | `grammatical_words.py` | `directions.py` | language-local `tokenizer.py` |
+|---|---:|---:|---:|---:|---:|---:|
+| zh | ✅ | ✅ | ⭕ | ✅ | ✅ | ✅ |
+| ja | ✅ | ✅ | ⭕ | ✅ | ⭕ | ⭕ |
+| ko | ✅ | ✅ | ⭕ | ⭕ | ✅ | ⭕ |
+| fr | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| it | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| de | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| es | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| pt | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| nl | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| sv | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+| lt | ✅ | ✅ | ✅ | ✅ | ✅ | ⭕ |
+
+## Notes for architecture cleanup
+
+1. The **directory-per-language** pattern is in place for all core languages.
+2. The **forms stack** (`forms_config.py` + `llm_forms.py`) is present across
+   all core languages listed here.
+3. **Verb conjugation** is currently concentrated in FIGS + `pt`, `nl`, `sv`,
+   `lt`, `de`, while CJK languages use other morphology pathways.
+4. Tokenization is mixed: `zh` has language-local tokenizer logic, while many
+   other languages rely on shared behavior.
+5. Dispatcher standardization at top-level `src/langtools/*.py` should continue
+   to converge toward language-first dynamic import entrypoints.

--- a/src/langtools/README.md
+++ b/src/langtools/README.md
@@ -25,7 +25,8 @@ Langtools is being aligned to a language-plugin architecture with these rules:
    - registry-based LLM form querying.
 
 This README is intentionally high-level; see `STRUCTURE.md` for concrete
-module contracts and `LANGUAGE_STATUS.md` for per-language status.
+module contracts, `LANGUAGE_MODULE_FORMAT.md` for per-language file standards,
+and `LANGUAGE_STATUS.md` for per-language status.
 
 ## Important scope note
 

--- a/src/langtools/README.md
+++ b/src/langtools/README.md
@@ -2,71 +2,37 @@
 
 `src/langtools` is Greenland's shared language-logic package.
 
-It provides reusable building blocks for:
+## Target architecture (current direction)
 
-1. **Form generation** (noun/verb/adjective/adverb paradigms).
-2. **Script helpers** (romanization, reading extraction, script conversion).
-3. **Language-aware collation** (stable dictionary sorting behavior).
-4. **Prompt direction notes** used by form-generation workflows.
+Langtools is being aligned to a language-plugin architecture with these rules:
 
-## Who uses this package
+1. **Each language lives in its own directory** under `src/langtools/<lang>/`.
+2. **Top-level `src/langtools/*.py` functions are dispatchers** that:
+   - take `language` as the first argument, and
+   - perform a dynamic import of the language implementation.
+3. **Language capability is intentionally partial**:
+   - not every function is meaningful for every language,
+   - missing functionality should be represented explicitly (for example by
+     no implementation, `NotImplementedError`, or a capability check).
+4. **A focused core surface area** (about eight key functions), such as:
+   - collation key generation,
+   - grammatical-word classification,
+   - verb conjugation,
+   - noun/other inflectional form generation,
+   - language-specific prompt direction notes,
+   - tokenizer/splitting helpers,
+   - script/romanization helpers,
+   - registry-based LLM form querying.
 
-`langtools` is imported by higher-level systems, especially:
+This README is intentionally high-level; see `STRUCTURE.md` for concrete
+module contracts and `LANGUAGE_STATUS.md` for per-language status.
 
-- `src/wordfreq/translation/*` for LLM form generation pipelines.
-- `src/clients/*` dispatch paths that call language-specific query methods.
-- `src/barsukas/*` browse/search experiences that rely on sorting and display helpers.
+## Important scope note
 
-## High-level layout
+Core-language planning and gap discussion currently focuses on:
 
-```text
-src/langtools/
-├── <lang>/            # Per-language modules (e.g. en, zh, lt, ko)
-├── form_registry.py   # Central (language, POS) form specs
-├── llm_forms_base.py  # Shared query engine for all language/POS specs
-├── form_patterns.py   # Pattern expansion for forms_config definitions
-├── collation.py       # Shared sort-key generation
-├── directions.py      # Dispatcher for optional language direction notes
-├── dialect_overrides.py
-├── README.md
-└── STRUCTURE.md       # Detailed architecture + extension guide
-```
+- **CJK**: `zh`, `ja`, `ko`
+- **FIGS + additional core**: `fr`, `it`, `de`, `es`, `pt`, `nl`, `sv`, `lt`
 
-## Language module patterns
-
-Most language folders follow one of these patterns:
-
-- **Full-stack modules** (for example `en`, `de`, `es`, `fr`, `lt`):
-  - rich `types.py` models,
-  - language utilities,
-  - optional Wiktionary parsing,
-  - `llm_forms.py` entrypoints.
-- **Config-driven modules** (many newer languages):
-  - `forms_config.py` declares form axes,
-  - `form_registry.py` + `form_patterns.py` derive mappings automatically,
-  - thin `llm_forms.py` wrappers call shared logic.
-- **Script/helper-heavy modules** (for example `zh`, `ja`, `ko`):
-  - still support form queries,
-  - additionally expose script-specific utilities such as pinyin/romaji/hangul decomposition.
-
-## Core idea: registry-driven forms
-
-The central `FORM_SPECS` registry (in `form_registry.py`) defines each supported
-`(language_code, pos_type)` combination. Shared logic in `llm_forms_base.py`
-consumes a `LanguageFormSpec` and performs schema construction, prompt loading,
-LLM calling, and query logging.
-
-This removes duplicated per-language boilerplate and keeps task generation in
-`src/wordfreq/translation/generate_forms_tasks.py` data-driven.
-
-## Quick extension checklist
-
-When adding a new config-driven language or POS:
-
-1. Add `src/langtools/<lang>/forms_config.py` with the form pattern config.
-2. Add a thin `src/langtools/<lang>/llm_forms.py` wrapper if explicit import
-   points are needed by other code.
-3. Confirm `FORM_SPECS[(<lang>, <pos>)]` is populated.
-4. Run task discovery/validation paths in translation tooling.
-
-For the deep architecture and dependency notes, read `STRUCTURE.md`.
+Non-core languages can continue to evolve, but are not the focus of the current
+architecture cleanup pass.

--- a/src/langtools/STRUCTURE.md
+++ b/src/langtools/STRUCTURE.md
@@ -78,3 +78,9 @@ When refactoring existing code toward this architecture:
 4. Keep shared logic generic; keep language exceptions local to the language
    folder.
 5. Update `LANGUAGE_STATUS.md` whenever core-language capability status changes.
+
+
+## 7) File-format standardization
+
+For the concrete per-language filename/entrypoint contract required by
+conditional imports, see `LANGUAGE_MODULE_FORMAT.md`.

--- a/src/langtools/STRUCTURE.md
+++ b/src/langtools/STRUCTURE.md
@@ -1,208 +1,80 @@
 # Langtools Architecture
 
-This document is the implementation-focused reference for `src/langtools`.
+This document defines the cleanup target for `src/langtools`.
 
-## 1) System overview
+## 1) Organizing principle
 
-`langtools` is organized around a **registry-driven form generation model**:
+Langtools should operate as a **language-plugin system**:
 
-- Per-language config/modules declare grammatical form inventory.
-- `form_registry.py` builds `FORM_SPECS[(language_code, pos_type)]` entries.
-- `llm_forms_base.py` executes shared form query logic using one spec.
-- `wordfreq.translation.generate_forms_tasks` builds runnable tasks from
-  those specs.
+- Shared dispatch functions live at `src/langtools/*.py`.
+- Language implementations live in `src/langtools/<lang>/`.
+- Top-level dispatchers dynamically import language modules based on the
+  requested language code.
 
-In parallel, `langtools` also contains:
+## 2) Directory contract
 
-- script helpers (Chinese/Japanese/Korean and others),
-- language collation helpers,
-- dialect override behavior,
-- optional language-specific direction notes.
+### Per-language directories
 
----
+Every supported language should have a dedicated folder:
 
-## 2) Top-level modules and responsibilities
+- `src/langtools/<lang>/`
 
-- `form_registry.py`
-  - Discovers `langtools/*/forms_config.py` files.
-  - Expands config patterns into concrete form field lists + enum mappings.
-  - Builds the canonical `FORM_SPECS` mapping.
+That folder may expose any subset of the standard capabilities. Missing
+capabilities are valid and expected for some languages.
 
-- `llm_forms_base.py`
-  - Defines `LanguageFormSpec` dataclass.
-  - Implements shared `query_forms(...)` logic:
-    - lemma/translation loading,
-    - JSON schema assembly,
-    - prompt/context loading,
-    - LLM call + logging,
-    - form extraction/validation.
+### Top-level dispatcher modules
 
-- `form_patterns.py`
-  - Expands declarative form patterns such as:
-    - `case_number`,
-    - `person_tense`,
-    - `case_number_gender`,
-    - `degree`,
-    - `explicit`,
-    - `singular_plural`, `tense_only`, `base_only`.
+Top-level modules in `src/langtools/` provide stable call points for the rest of
+Greenland. Dispatcher functions should:
 
-- `collation.py`
-  - Produces language-aware sort keys so SQLite binary collation aligns with
-    expected lexical order.
+1. accept `language` as the first argument,
+2. resolve the implementation module using dynamic import, and
+3. call the language-specific function when present.
 
-- `directions.py`
-  - Loads optional per-language prompt direction notes (from
-    `langtools/<lang>/directions.py` when present).
+## 3) Capability model
 
-- `dialect_overrides.py`
-  - Declares dialect relationships and optional transforms (for example
-    Simplified/Traditional Chinese behavior).
+Not every language should be forced to implement every function.
 
----
+Use a **capability-based** model:
 
-## 3) Language folder archetypes
+- If a language implements a capability, expose it via the expected module/file.
+- If not implemented, fail clearly (or return an explicit “not supported” result,
+  depending on caller contract).
+- Avoid stubs that silently do nothing.
 
-### A. Full-stack lexical modules (deep file breakdown)
+## 4) Core function surface (target ~8 functions)
 
-Primary examples: `en`, `de`, `es`, `fr`, `lt`.
+The practical shared API should stay focused around a small set of key
+capabilities. Current target categories:
 
-These folders usually contain the files below (some language-specific extras
-exist, but this is the common pattern):
+1. **Collation key** (`collation` dispatcher + per-language collation behavior)
+2. **Grammatical words** (language-aware grammatical-word classification)
+3. **Verb conjugation** (deterministic or assisted)
+4. **General grammatical forms** (noun/adjective/etc form generation)
+5. **Prompt direction notes** (`directions`)
+6. **Tokenization helpers** (`tokenizer` where language-specific behavior matters)
+7. **Script/romanization helpers** (CJK-focused converters/readings)
+8. **LLM form-query integration** (registry-based form slots + query adapters)
 
-- `__init__.py`
-  - Package marker and light exports.
+The exact function names can evolve, but architecture should keep this surface
+small and explicit.
 
-- `types.py`
-  - Dataclasses/enums for that language's paradigm outputs (noun/verb/etc).
-  - Defines expected form slot names and metadata fields used by parsers and
-    generation paths.
+## 5) Core-language focus for cleanup
 
-- `forms_config.py`
-  - Declarative POS configs consumed by registry auto-discovery.
-  - Source of truth for form axes in the registry-driven pipeline.
+This cleanup pass tracks completeness only for:
 
-- `utils.py`
-  - Text normalization and utility heuristics (cleaning, article extraction,
-    gender hints, person-label normalization, etc.).
+- **CJK**: `zh`, `ja`, `ko`
+- **FIGS + additional core**: `fr`, `it`, `de`, `es`, `pt`, `nl`, `sv`, `lt`
 
-- `wiktionary.py`
-  - Optional Wiktionary parser implementation for this language.
-  - Converts templates/tables/text into language `types.py` structures.
+Do not treat missing features in other languages as blockers for this phase.
 
-- `conjugation.py`
-  - Mechanical conjugation logic where available.
-  - Used by `llm_forms.py` as a fast deterministic path before LLM fallback.
+## 6) Migration guidance
 
-- `llm_forms.py`
-  - Runtime entrypoints called by client/workflow code.
-  - Common contents:
-    1. `*_FORM_MAPPING` constants read from `FORM_SPECS`.
-    2. `query_<language>_<pos>_*` functions that call shared `query_forms(...)`.
-    3. Optional deterministic fast path for verbs (mechanical conjugation), with
-       fallback to shared LLM querying and query logging.
-  - In other words, `llm_forms.py` is the language adapter that binds the shared
-    engine to language-specific naming and optional pre-LLM logic.
+When refactoring existing code toward this architecture:
 
-- `pronouns.py`
-  - Subject-pronoun inventory by person slot (`1s`, `2s`, ...).
-  - Consumed by `langtools.person_labels` to generate person labels/metadata
-    for UI/prompts and ambiguity handling.
-
-- `grammatical_words.py`
-  - Four-tier lexical inventory for filtering/linking behavior:
-    - personal pronouns,
-    - grammatical-only words,
-    - function words,
-    - non-personal pronouns.
-  - Consumed by top-level `langtools.grammatical_words` registry and sentence/
-    linker pipelines.
-
-- `manifest.py` (where present)
-  - WireWord grammar-manifest metadata for tense/person slot presentation.
-
-- `verb_forms.py` (where present)
-  - Verb-form benchmark layout/prompt config for evaluation tooling.
-
-- `directions.py` (where present)
-  - Additional language prompt-direction notes.
-
-- language-specific extras
-  - Example: Lithuanian `principal_parts.py`, German generated conjugation data,
-    English `rhyme_key.py`, test helper modules.
-
-#### Why `pronouns.py` and `grammatical_words.py` are separate
-
-They should stay separate.
-
-- `pronouns.py` is **person-slot metadata** (`1s`/`2s`/`3p`) for conjugation and
-  person-label UX paths.
-- `grammatical_words.py` is **token-tier classification** for lexical filtering
-  and lemma-link decisions.
-
-There is intentional overlap in surface words (for example subject pronouns),
-but the data models and consumers are different, so merging would blur two
-separate responsibilities.
-
-### B. Config-driven modules
-
-Many languages use:
-
-- `forms_config.py` as the single declarative source of form axes,
-- `types.py` and `llm_forms.py` wrappers,
-- automatic registration via top-level registry tooling.
-
-This pattern minimizes duplicated boilerplate.
-
-### C. Script/helper-focused modules
-
-Examples: `zh`, `ja`, `ko`.
-
-These modules provide script-specific helpers **and** can participate in
-registry-driven form generation (via `forms_config.py` + `llm_forms.py`).
-
-Helper highlights:
-
-- `zh/pinyin_helper.py`, `zh/converter.py`
-- `ja/romaji_helper.py`, `ja/gojuon.py`
-- `ko/hangul_helper.py`
-
----
-
-## 4) Form generation flow (runtime)
-
-1. A workflow asks for forms for language/POS.
-2. It resolves a `LanguageFormSpec` from `FORM_SPECS`.
-3. `query_forms(...)` builds the schema + prompt payload.
-4. Client call executes through the unified LLM client.
-5. Response forms are normalized into `Dict[str, str]` and logged.
-
-`generate_forms_tasks.py` creates tasks from all registered specs and applies
-language/POS overrides (thresholds, fetch strategy, explicit client methods)
-where needed.
-
----
-
-## 5) Adding or updating a language (recommended path)
-
-For a new config-driven language:
-
-1. Create `src/langtools/<lang>/forms_config.py` with POS configs.
-2. Ensure enum members needed by those forms are derivable from pattern output.
-3. Add `src/langtools/<lang>/llm_forms.py` wrapper functions if call sites
-   expect explicit imports.
-4. Verify `FORM_SPECS` contains the expected `(lang, pos)` entries.
-5. Run related translation/form-generation checks.
-
-For languages that require advanced parsing or special behavior, add optional
-helpers (`utils.py`, parser modules, script tools) without bypassing the shared
-registry/query path unless there is a clear reason.
-
----
-
-## 6) Notes for maintainers
-
-- Prefer adding new behavior through declarative config + shared infrastructure
-  before creating bespoke per-language pipelines.
-- Keep language-specific constants/logic scoped to each language folder.
-- Keep doc comments near pattern definitions and overrides synchronized with the
-  behavior in `form_registry.py` and `generate_forms_tasks.py`.
+1. Move language logic into `src/langtools/<lang>/...` if still top-level.
+2. Keep top-level functions as lightweight dispatchers.
+3. Prefer explicit capability checks over implicit fallbacks.
+4. Keep shared logic generic; keep language exceptions local to the language
+   folder.
+5. Update `LANGUAGE_STATUS.md` whenever core-language capability status changes.


### PR DESCRIPTION
### Motivation

- Establish a clear language-plugin architecture for `src/langtools` with language-first dispatchers and dynamic imports to guide upcoming refactors.
- Make explicit that language capabilities are partial and focus the cleanup scope on the core set (CJK and FIGS + pt/nl/sv/lt).

### Description

- Rewrote `src/langtools/README.md` to document the target plugin-style architecture, dispatcher contract, capability model, and core function surface.
- Replaced `src/langtools/STRUCTURE.md` with a concise architecture-target document that specifies directory contracts, capability guidance, and migration steps.
- Added `src/langtools/LANGUAGE_STATUS.md` providing a per-language status matrix for the core languages (`zh`, `ja`, `ko`, `fr`, `it`, `de`, `es`, `pt`, `nl`, `sv`, `lt`).
- This PR is documentation-only and does not change runtime code or behavior.

### Testing

- Ran a quick presence check script (`python - <<'PY' ...`) to enumerate core-language files and used its output to build the status matrix, and the script completed successfully.
- Verified working-tree status with `git status --short` and committed the documentation changes successfully with `git commit`.
- Displayed the updated files (`nl -ba ...`) to confirm expected content; no automated unit tests were required or run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020881568c83278f8f35ec9ae956c7)