### PR TITLE
Refactor barsukas API routes into package modules

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,7 +1,7 @@
 # `api/` — Python wrapper around the Barsukas HTTP API
 
 This package provides a thin, typed Python facade over the JSON endpoints
-exposed by the Barsukas web app (`src/barsukas/routes/api.py` and
+exposed by the Barsukas web app (`src/barsukas/routes/api/v1.py`, `src/barsukas/routes/api/html.py`, and
 `src/barsukas/routes/pending_imports.py`).
 
 It is the recommended way for scripts, agents, and external tools to consume

--- a/api/audio.py
+++ b/api/audio.py
@@ -4,7 +4,7 @@ Lemma audio availability is currently a sub-resource of ``/api/v1/lemma/<guid>``
 in the Barsukas API, so this module re-exports :func:`api.lemmas.get_audio`
 and exists as the natural home for future standalone audio endpoints.
 
-Mirrors ``src/barsukas/routes/api.py``. Any change to a route signature or
+Mirrors ``src/barsukas/routes/api/v1.py``. Any change to a route signature or
 response shape there must be reflected here in the same commit.
 """
 

--- a/api/batch_operations.py
+++ b/api/batch_operations.py
@@ -2,7 +2,7 @@
 
 Covers per-language word-metadata aggregates, the LLM model registry, and the
 pending-imports listing/duplicate-detection endpoints, plus POS metadata helpers. Mirrors
-``src/barsukas/routes/api.py`` and ``src/barsukas/routes/pending_imports.py``.
+``src/barsukas/routes/api/v1.py`` and ``src/barsukas/routes/pending_imports.py``.
 Any change to a route signature or response shape there must be reflected
 here in the same commit.
 """

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -1,6 +1,6 @@
 """HTTP facade for lemma-related Barsukas endpoints.
 
-Mirrors ``src/barsukas/routes/api.py``. Any change to a route signature or
+Mirrors ``src/barsukas/routes/api/v1.py``. Any change to a route signature or
 response shape there must be reflected here in the same commit.
 """
 

--- a/api/sentences.py
+++ b/api/sentences.py
@@ -1,6 +1,6 @@
 """HTTP facade for sentence-domain Barsukas endpoints.
 
-Mirrors ``src/barsukas/routes/api.py``. Any change to a route signature or
+Mirrors ``src/barsukas/routes/api/v1.py``. Any change to a route signature or
 response shape there must be reflected here in the same commit.
 
 Currently exposes only the per-language sentence metadata aggregate; example

--- a/api/translations.py
+++ b/api/translations.py
@@ -4,7 +4,7 @@ Translations are currently a lemma sub-resource in the Barsukas API, so this
 module re-exports :func:`api.lemmas.get_translations` and exists as the
 natural home for future standalone translation endpoints.
 
-Mirrors ``src/barsukas/routes/api.py``. Any change to a route signature or
+Mirrors ``src/barsukas/routes/api/v1.py``. Any change to a route signature or
 response shape there must be reflected here in the same commit.
 """
 

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -1,6 +1,6 @@
 # Barsukas API quick reference
 
-This file documents the main JSON endpoints under `src/barsukas/routes/api.py` that are useful for automation/agents.
+This file documents the main JSON endpoints under `src/barsukas/routes/api/v1.py` that are useful for automation/agents.
 
 Base prefix: `/api`.
 

--- a/src/barsukas/routes/api/__init__.py
+++ b/src/barsukas/routes/api/__init__.py
@@ -1,0 +1,9 @@
+"""API route package for Barsukas."""
+
+from flask import Blueprint
+
+bp = Blueprint("api", __name__, url_prefix="/api")
+
+# Register route handlers on the shared blueprint
+from barsukas.routes.api import html as _html  # noqa: F401
+from barsukas.routes.api import v1 as _v1  # noqa: F401

--- a/src/barsukas/routes/api/html.py
+++ b/src/barsukas/routes/api/html.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python3
+
+"""API routes for AJAX requests and REST API endpoints.
+
+MIRRORED: routes annotated with ``@mirrored_facade`` have a typed Python
+wrapper in the root-level ``api/`` package (``api/lemmas.py``,
+``api/sentences.py``, ``api/batch_operations.py``, ...). Edits to a mirrored
+route's path, query params, or response shape MUST be made in the matching
+facade in the same commit. See ``api/AGENTS.md`` for the mirroring contract.
+"""
+
+from datetime import datetime, timedelta
+import json
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from barsukas.config import Config
+from barsukas.routes._mirror import mirrored_facade
+from clients.audio.azure_tts import AzureVoice
+from clients.audio.google_tts import GoogleTtsVoice
+from clients.audio.gpt_voices import GptVoice
+from clients.audio.polly_tts import PollyVoice
+from flask import Response, g, jsonify, request
+from flask.typing import ResponseReturnValue
+from sqlalchemy import and_, case, func, or_
+from audioshoe.coqui.types import CoquiVoice
+from audioshoe.espeak.types import EspeakVoice
+from audioshoe.piper.types import PiperVoice
+from audioshoe.qwen.types import QwenVoice
+
+from storage.crud.grammar_fact import get_grammar_facts
+from storage.crud.lemma import get_lemma_by_guid
+from storage.lexeme import get_lexeme
+from storage.models import (
+    DerivativeForm,
+    GrammarFact,
+    Lemma,
+    LemmaTranslation,
+    Sentence,
+    SentenceTranslation,
+    SentenceWord,
+)
+from storage.models.schema import (
+    AudioQualityReview,
+    ExternalLexemeAnnotation,
+    LemmaDifficultyOverride,
+    BarsukasTask,
+)
+from storage.queries.lemma import build_lemma_search_query
+from storage.translation_helpers import (
+    LANGUAGE_HIERARCHY,
+    get_all_translations,
+    get_translation_pronunciations,
+)
+from workqueue.task_queue import TaskStatus, TaskType, enqueue_task
+from barsukas.routes.api import bp
+
+
+@bp.route("/check_lemma_exists")
+def check_lemma_exists() -> ResponseReturnValue:
+    """Check if a lemma exists or find similar lemmas."""
+    search = request.args.get("search", "").strip()
+    pos_type = request.args.get("pos_type", "").strip()
+
+    if not search:
+        return jsonify({"exact_match": None, "similar_matches": []})
+
+    # Check for exact match
+    exact_query = g.db.query(Lemma).filter(func.lower(Lemma.lemma_text) == search.lower())
+    if pos_type:
+        exact_query = exact_query.filter(Lemma.pos_type == pos_type)
+
+    exact_match = exact_query.first()
+
+    # Find similar matches (case-insensitive LIKE search)
+    similar_query = g.db.query(Lemma).filter(Lemma.lemma_text.ilike(f"%{search}%"))
+
+    # If exact match found, exclude it from similar matches
+    if exact_match:
+        similar_query = similar_query.filter(Lemma.id != exact_match.id)
+
+    similar_matches = similar_query.limit(5).all()
+
+    return jsonify(
+        {
+            "exact_match": (
+                {
+                    "id": exact_match.id,
+                    "lemma_text": exact_match.lemma_text,
+                    "pos_type": exact_match.pos_type,
+                    "definition_text": exact_match.definition_text,
+                }
+                if exact_match
+                else None
+            ),
+            "similar_matches": [
+                {
+                    "id": lemma.id,
+                    "lemma_text": lemma.lemma_text,
+                    "pos_type": lemma.pos_type,
+                    "definition_text": lemma.definition_text,
+                }
+                for lemma in similar_matches
+            ],
+        }
+    )
+
+
+@bp.route("/auto_populate_lemma")
+def auto_populate_lemma() -> ResponseReturnValue:
+    """Auto-populate lemma fields using LLM based on word and optional translation."""
+    word = request.args.get("word", "").strip()
+    translation = request.args.get("translation", "").strip()
+    lang_code = request.args.get("lang_code", "").strip()
+
+    if not word:
+        return jsonify({"success": False, "error": "Word is required"})
+
+    try:
+        # Use LLM to generate definition, POS type, and POS subtype
+        from wordfreq.translation.client import LinguisticClient
+
+        client = LinguisticClient(model="gpt-5.4-mini", db_path=Config.DB_PATH, debug=Config.DEBUG)
+
+        # Build prompt for LLM
+        if translation and lang_code:
+            context = f'English word: "{word}"\n{lang_code.upper()} translation: "{translation}"'
+        else:
+            context = f'English word: "{word}"'
+
+        prompt = f"""Analyze this word and provide its linguistic properties:
+
+{context}
+
+Provide:
+1. A clear, concise definition (1-2 sentences)
+2. Part of speech (pos_type): Choose from: noun, verb, adjective, adverb, pronoun, preposition, conjunction, interjection, determiner, numeral
+3. Part of speech subtype (pos_subtype): Choose the most appropriate:
+   - For nouns: animal, body_part, building_structure, clothing_accessory, concept_idea, emotion_feeling, food, beverage, furniture, vehicle, plant, plant_part, human, material_substance, nationality, natural_feature, personal_name, place_name, small_movable_object, temporal_name, time_period, tool_machine, unit_of_measurement
+   - For verbs: physical_action, creation_action, destruction_action, mental_state, emotional_state, perception, communication, possession, existence, development, change, directional_movement, manner_movement
+   - For adjectives: size, color, shape, texture, personal_quality, condition, quality, aesthetic, importance, origin, purpose, material, indefinite_quantity, duration, frequency, sequence
+   - For adverbs: style, attitude, specific_time, relative_time, duration, direction, location, distance, intensity, completeness, approximation, definite_frequency, indefinite_frequency
+   - For numerals: cardinal, ordinal
+   - For other POS: use appropriate subtype or "other"
+
+The definition should be suitable for language learners."""
+
+        # Define schema for structured output
+        from clients.types import Schema, SchemaProperty
+
+        schema = Schema(
+            name="LemmaProperties",
+            description="Linguistic properties of a word",
+            properties={
+                "definition": SchemaProperty(
+                    type="string",
+                    description="Clear, concise definition of the word (1-2 sentences)",
+                ),
+                "pos_type": SchemaProperty(type="string", description="Part of speech type"),
+                "pos_subtype": SchemaProperty(type="string", description="Part of speech subtype"),
+            },
+        )
+
+        response = client.client.generate_chat(
+            prompt=prompt, model="gpt-5.4-mini", json_schema=schema, timeout=30
+        )
+
+        if not response.structured_data:
+            return jsonify(
+                {"success": False, "error": "Failed to get structured response from LLM"}
+            )
+
+        result = response.structured_data
+
+        # Get the maximum difficulty level for this pos_subtype
+        max_level = None
+        if result.get("pos_subtype"):
+            max_level_query = (
+                g.db.query(func.max(Lemma.difficulty_level))
+                .filter(
+                    Lemma.pos_subtype == result["pos_subtype"],
+                    Lemma.difficulty_level.isnot(None),
+                    Lemma.difficulty_level != -1,  # Exclude "excluded" words
+                )
+                .scalar()
+            )
+            if max_level_query:
+                max_level = int(max_level_query)
+
+        return jsonify(
+            {
+                "success": True,
+                "definition": result.get("definition", ""),
+                "pos_type": result.get("pos_type", ""),
+                "pos_subtype": result.get("pos_subtype", ""),
+                "suggested_difficulty_level": max_level,
+            }
+        )
+
+    except Exception as e:
+        return jsonify({"success": False, "error": str(e)})
+
+
+# ============================================================================
+# REST API v1 - Read-only endpoints for external consumption
+# ============================================================================

--- a/src/barsukas/routes/api/v1.py
+++ b/src/barsukas/routes/api/v1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-"""API routes for AJAX requests and REST API endpoints.
+"""REST API v1 routes for external and automation consumption.
 
 MIRRORED: routes annotated with ``@mirrored_facade`` have a typed Python
 wrapper in the root-level ``api/`` package (``api/lemmas.py``,
@@ -19,7 +19,7 @@ from clients.audio.azure_tts import AzureVoice
 from clients.audio.google_tts import GoogleTtsVoice
 from clients.audio.gpt_voices import GptVoice
 from clients.audio.polly_tts import PollyVoice
-from flask import Blueprint, Response, g, jsonify, request
+from flask import Response, g, jsonify, request
 from flask.typing import ResponseReturnValue
 from sqlalchemy import and_, case, func, or_
 from audioshoe.coqui.types import CoquiVoice
@@ -52,158 +52,7 @@ from storage.translation_helpers import (
     get_translation_pronunciations,
 )
 from workqueue.task_queue import TaskStatus, TaskType, enqueue_task
-
-bp = Blueprint("api", __name__, url_prefix="/api")
-
-
-@bp.route("/check_lemma_exists")
-def check_lemma_exists() -> ResponseReturnValue:
-    """Check if a lemma exists or find similar lemmas."""
-    search = request.args.get("search", "").strip()
-    pos_type = request.args.get("pos_type", "").strip()
-
-    if not search:
-        return jsonify({"exact_match": None, "similar_matches": []})
-
-    # Check for exact match
-    exact_query = g.db.query(Lemma).filter(func.lower(Lemma.lemma_text) == search.lower())
-    if pos_type:
-        exact_query = exact_query.filter(Lemma.pos_type == pos_type)
-
-    exact_match = exact_query.first()
-
-    # Find similar matches (case-insensitive LIKE search)
-    similar_query = g.db.query(Lemma).filter(Lemma.lemma_text.ilike(f"%{search}%"))
-
-    # If exact match found, exclude it from similar matches
-    if exact_match:
-        similar_query = similar_query.filter(Lemma.id != exact_match.id)
-
-    similar_matches = similar_query.limit(5).all()
-
-    return jsonify(
-        {
-            "exact_match": (
-                {
-                    "id": exact_match.id,
-                    "lemma_text": exact_match.lemma_text,
-                    "pos_type": exact_match.pos_type,
-                    "definition_text": exact_match.definition_text,
-                }
-                if exact_match
-                else None
-            ),
-            "similar_matches": [
-                {
-                    "id": lemma.id,
-                    "lemma_text": lemma.lemma_text,
-                    "pos_type": lemma.pos_type,
-                    "definition_text": lemma.definition_text,
-                }
-                for lemma in similar_matches
-            ],
-        }
-    )
-
-
-@bp.route("/auto_populate_lemma")
-def auto_populate_lemma() -> ResponseReturnValue:
-    """Auto-populate lemma fields using LLM based on word and optional translation."""
-    word = request.args.get("word", "").strip()
-    translation = request.args.get("translation", "").strip()
-    lang_code = request.args.get("lang_code", "").strip()
-
-    if not word:
-        return jsonify({"success": False, "error": "Word is required"})
-
-    try:
-        # Use LLM to generate definition, POS type, and POS subtype
-        from wordfreq.translation.client import LinguisticClient
-
-        client = LinguisticClient(model="gpt-5.4-mini", db_path=Config.DB_PATH, debug=Config.DEBUG)
-
-        # Build prompt for LLM
-        if translation and lang_code:
-            context = f'English word: "{word}"\n{lang_code.upper()} translation: "{translation}"'
-        else:
-            context = f'English word: "{word}"'
-
-        prompt = f"""Analyze this word and provide its linguistic properties:
-
-{context}
-
-Provide:
-1. A clear, concise definition (1-2 sentences)
-2. Part of speech (pos_type): Choose from: noun, verb, adjective, adverb, pronoun, preposition, conjunction, interjection, determiner, numeral
-3. Part of speech subtype (pos_subtype): Choose the most appropriate:
-   - For nouns: animal, body_part, building_structure, clothing_accessory, concept_idea, emotion_feeling, food, beverage, furniture, vehicle, plant, plant_part, human, material_substance, nationality, natural_feature, personal_name, place_name, small_movable_object, temporal_name, time_period, tool_machine, unit_of_measurement
-   - For verbs: physical_action, creation_action, destruction_action, mental_state, emotional_state, perception, communication, possession, existence, development, change, directional_movement, manner_movement
-   - For adjectives: size, color, shape, texture, personal_quality, condition, quality, aesthetic, importance, origin, purpose, material, indefinite_quantity, duration, frequency, sequence
-   - For adverbs: style, attitude, specific_time, relative_time, duration, direction, location, distance, intensity, completeness, approximation, definite_frequency, indefinite_frequency
-   - For numerals: cardinal, ordinal
-   - For other POS: use appropriate subtype or "other"
-
-The definition should be suitable for language learners."""
-
-        # Define schema for structured output
-        from clients.types import Schema, SchemaProperty
-
-        schema = Schema(
-            name="LemmaProperties",
-            description="Linguistic properties of a word",
-            properties={
-                "definition": SchemaProperty(
-                    type="string",
-                    description="Clear, concise definition of the word (1-2 sentences)",
-                ),
-                "pos_type": SchemaProperty(type="string", description="Part of speech type"),
-                "pos_subtype": SchemaProperty(type="string", description="Part of speech subtype"),
-            },
-        )
-
-        response = client.client.generate_chat(
-            prompt=prompt, model="gpt-5.4-mini", json_schema=schema, timeout=30
-        )
-
-        if not response.structured_data:
-            return jsonify(
-                {"success": False, "error": "Failed to get structured response from LLM"}
-            )
-
-        result = response.structured_data
-
-        # Get the maximum difficulty level for this pos_subtype
-        max_level = None
-        if result.get("pos_subtype"):
-            max_level_query = (
-                g.db.query(func.max(Lemma.difficulty_level))
-                .filter(
-                    Lemma.pos_subtype == result["pos_subtype"],
-                    Lemma.difficulty_level.isnot(None),
-                    Lemma.difficulty_level != -1,  # Exclude "excluded" words
-                )
-                .scalar()
-            )
-            if max_level_query:
-                max_level = int(max_level_query)
-
-        return jsonify(
-            {
-                "success": True,
-                "definition": result.get("definition", ""),
-                "pos_type": result.get("pos_type", ""),
-                "pos_subtype": result.get("pos_subtype", ""),
-                "suggested_difficulty_level": max_level,
-            }
-        )
-
-    except Exception as e:
-        return jsonify({"success": False, "error": str(e)})
-
-
-# ============================================================================
-# REST API v1 - Read-only endpoints for external consumption
-# ============================================================================
+from barsukas.routes.api import bp
 
 
 @bp.route("/v1")


### PR DESCRIPTION
### Motivation
- Separate the public REST `/api/v1` surface from HTML/AJAX-oriented API handlers to make the codebase easier to navigate and maintain.
- Provide a package layout under `src/barsukas/routes/api/` so route groups can be split into focused modules while sharing a single `/api` blueprint.

### Description
- Added `src/barsukas/routes/api/__init__.py` which defines the shared `bp` blueprint and imports submodules to register routes on that blueprint.
- Moved non-`/v1` AJAX/HTML endpoints (e.g., `check_lemma_exists`, `auto_populate_lemma`) into `src/barsukas/routes/api/html.py` and adjusted imports to use the shared `bp`.
- Moved all REST `/api/v1` endpoints into `src/barsukas/routes/api/v1.py` and updated module imports to reference the shared blueprint.
- Preserved route paths and handler logic; this is a structural refactor only and keeps mirroring annotations (`@mirrored_facade`) intact where present.

### Testing
- Ran code formatting with `black src/barsukas/routes/api` and it completed successfully.
- Ran static typing checks with `PYTHONPATH=src mypy src/barsukas/routes/api/__init__.py src/barsukas/routes/api/html.py src/barsukas/routes/api/v1.py` and there were no issues reported.
- No other automated tests were modified or run as part of this refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02069e92388327a3c06d337057a183)