### PR TITLE
Gate sentence Phase 3 on translation breadth + drop CJK substring match

### DIFF
--- a/src/sentences/candidate_lookup.py
+++ b/src/sentences/candidate_lookup.py
@@ -20,7 +20,6 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from langtools.tokenizer import tokenize
-from sentences.analysis import SUBSTRING_MATCH_LANGUAGES
 from storage.models.schema import DerivativeForm, Lemma, LemmaTranslation, SentenceTranslation
 from storage.translation_helpers import LANGUAGE_FIELDS, get_translation
 
@@ -39,15 +38,19 @@ _PUNCTUATION_STRIP = ".,!?;:\"'()[]{}—-…"
 
 
 def _forms_match(token: str, lemma_form: str, language_code: str) -> bool:
-    """Case-insensitive exact match; substring containment for CJK scripts."""
-    token_lower = token.lower()
-    lemma_lower = lemma_form.lower()
-    if token_lower == lemma_lower:
-        return True
-    if language_code in SUBSTRING_MATCH_LANGUAGES:
-        if token in lemma_form or lemma_form in token:
-            return True
-    return False
+    """Case-insensitive exact match in every language.
+
+    We previously allowed substring containment for CJK (``SUBSTRING_MATCH_LANGUAGES``)
+    as a fallback for jieba mis-segmentation, but single-character function
+    words like ``的`` then matched hundreds of unrelated lemmas whose
+    translations happened to contain that character, drowning out real
+    candidates. Exact match across the board trades that for occasional
+    false negatives on compound CJK tokens, which is the correct tradeoff
+    here. The ``language_code`` parameter is retained for callers but no
+    longer affects matching.
+    """
+    del language_code  # no longer used; retained in signature for callers
+    return token.lower() == lemma_form.lower()
 
 
 @dataclass
@@ -103,27 +106,21 @@ def _find_candidate_lemmas_in_language(
     if field_info is not None:
         _field_name, _display, use_translation_table = field_info
         if use_translation_table:
-            if language_code in SUBSTRING_MATCH_LANGUAGES:
-                # CJK: ask SQL for "field contains token"; the opposite
-                # direction ("token contains field") is recovered at scoring
-                # time and via derivative-form / other-language matches.
-                trans_rows = (
-                    session.query(LemmaTranslation.lemma_id)
-                    .filter(
-                        LemmaTranslation.language_code == language_code,
-                        LemmaTranslation.translation.like(f"%{token}%"),
-                    )
-                    .all()
+            # Exact match in every language. CJK previously used substring
+            # LIKE here, but single-character function-word tokens (e.g. zh
+            # ``的``, ``了``, ``是``) matched hundreds of unrelated lemmas
+            # whose translations happened to contain that character, drowning
+            # out real candidates. The cost is occasional false negatives
+            # when jieba returns a compound like ``好朋友`` and the DB only
+            # has ``朋友`` — acceptable to keep the candidate list clean.
+            trans_rows = (
+                session.query(LemmaTranslation.lemma_id)
+                .filter(
+                    LemmaTranslation.language_code == language_code,
+                    func.lower(LemmaTranslation.translation) == token,
                 )
-            else:
-                trans_rows = (
-                    session.query(LemmaTranslation.lemma_id)
-                    .filter(
-                        LemmaTranslation.language_code == language_code,
-                        func.lower(LemmaTranslation.translation) == token,
-                    )
-                    .all()
-                )
+                .all()
+            )
             trans_lemma_ids = {row[0] for row in trans_rows}
             if trans_lemma_ids:
                 direct = session.query(Lemma).filter(Lemma.id.in_(trans_lemma_ids)).all()
@@ -139,26 +136,17 @@ def _find_candidate_lemmas_in_language(
                     seen_ids.add(lemma.id)
                     out.append(lemma)
 
-    # DerivativeForm match for this language.
-    if language_code in SUBSTRING_MATCH_LANGUAGES:
-        form_rows = (
-            session.query(DerivativeForm.lemma_id, DerivativeForm.derivative_form_text)
-            .filter(DerivativeForm.language_code == language_code)
-            .all()
+    # DerivativeForm match for this language. Exact match across the board
+    # (see _forms_match for why CJK no longer substring-matches).
+    form_rows = (
+        session.query(DerivativeForm.lemma_id, DerivativeForm.derivative_form_text)
+        .filter(
+            DerivativeForm.language_code == language_code,
+            func.lower(DerivativeForm.derivative_form_text) == token,
         )
-        form_lemma_ids = {
-            row[0] for row in form_rows if row[1] and _forms_match(token, row[1], language_code)
-        }
-    else:
-        form_rows = (
-            session.query(DerivativeForm.lemma_id, DerivativeForm.derivative_form_text)
-            .filter(
-                DerivativeForm.language_code == language_code,
-                func.lower(DerivativeForm.derivative_form_text) == token,
-            )
-            .all()
-        )
-        form_lemma_ids = {row[0] for row in form_rows}
+        .all()
+    )
+    form_lemma_ids = {row[0] for row in form_rows}
 
     new_ids = form_lemma_ids - seen_ids
     if new_ids:

--- a/src/sentences/translate_and_decompose.py
+++ b/src/sentences/translate_and_decompose.py
@@ -623,8 +623,71 @@ def translate_and_decompose(
         return result
     result.translations = translations
 
+    decompose_with_existing_translations(
+        sentence_text=sentence_text,
+        source_language=normalized_source,
+        translations=translations,
+        session=session,
+        client=client,
+        decompose_languages=decompose_languages,
+        model=model,
+        result=result,
+    )
+    return result
+
+
+# Minimum number of languages (counting the source) that must have a sentence
+# translation before Phase 3 will run. Phase 2 candidate-lemma ranking is much
+# weaker with fewer languages, and Phase 3 with few candidates yields mostly
+# synthetic GUIDs that can't be paired to real lemmas.
+PHASE3_MIN_LANGUAGES: int = 3
+
+
+def decompose_with_existing_translations(
+    *,
+    sentence_text: str,
+    source_language: str,
+    translations: Dict[str, str],
+    session: Session,
+    client: UnifiedLLMClient,
+    decompose_languages: Optional[Sequence[str]] = None,
+    model: str = DEFAULT_MODEL,
+    result: Optional[TranslateAndDecomposeResult] = None,
+) -> TranslateAndDecomposeResult:
+    """Run Phase 2 (candidate lookup) + Phase 3 (decomposition) against a set of
+    already-known sentence translations.
+
+    Intended for the synchronous path that persists Phase-1 translations to the
+    database before invoking Phase 3, and for any caller that has obtained
+    translations through some other route (e.g. the OpenAI Batch flow).
+
+    ``translations`` is ``{language_code: text}`` and must NOT include the
+    source language (the source sentence is added internally from
+    ``sentence_text``).
+
+    Enforces two preconditions before running Phase 3:
+      1. At least :data:`PHASE3_MIN_LANGUAGES` languages must be available
+         (counting the source). With fewer than that, candidate-lemma scoring
+         is too weak to disambiguate per-word entries.
+      2. At least one candidate lemma must be returned by Phase 2. If the DB
+         has no lemmas matching any token, Phase 3 would only produce synthetic
+         GUIDs that can't be paired to real lemmas.
+
+    If a precondition fails, every requested ``decompose_languages`` entry is
+    populated with ``DecomposedLanguage(success=False, error=...)`` and Phase 3
+    is skipped. The returned result still has ``phase1_ok`` true (Phase 1 ran)
+    and the candidate lemmas (possibly empty) for diagnostics.
+    """
+    normalized_source = source_language.strip().lower()
+
+    if result is None:
+        result = TranslateAndDecomposeResult(
+            source_sentence=sentence_text,
+            source_language=normalized_source,
+        )
+        result.translations = dict(translations)
+
     # ── Phase 2 ────────────────────────────────────────────────────────────
-    # Source language pool: every translation we have plus the source itself.
     lookup_translations: Dict[str, str] = dict(translations)
     if normalized_source not in lookup_translations:
         lookup_translations[normalized_source] = sentence_text
@@ -641,6 +704,36 @@ def translate_and_decompose(
         languages_to_decompose: List[str] = ["en"]
     else:
         languages_to_decompose = [lang.strip().lower() for lang in decompose_languages if lang]
+
+    available_language_count = len(lookup_translations)
+    precondition_error: Optional[str] = None
+    if available_language_count < PHASE3_MIN_LANGUAGES:
+        precondition_error = (
+            f"Phase 3 requires at least {PHASE3_MIN_LANGUAGES} languages; "
+            f"only {available_language_count} available "
+            f"({sorted(lookup_translations.keys())})"
+        )
+    elif not result.candidate_lemmas:
+        precondition_error = (
+            "Phase 3 requires at least one candidate lemma from Phase 2; "
+            "none of the sentence tokens matched any known lemma"
+        )
+
+    if precondition_error is not None:
+        logger.warning("Skipping Phase 3: %s", precondition_error)
+        for skipped_language in languages_to_decompose:
+            skipped_translation = (
+                sentence_text
+                if skipped_language == normalized_source
+                else translations.get(skipped_language, "")
+            )
+            result.decompositions[skipped_language] = DecomposedLanguage(
+                language_code=skipped_language,
+                translation=skipped_translation,
+                success=False,
+                error=precondition_error,
+            )
+        return result
 
     all_known: Dict[str, str] = dict(translations)
     if normalized_source not in all_known:

--- a/src/sentences/translation.py
+++ b/src/sentences/translation.py
@@ -119,7 +119,12 @@ def translate_sentence(
         produced this call (includes English when it was missing). Per-language
         word breakdowns are persisted to ``SentenceWord`` as a side effect.
     """
-    from sentences.translate_and_decompose import translate_and_decompose
+    from sentences.candidate_lookup import DEFAULT_SOURCE_LANGUAGES
+    from sentences.translate_and_decompose import (
+        TranslateAndDecomposeResult,
+        decompose_with_existing_translations,
+        translate_sentence_text,
+    )
 
     sentence = session.query(Sentence).get(sentence_id)
     if not sentence:
@@ -144,28 +149,63 @@ def translate_sentence(
     # Phase 1 must not retranslate the source language back to itself.
     phase1_targets = [lang for lang in normalized_targets_all if lang != source_language]
 
+    # Add candidate-lookup pivots to Phase 1 so Phase 2 has enough languages to
+    # rank lemmas against (PHASE3_MIN_LANGUAGES precondition in
+    # translate_and_decompose).
+    phase1_languages: List[str] = list(phase1_targets)
+    seen_phase1: set[str] = {source_language, *phase1_languages}
+    for pivot in DEFAULT_SOURCE_LANGUAGES:
+        if pivot not in seen_phase1:
+            phase1_languages.append(pivot)
+            seen_phase1.add(pivot)
+
     # Phase 3 should decompose every language the caller asked for, including
     # the source language: callers requesting "decompose lt" for an LT-source
     # sentence still want LT SentenceWord rows produced from the existing
-    # source translation. translate_and_decompose handles a decompose_languages
-    # entry that has no Phase 1 translation by falling back to the source text.
+    # source translation. decompose_with_existing_translations handles a
+    # decompose_languages entry that has no Phase 1 translation by falling back
+    # to the source text.
     decompose_languages: List[str] = list(normalized_targets_all)
     if include_english and "en" not in decompose_languages and source_language != "en":
         decompose_languages.append("en")
 
     client = UnifiedLLMClient()
-    pipeline_result = translate_and_decompose(
-        sentence_text=source_translation.translation_text,
+    source_text = source_translation.translation_text
+
+    # ── Phase 1: translate, then PERSIST before Phase 3 ────────────────────
+    phase1_translations = translate_sentence_text(
+        sentence_text=source_text,
         source_language=source_language,
-        session=session,
+        target_languages=phase1_languages,
         client=client,
-        target_languages=phase1_targets,
-        decompose_languages=decompose_languages,
         model=model,
     )
+    if not phase1_translations:
+        raise ValueError("Phase 1 translation produced no results")
 
-    if not pipeline_result.phase1_ok:
-        raise ValueError(pipeline_result.phase1_error or "Phase 1 translation failed")
+    # Persist Phase 1 translations (SentenceTranslation rows only) and commit
+    # before Phase 3. This way the explicit batch decompose path's precondition
+    # is satisfied on retry, and a Phase-3 failure doesn't lose the Phase-1
+    # work.
+    _persist_phase1_translations(sentence_id, phase1_translations, session)
+
+    # ── Phase 2 + Phase 3 ─────────────────────────────────────────────────
+    pipeline_result = TranslateAndDecomposeResult(
+        source_sentence=source_text,
+        source_language=source_language,
+    )
+    pipeline_result.translations = dict(phase1_translations)
+
+    decompose_with_existing_translations(
+        sentence_text=source_text,
+        source_language=source_language,
+        translations=phase1_translations,
+        session=session,
+        client=client,
+        decompose_languages=decompose_languages,
+        model=model,
+        result=pipeline_result,
+    )
 
     translations: Dict[str, Any] = dict(pipeline_result.translations)
 
@@ -188,6 +228,44 @@ def translate_sentence(
 
     store_translation_results(sentence_id, translations, session)
     return translations
+
+
+def _persist_phase1_translations(
+    sentence_id: int,
+    translations: Dict[str, str],
+    session: Session,
+) -> None:
+    """Insert/update SentenceTranslation rows for Phase-1 outputs and commit.
+
+    Used by the synchronous decompose path so Phase-1 work survives a Phase-3
+    failure and so the DB state matches what the explicit two-phase OpenAI
+    Batch flow produces.
+    """
+    for lang_code, translation_text in translations.items():
+        if not isinstance(translation_text, str) or not translation_text.strip():
+            continue
+        existing = (
+            session.query(SentenceTranslation)
+            .filter_by(sentence_id=sentence_id, language_code=lang_code)
+            .first()
+        )
+        if existing:
+            existing.translation_text = translation_text
+        else:
+            session.add(
+                SentenceTranslation(
+                    sentence_id=sentence_id,
+                    language_code=lang_code,
+                    translation_text=translation_text,
+                    verified=False,
+                )
+            )
+    session.commit()
+    logger.info(
+        "Persisted Phase-1 translations for sentence %d: %s",
+        sentence_id,
+        sorted(translations.keys()),
+    )
 
 
 def _adapt_decomposed_word(word_entry: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
Phase 3 (per-word decomposition) previously ran even when Phase 2 had no candidate lemmas to anchor against, producing breakdowns full of synthetic SYN_* GUIDs that could not be paired to real database lemmas. It also ran when only the source language was available, which gave Phase 2 nothing to score against.

Refuse to run Phase 3 unless:
  - at least 3 languages have a sentence translation (counting source), and
  - Phase 2 returned at least one candidate lemma.

On precondition failure, each requested decompose language is recorded as DecomposedLanguage(success=False, error=...) and the task fails per-language rather than silently producing useless output.

Also split the synchronous translate_sentence path so Phase 1 translations are committed before Phase 3 runs: a Phase-3 failure no longer loses the Phase-1 work, and the DB state on the sync path now matches what the explicit two-phase OpenAI Batch flow produces.

Separately, drop CJK substring matching in candidate_lookup. Single-character function-word tokens (zh ``的``, ``了``, ``是``...) were matching hundreds of unrelated lemmas via SQL ``LIKE '%X%'``, swamping the DEFAULT_MAX_CANDIDATES=30 cap and pushing real matches like ``朋友`` -> N01_059 off the candidate list entirely. Exact match across the board trades occasional false negatives on jieba-segmented compounds for a clean candidate list.