### PR TITLE
start of "Trakaido"-themed screens

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -76,6 +76,7 @@ from barsukas.routes import (
     sentences,
     settings,
     strings_export,
+    trakaido,
     translations,
     wireword,
 )
@@ -229,6 +230,7 @@ def create_app(
     app.register_blueprint(rapid_review_hub.bp)
     app.register_blueprint(settings.bp)
     app.register_blueprint(strings_export.bp)
+    app.register_blueprint(trakaido.bp)
     app.register_blueprint(pattern_sentences.bp)
     app.register_blueprint(peleda.bp)
     app.register_blueprint(rhymes.bp)

--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -274,6 +274,18 @@ def view_sentence(sentence_id: int) -> Union[str, Response]:
         if sw.language_code not in entry["surfaces"]:
             entry["surfaces"][sw.language_code] = sw.target_language_text
 
+    # Function-word POS types: extra occurrences in just a few languages
+    # (e.g. an extra "from" in 1/9 languages) are usually noise, not signal.
+    function_word_pos_types = {
+        "preposition",
+        "conjunction",
+        "article",
+        "determiner",
+        "interjection",
+        "particle",
+    }
+    most_threshold = n_decomposed - miss_threshold
+
     lemmas_used: list[dict[str, Any]] = []
     for entry in lemma_usage.values():
         present = set(entry["surfaces"].keys())
@@ -281,9 +293,9 @@ def view_sentence(sentence_id: int) -> Union[str, Response]:
         count = len(present)
         entry["language_count"] = count
         entry["missing_languages"] = missing
-        entry["flag_missing"] = (
-            0 < len(missing) <= miss_threshold and count >= n_decomposed - miss_threshold
-        )
+        entry["flag_missing"] = 0 < len(missing) <= miss_threshold and count >= most_threshold
+        if entry["lemma"].pos_type in function_word_pos_types and count < most_threshold:
+            continue
         lemmas_used.append(entry)
     lemmas_used.sort(key=lambda e: (-e["language_count"], e["lemma_display_text"] or ""))
 

--- a/src/barsukas/routes/trakaido.py
+++ b/src/barsukas/routes/trakaido.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python3
+
+"""Trakaido views served directly by Barsukas.
+
+The first activity is a sentence comparison view: pick a sentence and render
+it in two languages — an "interface language" the user already knows (defaults
+to English) and a "foreign language" they are studying (defaults to Lithuanian).
+
+When the interface language is English, words in the foreign sentence are
+rendered with their English glosses underneath (using SentenceWord.english_text).
+A second block always shows the two sentences in their original word order with
+matched lemmas connected by lines and shared colors.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from flask import Blueprint, abort, g, redirect, render_template, request, url_for
+from flask.typing import ResponseReturnValue
+from sqlalchemy import func
+
+from storage.models.schema import (
+    AudioQualityReview,
+    Sentence,
+    SentenceWord,
+)
+from storage.translation_helpers import get_supported_languages
+
+bp = Blueprint("trakaido", __name__, url_prefix="/trakaido")
+
+
+DEFAULT_INTERFACE_LANG = "en"
+DEFAULT_FOREIGN_LANG = "lt"
+
+
+def _parse_language_params() -> Tuple[str, str]:
+    """Read interface/foreign language codes from the query string."""
+    supported = set(get_supported_languages().keys())
+    interface_lang = (request.args.get("interface_lang") or DEFAULT_INTERFACE_LANG).strip().lower()
+    foreign_lang = (request.args.get("foreign_lang") or DEFAULT_FOREIGN_LANG).strip().lower()
+    if interface_lang not in supported:
+        interface_lang = DEFAULT_INTERFACE_LANG
+    if foreign_lang not in supported:
+        foreign_lang = DEFAULT_FOREIGN_LANG
+    return interface_lang, foreign_lang
+
+
+def _pick_random_sentence_id(interface_lang: str, foreign_lang: str) -> Optional[int]:
+    """Pick a random non-rejected sentence with SentenceWord rows in both languages."""
+    sub_iface = g.db.query(SentenceWord.sentence_id).filter(
+        SentenceWord.language_code == interface_lang
+    )
+    sub_foreign = g.db.query(SentenceWord.sentence_id).filter(
+        SentenceWord.language_code == foreign_lang
+    )
+    row = (
+        g.db.query(Sentence.id)
+        .filter(Sentence.rejected == False)  # noqa: E712
+        .filter(Sentence.id.in_(sub_iface))
+        .filter(Sentence.id.in_(sub_foreign))
+        .order_by(func.random())
+        .limit(1)
+        .first()
+    )
+    return row[0] if row else None
+
+
+# Tokens within grammatical_form features (post `pos/{lang}_` prefix) mapped to full words.
+_GRAM_TOKEN_LABELS: Dict[str, str] = {
+    # Case
+    "nominative": "nominative",
+    "accusative": "accusative",
+    "genitive": "genitive",
+    "dative": "dative",
+    "instrumental": "instrumental",
+    "locative": "locative",
+    "vocative": "vocative",
+    "ablative": "ablative",
+    # Number
+    "singular": "singular",
+    "plural": "plural",
+    # Gender
+    "m": "masculine",
+    "f": "feminine",
+    "n": "neuter",
+    "masculine": "masculine",
+    "feminine": "feminine",
+    "neuter": "neuter",
+    # Tense / aspect / mood
+    "present": "present",
+    "past": "past",
+    "future": "future",
+    "imperf": "imperfect",
+    "imperfect": "imperfect",
+    "perfect": "perfect",
+    "subjunctive": "subjunctive",
+    "imperative": "imperative",
+    "conditional": "conditional",
+    "participle": "participle",
+    "gerund": "gerund",
+    "inf": "infinitive",
+    "infinitive": "infinitive",
+    "reflexive": "reflexive",
+    "possessive": "possessive",
+    "cardinal": "cardinal",
+    "ordinal": "ordinal",
+    "base": "",
+    "pres": "present",
+    "fut": "future",
+    "objective": "objective",
+    "subjective": "subjective",
+}
+
+_PERSON_NUMBER_TOKENS: Dict[str, str] = {
+    "1s": "1st person singular",
+    "2s": "2nd person singular",
+    "3s": "3rd person singular",
+    "1p": "1st person plural",
+    "2p": "2nd person plural",
+    "3p": "3rd person plural",
+}
+
+# Skip drawing connector lines when either side exceeds this word count.
+_MAX_WORDS_FOR_LINES = 10
+
+
+def _format_grammatical_label(form: Optional[str], lang: str) -> Optional[str]:
+    """Turn 'noun/lt_accusative_singular_m' into 'acc. sg. masc.' etc."""
+    if not form:
+        return None
+    if "/" not in form:
+        return None
+    _, _, features = form.partition("/")
+    prefix = f"{lang}_"
+    if features.startswith(prefix):
+        features = features[len(prefix) :]
+    elif features == lang:
+        features = ""
+    if not features or features == "base":
+        return None
+    labels: List[str] = []
+    for tok in features.split("_"):
+        if not tok:
+            continue
+        if tok in _PERSON_NUMBER_TOKENS:
+            labels.append(_PERSON_NUMBER_TOKENS[tok])
+        elif tok in _GRAM_TOKEN_LABELS:
+            mapped = _GRAM_TOKEN_LABELS[tok]
+            if mapped:
+                labels.append(mapped)
+        else:
+            labels.append(tok)
+    if not labels:
+        return None
+    return " ".join(labels)
+
+
+def _word_payload(w: SentenceWord, lang: str) -> Dict[str, Any]:
+    return {
+        "position": w.position,
+        "text": w.target_language_text,
+        "gloss": w.english_text,
+        "lemma_id": w.lemma_id,
+        "role": w.word_role,
+        "form": w.grammatical_form,
+        "gram_label": _format_grammatical_label(w.grammatical_form, lang),
+    }
+
+
+# Rank for keeping pairs when we cap the colored set; lower number = higher priority.
+_ROLE_PRIORITY: Dict[str, int] = {
+    "verb": 0,
+    "noun": 1,
+    "subject": 1,
+    "object": 1,
+    "adjective": 2,
+    "adverb": 3,
+    "numeral": 4,
+    "pronoun": 5,
+    "article": 6,
+    "preposition": 6,
+    "conjunction": 7,
+    "particle": 7,
+    "other": 8,
+}
+
+_MAX_COLORED_PAIRS = 4
+
+
+def _role_rank(role: Optional[str]) -> int:
+    return _ROLE_PRIORITY.get(role or "", 9)
+
+
+def _assign_pair_keys(
+    iface_words: List[Dict[str, Any]], foreign_words: List[Dict[str, Any]]
+) -> None:
+    """Annotate words with 'pair_key' / 'pair_index' for cross-language coloring.
+
+    Pairs are matched strictly by shared lemma_id (function words without a
+    lemma never pair up). We then rank candidate pairs by the best role on
+    either side (content words like verb/noun outrank pronouns/conjunctions)
+    and keep at most _MAX_COLORED_PAIRS. Words outside the kept set get
+    pair_key=None, pair_index=None and render without color.
+    """
+    for w in iface_words:
+        w["pair_key"] = None
+        w["pair_index"] = None
+    for w in foreign_words:
+        w["pair_key"] = None
+        w["pair_index"] = None
+
+    iface_by_lemma: Dict[int, List[Dict[str, Any]]] = {}
+    for w in iface_words:
+        if w["lemma_id"] is not None:
+            iface_by_lemma.setdefault(w["lemma_id"], []).append(w)
+    foreign_by_lemma: Dict[int, List[Dict[str, Any]]] = {}
+    for w in foreign_words:
+        if w["lemma_id"] is not None:
+            foreign_by_lemma.setdefault(w["lemma_id"], []).append(w)
+
+    shared_lemmas = set(iface_by_lemma.keys()) & set(foreign_by_lemma.keys())
+
+    candidates: List[Tuple[int, int, int]] = []  # (role_rank, first_position, lemma_id)
+    for lemma_id in shared_lemmas:
+        best_rank = min(
+            _role_rank(w["role"]) for w in iface_by_lemma[lemma_id] + foreign_by_lemma[lemma_id]
+        )
+        first_pos = min(w["position"] for w in iface_by_lemma[lemma_id])
+        candidates.append((best_rank, first_pos, lemma_id))
+
+    candidates.sort()
+
+    for index, (_rank, _pos, lemma_id) in enumerate(candidates[:_MAX_COLORED_PAIRS]):
+        key = f"lemma:{lemma_id}"
+        for w in iface_by_lemma[lemma_id] + foreign_by_lemma[lemma_id]:
+            w["pair_key"] = key
+            w["pair_index"] = index
+
+
+_AUDIO_STATUS_PRIORITY = {
+    "approved": 0,
+    "approved_with_issues": 1,
+    "pending_review": 2,
+    "needs_replacement": 3,
+}
+
+
+def _pick_sentence_audio(sentence_id: int, language_code: str) -> Optional[AudioQualityReview]:
+    """Return the best available audio review for this sentence/language, or None."""
+    reviews = (
+        g.db.query(AudioQualityReview)
+        .filter(AudioQualityReview.sentence_id == sentence_id)
+        .filter(AudioQualityReview.language_code == language_code)
+        .all()
+    )
+    if not reviews:
+        return None
+    reviews.sort(key=lambda r: (_AUDIO_STATUS_PRIORITY.get(r.status, 99), r.id))
+    return cast(AudioQualityReview, reviews[0])
+
+
+@bp.route("/")
+def index() -> ResponseReturnValue:
+    """Trakaido landing page (lists available activities)."""
+    return render_template("trakaido/index.html")
+
+
+@bp.route("/compare")
+def compare_random() -> ResponseReturnValue:
+    """Pick a random eligible sentence and redirect to its canonical compare URL."""
+    interface_lang, foreign_lang = _parse_language_params()
+    sentence_id = _pick_random_sentence_id(interface_lang, foreign_lang)
+    if sentence_id is None:
+        return render_template(
+            "trakaido/compare.html",
+            sentence=None,
+            interface_words=[],
+            foreign_words=[],
+            interface_lang=interface_lang,
+            foreign_lang=foreign_lang,
+            supported_languages=get_supported_languages(),
+            show_gloss_block=False,
+            show_lines=False,
+            foreign_audio_url=None,
+            foreign_audio_voice=None,
+            no_results=True,
+        )
+    return redirect(
+        url_for(
+            "trakaido.compare",
+            sentence_id=sentence_id,
+            interface_lang=interface_lang,
+            foreign_lang=foreign_lang,
+        )
+    )
+
+
+@bp.route("/compare/<int:sentence_id>")
+def compare(sentence_id: int) -> ResponseReturnValue:
+    """Sentence comparison view."""
+    interface_lang, foreign_lang = _parse_language_params()
+
+    sentence = g.db.query(Sentence).filter(Sentence.id == sentence_id).first()
+    if sentence is None:
+        abort(404)
+
+    rows = (
+        g.db.query(SentenceWord)
+        .filter(SentenceWord.sentence_id == sentence_id)
+        .filter(SentenceWord.language_code.in_([interface_lang, foreign_lang]))
+        .order_by(SentenceWord.language_code, SentenceWord.position)
+        .all()
+    )
+
+    interface_words = [
+        _word_payload(w, interface_lang) for w in rows if w.language_code == interface_lang
+    ]
+    foreign_words = [
+        _word_payload(w, foreign_lang) for w in rows if w.language_code == foreign_lang
+    ]
+    interface_words.sort(key=lambda w: w["position"])
+    foreign_words.sort(key=lambda w: w["position"])
+
+    _assign_pair_keys(interface_words, foreign_words)
+
+    foreign_audio = _pick_sentence_audio(sentence_id, foreign_lang)
+    foreign_audio_url: Optional[str] = None
+    if foreign_audio is not None:
+        foreign_audio_url = url_for(
+            "audio.serve_audio_file",
+            language=foreign_audio.language_code,
+            voice=foreign_audio.voice_name,
+            filename=foreign_audio.filename,
+        )
+
+    return render_template(
+        "trakaido/compare.html",
+        sentence=sentence,
+        interface_words=interface_words,
+        foreign_words=foreign_words,
+        interface_lang=interface_lang,
+        foreign_lang=foreign_lang,
+        supported_languages=get_supported_languages(),
+        show_gloss_block=(interface_lang == "en"),
+        show_lines=(
+            len(interface_words) <= _MAX_WORDS_FOR_LINES
+            and len(foreign_words) <= _MAX_WORDS_FOR_LINES
+        ),
+        foreign_audio_url=foreign_audio_url,
+        foreign_audio_voice=foreign_audio.voice_name if foreign_audio else None,
+        no_results=False,
+    )

--- a/src/barsukas/routes/trakaido.py
+++ b/src/barsukas/routes/trakaido.py
@@ -20,6 +20,9 @@ from sqlalchemy import func
 
 from storage.models.schema import (
     AudioQualityReview,
+    DerivativeForm,
+    Lemma,
+    LemmaTranslation,
     Sentence,
     SentenceWord,
 )
@@ -348,4 +351,177 @@ def compare(sentence_id: int) -> ResponseReturnValue:
         foreign_audio_url=foreign_audio_url,
         foreign_audio_voice=foreign_audio.voice_name if foreign_audio else None,
         no_results=False,
+    )
+
+
+def _lemma_translation_for_language(
+    lemma: Lemma, lang: str
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return (text, definition, disambiguation) for the lemma in `lang`.
+
+    English data lives on the Lemma itself; other languages come from
+    LemmaTranslation rows.
+    """
+    if lang == "en":
+        return lemma.lemma_text, lemma.definition_text, None
+    row = (
+        g.db.query(LemmaTranslation)
+        .filter(LemmaTranslation.lemma_id == lemma.id)
+        .filter(LemmaTranslation.language_code == lang)
+        .first()
+    )
+    if row is None:
+        return None, None, None
+    return row.translation, row.definition_text, row.disambiguation
+
+
+def _pick_lemma_audio(lemma_id: int, language_code: str) -> Optional[AudioQualityReview]:
+    """Return the best available lemma audio review for this language, or None."""
+    reviews = (
+        g.db.query(AudioQualityReview)
+        .filter(AudioQualityReview.lemma_id == lemma_id)
+        .filter(AudioQualityReview.language_code == language_code)
+        .filter(AudioQualityReview.sentence_id.is_(None))
+        .all()
+    )
+    if not reviews:
+        return None
+    reviews.sort(key=lambda r: (_AUDIO_STATUS_PRIORITY.get(r.status, 99), r.id))
+    return cast(AudioQualityReview, reviews[0])
+
+
+_LEMMA_SEARCH_LIMIT = 50
+
+
+def _form_order_key(lang: str, pos_type: Optional[str], grammatical_form: str) -> Tuple[int, str]:
+    """Return a sort key giving canonical order for grammatical forms in (lang, pos).
+
+    Falls back to alphabetical for unknown (lang, pos) or unknown forms.
+    """
+    if pos_type is None:
+        return (10_000, grammatical_form)
+    try:
+        from langtools.form_registry import FORM_SPECS
+    except ImportError:
+        return (10_000, grammatical_form)
+    spec = FORM_SPECS.get((lang, pos_type))
+    if spec is None:
+        return (10_000, grammatical_form)
+    enum_to_index = {
+        spec.form_mapping[field_name].value: idx
+        for idx, field_name in enumerate(spec.form_fields)
+        if field_name in spec.form_mapping
+    }
+    idx = enum_to_index.get(grammatical_form)
+    if idx is None:
+        return (10_000, grammatical_form)
+    return (idx, grammatical_form)
+
+
+@bp.route("/lemma/")
+def lemma_search() -> ResponseReturnValue:
+    """Search page for picking a lemma to open in the Trakaido lemma view."""
+    interface_lang, foreign_lang = _parse_language_params()
+    search = (request.args.get("search") or "").strip()
+
+    results: List[Dict[str, Any]] = []
+    if search:
+        like = f"%{search}%"
+        en_matches = (
+            g.db.query(Lemma)
+            .filter(Lemma.lemma_text.ilike(like))
+            .order_by(Lemma.lemma_text)
+            .limit(_LEMMA_SEARCH_LIMIT)
+            .all()
+        )
+        translation_matches = (
+            g.db.query(Lemma)
+            .join(LemmaTranslation, LemmaTranslation.lemma_id == Lemma.id)
+            .filter(LemmaTranslation.translation.ilike(like))
+            .filter(LemmaTranslation.language_code.in_([interface_lang, foreign_lang]))
+            .order_by(Lemma.lemma_text)
+            .limit(_LEMMA_SEARCH_LIMIT)
+            .all()
+        )
+        seen: set[int] = set()
+        for lemma in list(en_matches) + list(translation_matches):
+            if lemma.id in seen:
+                continue
+            seen.add(lemma.id)
+            results.append(
+                {
+                    "id": lemma.id,
+                    "lemma_text": lemma.lemma_text,
+                    "definition_text": lemma.definition_text,
+                    "pos_type": lemma.pos_type,
+                    "disambiguation": lemma.disambiguation,
+                }
+            )
+            if len(results) >= _LEMMA_SEARCH_LIMIT:
+                break
+
+    return render_template(
+        "trakaido/lemma_search.html",
+        search=search,
+        results=results,
+        interface_lang=interface_lang,
+        foreign_lang=foreign_lang,
+        supported_languages=get_supported_languages(),
+    )
+
+
+@bp.route("/lemma/<int:lemma_id>")
+def lemma_view(lemma_id: int) -> ResponseReturnValue:
+    """Trakaido lemma view: details + foreign forms + foreign audio."""
+    interface_lang, foreign_lang = _parse_language_params()
+
+    lemma = g.db.query(Lemma).filter(Lemma.id == lemma_id).first()
+    if lemma is None:
+        abort(404)
+
+    iface_text, iface_definition, iface_disambiguation = _lemma_translation_for_language(
+        lemma, interface_lang
+    )
+    foreign_text, foreign_definition, foreign_disambiguation = _lemma_translation_for_language(
+        lemma, foreign_lang
+    )
+
+    foreign_forms = list(
+        g.db.query(DerivativeForm)
+        .filter(DerivativeForm.lemma_id == lemma_id)
+        .filter(DerivativeForm.language_code == foreign_lang)
+        .all()
+    )
+    foreign_forms.sort(
+        key=lambda f: (
+            not f.is_base_form,
+            _form_order_key(foreign_lang, lemma.pos_type, f.grammatical_form or ""),
+        )
+    )
+
+    foreign_audio = _pick_lemma_audio(lemma_id, foreign_lang)
+    foreign_audio_url: Optional[str] = None
+    if foreign_audio is not None:
+        foreign_audio_url = url_for(
+            "audio.serve_audio_file",
+            language=foreign_audio.language_code,
+            voice=foreign_audio.voice_name,
+            filename=foreign_audio.filename,
+        )
+
+    return render_template(
+        "trakaido/lemma.html",
+        lemma=lemma,
+        interface_lang=interface_lang,
+        foreign_lang=foreign_lang,
+        supported_languages=get_supported_languages(),
+        interface_text=iface_text,
+        interface_definition=iface_definition,
+        interface_disambiguation=iface_disambiguation,
+        foreign_text=foreign_text,
+        foreign_definition=foreign_definition,
+        foreign_disambiguation=foreign_disambiguation,
+        foreign_forms=foreign_forms,
+        foreign_audio_url=foreign_audio_url,
+        foreign_audio_voice=foreign_audio.voice_name if foreign_audio else None,
     )

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -1,0 +1,337 @@
+/* Trakaido views — styled to echo the Trakaido React app palette
+   (primary blue #0095ff family, clean card-based layout). */
+
+:root {
+    --tk-primary: #0095ff;
+    --tk-primary-hover: #0085f3;
+    --tk-primary-dark: #0056a4;
+    --tk-bg: #f5f7fa;
+    --tk-card-bg: #ffffff;
+    --tk-text: #1a1a1a;
+    --tk-text-muted: #6b7280;
+    --tk-border: #e5e7eb;
+    --tk-radius: 10px;
+    --tk-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.trakaido-page {
+    max-width: 1100px;
+    margin: 1.5rem auto;
+    padding: 0 1rem;
+    color: var(--tk-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.trakaido-header,
+.trakaido-hero {
+    margin-bottom: 1.5rem;
+}
+
+.trakaido-hero h1,
+.trakaido-header h1 {
+    margin: 0 0 0.25rem 0;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--tk-primary-dark);
+}
+
+.trakaido-subtitle,
+.trakaido-meta {
+    color: var(--tk-text-muted);
+    font-size: 0.95rem;
+}
+
+.trakaido-source {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+}
+
+/* Activity grid (landing) */
+.trakaido-activity-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1rem;
+}
+
+.trakaido-activity-card {
+    display: block;
+    background: var(--tk-card-bg);
+    border: 1px solid var(--tk-border);
+    border-radius: var(--tk-radius);
+    padding: 1.25rem;
+    box-shadow: var(--tk-shadow);
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.1s ease, box-shadow 0.1s ease, border-color 0.1s ease;
+}
+
+.trakaido-activity-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--tk-primary);
+    box-shadow: 0 4px 10px rgba(0, 149, 255, 0.12);
+    color: inherit;
+    text-decoration: none;
+}
+
+.trakaido-activity-icon {
+    font-size: 1.75rem;
+    color: var(--tk-primary);
+    margin-bottom: 0.5rem;
+}
+
+.trakaido-activity-card h2 {
+    margin: 0 0 0.25rem 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.trakaido-activity-card p {
+    margin: 0;
+    color: var(--tk-text-muted);
+    font-size: 0.9rem;
+}
+
+/* Controls bar */
+.trakaido-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: 0.75rem;
+    background: var(--tk-card-bg);
+    border: 1px solid var(--tk-border);
+    border-radius: var(--tk-radius);
+    padding: 0.9rem 1rem;
+    margin-bottom: 1.25rem;
+    box-shadow: var(--tk-shadow);
+}
+
+.trakaido-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    color: var(--tk-text-muted);
+}
+
+.trakaido-control select {
+    min-width: 180px;
+    padding: 0.4rem 0.55rem;
+    border: 1px solid var(--tk-border);
+    border-radius: 6px;
+    background: #fff;
+    font-size: 0.95rem;
+    color: var(--tk-text);
+}
+
+.trakaido-button {
+    padding: 0.5rem 1rem;
+    background: var(--tk-primary);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.1s ease;
+}
+
+.trakaido-button:hover {
+    background: var(--tk-primary-hover);
+}
+
+/* Card sections */
+.trakaido-card {
+    background: var(--tk-card-bg);
+    border: 1px solid var(--tk-border);
+    border-radius: var(--tk-radius);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+    box-shadow: var(--tk-shadow);
+}
+
+.trakaido-section-title {
+    margin: 0 0 1rem 0;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--tk-text-muted);
+}
+
+.trakaido-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.trakaido-section-header .trakaido-section-title {
+    margin: 0;
+}
+
+.trakaido-audio-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    background: var(--tk-primary);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.1s ease, transform 0.08s ease;
+}
+
+.trakaido-audio-button:hover {
+    background: var(--tk-primary-hover);
+}
+
+.trakaido-audio-button.is-playing {
+    background: var(--tk-primary-dark);
+}
+
+.trakaido-audio-icon {
+    font-size: 0.7rem;
+    line-height: 1;
+}
+
+/* Glossed (per-word) block */
+.trakaido-gloss-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.trakaido-gloss-words {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    flex: 1;
+}
+
+.trakaido-glossed-word {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.25;
+    min-width: 2rem;
+}
+
+.trakaido-glossed-native {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--tk-text);
+}
+
+.trakaido-glossed-gloss {
+    font-size: 0.9rem;
+    color: var(--tk-primary-dark);
+    margin-top: 0.15rem;
+}
+
+/* Side-by-side comparison with connecting lines */
+.trakaido-compare {
+    position: relative;
+    padding: 0.5rem 0;
+}
+
+.trakaido-compare-row {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.5rem 0;
+}
+
+.trakaido-compare-words {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    flex: 1;
+    min-height: 2rem;
+    align-items: center;
+}
+
+.trakaido-lines {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.tk-chip-stack {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.15;
+}
+
+.tk-chip-gram {
+    margin-top: 0.1rem;
+    font-size: 0.72rem;
+    color: var(--tk-text-muted);
+    font-style: italic;
+    letter-spacing: 0.01em;
+    min-height: 1em;
+    white-space: pre;
+}
+
+/* Word chips — colored text on a barely-there tinted background. */
+.tk-chip {
+    display: inline-block;
+    padding: 0.2rem 0.5rem;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--tk-text);
+    font-size: 1.05rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+    transition: background 0.08s ease, border-color 0.08s ease;
+}
+
+.tk-chip-active {
+    border-color: currentColor;
+}
+
+/* 12-color pair palette: saturated text color + very low-saturation tint. */
+.tk-pair-0  { color: #c43a3a; background: rgba(196, 58, 58, 0.07); }
+.tk-pair-1  { color: #c46a1a; background: rgba(196, 106, 26, 0.07); }
+.tk-pair-2  { color: #9b8a0c; background: rgba(155, 138, 12, 0.08); }
+.tk-pair-3  { color: #5a8a1a; background: rgba(90, 138, 26, 0.07); }
+.tk-pair-4  { color: #1f8a5a; background: rgba(31, 138, 90, 0.07); }
+.tk-pair-5  { color: #1a7a99; background: rgba(26, 122, 153, 0.07); }
+.tk-pair-6  { color: #2a5fbf; background: rgba(42, 95, 191, 0.07); }
+.tk-pair-7  { color: #6b3fbf; background: rgba(107, 63, 191, 0.07); }
+.tk-pair-8  { color: #a1399f; background: rgba(161, 57, 159, 0.07); }
+.tk-pair-9  { color: #b03060; background: rgba(176, 48, 96, 0.08); }
+.tk-pair-10 { color: #4a6a2a; background: rgba(74, 106, 42, 0.08); }
+.tk-pair-11 { color: #4a5a6a; background: rgba(74, 90, 106, 0.07); }
+
+.trakaido-lang-tag {
+    flex-shrink: 0;
+    display: inline-block;
+    min-width: 2.25rem;
+    padding: 0.15rem 0.5rem;
+    background: var(--tk-primary);
+    color: white;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-align: center;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.trakaido-empty {
+    padding: 1.5rem;
+    background: var(--tk-card-bg);
+    border: 1px dashed var(--tk-border);
+    border-radius: var(--tk-radius);
+    color: var(--tk-text-muted);
+    text-align: center;
+}

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -352,3 +352,122 @@
     color: var(--tk-text-muted);
     text-align: center;
 }
+
+/* Lemma view */
+.trakaido-lemma-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+@media (max-width: 720px) {
+    .trakaido-lemma-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.trakaido-lemma-cell {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.trakaido-lemma-text {
+    font-size: 1.6rem;
+    font-weight: 600;
+    color: var(--tk-text);
+}
+
+.trakaido-lemma-disambig {
+    color: var(--tk-text-muted);
+    font-style: italic;
+}
+
+.trakaido-lemma-definition {
+    color: var(--tk-text);
+    line-height: 1.4;
+}
+
+.trakaido-empty-inline {
+    color: var(--tk-text-muted);
+    font-style: italic;
+}
+
+.trakaido-forms-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+}
+
+.trakaido-forms-table th,
+.trakaido-forms-table td {
+    text-align: left;
+    padding: 0.4rem 0.6rem;
+    border-bottom: 1px solid var(--tk-border);
+}
+
+.trakaido-forms-table th {
+    color: var(--tk-text-muted);
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.trakaido-forms-table code {
+    background: var(--tk-bg);
+    padding: 0.05rem 0.3rem;
+    border-radius: 3px;
+    font-size: 0.85rem;
+}
+
+/* Lemma search results */
+.trakaido-result-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.trakaido-result {
+    padding: 0.65rem 0;
+    border-bottom: 1px solid var(--tk-border);
+}
+
+.trakaido-result:last-child {
+    border-bottom: none;
+}
+
+.trakaido-result a {
+    color: var(--tk-primary-dark);
+    text-decoration: none;
+    font-size: 1.05rem;
+}
+
+.trakaido-result a:hover {
+    text-decoration: underline;
+}
+
+.trakaido-result-disambig {
+    color: var(--tk-text-muted);
+    margin-left: 0.35rem;
+    font-size: 0.9rem;
+}
+
+.trakaido-result-pos {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.05rem 0.45rem;
+    background: var(--tk-bg);
+    border: 1px solid var(--tk-border);
+    border-radius: 4px;
+    font-size: 0.75rem;
+    color: var(--tk-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.trakaido-result-def {
+    color: var(--tk-text-muted);
+    font-size: 0.9rem;
+    margin-top: 0.2rem;
+}

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -231,6 +231,23 @@
     margin-top: 0.15rem;
 }
 
+.trakaido-glossed-link {
+    text-decoration: none;
+    color: inherit;
+    border-radius: 6px;
+    padding: 0.15rem 0.3rem;
+    margin: -0.15rem -0.3rem;
+    transition: background-color 0.12s ease;
+}
+
+.trakaido-glossed-link:hover {
+    background-color: rgba(0, 149, 255, 0.08);
+}
+
+.trakaido-glossed-link:hover .trakaido-glossed-native {
+    color: var(--tk-primary);
+}
+
 /* Side-by-side comparison with connecting lines */
 .trakaido-compare {
     position: relative;

--- a/src/barsukas/static/js/trakaido_audio.js
+++ b/src/barsukas/static/js/trakaido_audio.js
@@ -1,0 +1,40 @@
+(function () {
+    "use strict";
+
+    function setupAudio() {
+        var buttons = document.querySelectorAll(".trakaido-audio-button[data-audio-url]");
+        if (!buttons.length) return;
+        var audio = new Audio();
+        var current = null;
+        audio.addEventListener("ended", function () {
+            if (current) current.classList.remove("is-playing");
+            current = null;
+        });
+        buttons.forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                var url = btn.getAttribute("data-audio-url");
+                if (!url) return;
+                if (current === btn && !audio.paused) {
+                    audio.pause();
+                    btn.classList.remove("is-playing");
+                    current = null;
+                    return;
+                }
+                if (current) current.classList.remove("is-playing");
+                audio.src = url;
+                audio.play().then(function () {
+                    btn.classList.add("is-playing");
+                    current = btn;
+                }).catch(function () {
+                    btn.classList.remove("is-playing");
+                });
+            });
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", setupAudio);
+    } else {
+        setupAudio();
+    }
+})();

--- a/src/barsukas/static/js/trakaido_compare.js
+++ b/src/barsukas/static/js/trakaido_compare.js
@@ -1,0 +1,124 @@
+(function () {
+    "use strict";
+
+    function draw() {
+        var container = document.getElementById("tk-compare");
+        var svg = document.getElementById("tk-lines");
+        if (!container || !svg) return;
+
+        var rect = container.getBoundingClientRect();
+        var width = rect.width;
+        var height = rect.height;
+        svg.setAttribute("width", width);
+        svg.setAttribute("height", height);
+        svg.setAttribute("viewBox", "0 0 " + width + " " + height);
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+
+        var ifaceRow = container.querySelector('[data-row="interface"]');
+        var foreignRow = container.querySelector('[data-row="foreign"]');
+        if (!ifaceRow || !foreignRow) return;
+
+        var ifaceChips = ifaceRow.querySelectorAll(".tk-chip");
+        var foreignChips = foreignRow.querySelectorAll(".tk-chip");
+
+        var foreignByKey = {};
+        foreignChips.forEach(function (chip) {
+            var key = chip.getAttribute("data-pair-key");
+            if (key) {
+                if (!foreignByKey[key]) foreignByKey[key] = [];
+                foreignByKey[key].push(chip);
+            }
+        });
+
+        ifaceChips.forEach(function (chip) {
+            var key = chip.getAttribute("data-pair-key");
+            if (!key || !foreignByKey[key]) return;
+            var partners = foreignByKey[key];
+            var color = window.getComputedStyle(chip).color;
+            partners.forEach(function (partner) {
+                drawLine(svg, container, chip, partner, color);
+            });
+        });
+    }
+
+    function drawLine(svg, container, a, b, color) {
+        var cRect = container.getBoundingClientRect();
+        var aRect = a.getBoundingClientRect();
+        var bRect = b.getBoundingClientRect();
+        var x1 = aRect.left + aRect.width / 2 - cRect.left;
+        var y1 = aRect.bottom - cRect.top;
+        var x2 = bRect.left + bRect.width / 2 - cRect.left;
+        var y2 = bRect.top - cRect.top;
+        var midY = (y1 + y2) / 2;
+        var path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+        var d = "M " + x1 + " " + y1 +
+                " C " + x1 + " " + midY + ", " + x2 + " " + midY + ", " + x2 + " " + y2;
+        path.setAttribute("d", d);
+        path.setAttribute("stroke", color);
+        path.setAttribute("stroke-width", "2");
+        path.setAttribute("fill", "none");
+        path.setAttribute("opacity", "0.6");
+        svg.appendChild(path);
+    }
+
+    function setupHover() {
+        var chips = document.querySelectorAll("#tk-compare .tk-chip[data-pair-key]");
+        chips.forEach(function (chip) {
+            chip.addEventListener("mouseenter", function () {
+                var key = chip.getAttribute("data-pair-key");
+                if (!key) return;
+                document.querySelectorAll('#tk-compare .tk-chip[data-pair-key="' + key + '"]')
+                    .forEach(function (c) { c.classList.add("tk-chip-active"); });
+            });
+            chip.addEventListener("mouseleave", function () {
+                document.querySelectorAll("#tk-compare .tk-chip-active")
+                    .forEach(function (c) { c.classList.remove("tk-chip-active"); });
+            });
+        });
+    }
+
+    function setupAudio() {
+        var buttons = document.querySelectorAll(".trakaido-audio-button[data-audio-url]");
+        if (!buttons.length) return;
+        var audio = new Audio();
+        var current = null;
+        audio.addEventListener("ended", function () {
+            if (current) current.classList.remove("is-playing");
+            current = null;
+        });
+        buttons.forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                var url = btn.getAttribute("data-audio-url");
+                if (!url) return;
+                if (current === btn && !audio.paused) {
+                    audio.pause();
+                    btn.classList.remove("is-playing");
+                    current = null;
+                    return;
+                }
+                if (current) current.classList.remove("is-playing");
+                audio.src = url;
+                audio.play().then(function () {
+                    btn.classList.add("is-playing");
+                    current = btn;
+                }).catch(function () {
+                    btn.classList.remove("is-playing");
+                });
+            });
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", function () {
+            draw(); setupHover(); setupAudio();
+        });
+    } else {
+        draw();
+        setupHover();
+        setupAudio();
+    }
+    window.addEventListener("resize", draw);
+    if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(draw);
+    }
+})();

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -116,6 +116,9 @@
                             <li><a class="dropdown-item" href="{{ url_for('trakaido.compare_random') }}">
                                 <i class="bi bi-arrow-left-right"></i> Sentence Comparison
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido.lemma_search') }}">
+                                <i class="bi bi-book"></i> Lemma View
+                            </a></li>
                         </ul>
                     </li>
                     {% if not config.get('READONLY', False) %}

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -107,6 +107,17 @@
                             </a></li>
                         </ul>
                     </li>
+                    <!-- Trakaido dropdown -->
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                            <i class="bi bi-translate"></i> Trakaido
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-dark">
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido.compare_random') }}">
+                                <i class="bi bi-arrow-left-right"></i> Sentence Comparison
+                            </a></li>
+                        </ul>
+                    </li>
                     {% if not config.get('READONLY', False) %}
                     <!-- Sync dropdown (hidden in read-only/golden mode where DB is the release files) -->
                     <li class="nav-item dropdown">

--- a/src/barsukas/templates/trakaido/compare.html
+++ b/src/barsukas/templates/trakaido/compare.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+
+{% block title %}Sentence Comparison · Trakaido{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% macro word_chip(w) -%}
+<span class="tk-chip{% if w.pair_index is not none %} tk-pair-{{ w.pair_index % 12 }}{% endif %}"
+      data-pair-key="{{ w.pair_key or '' }}">{{ w.text or '—' }}</span>
+{%- endmacro %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-header">
+        <h1>Sentence Comparison</h1>
+        {% if sentence %}
+        <div class="trakaido-meta">
+            Sentence #{{ sentence.id }}
+            {% if sentence.source_filename %} · <span class="trakaido-source">{{ sentence.source_filename }}</span>{% endif %}
+            {% if sentence.minimum_level is not none %} · level {{ sentence.minimum_level }}{% endif %}
+        </div>
+        {% endif %}
+    </div>
+
+    <form class="trakaido-controls" method="get" action="{{ url_for('trakaido.compare_random') }}">
+        <label class="trakaido-control">
+            <span>Interface language</span>
+            <select name="interface_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == interface_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label class="trakaido-control">
+            <span>Foreign language</span>
+            <select name="foreign_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == foreign_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button class="trakaido-button" type="submit">New random sentence</button>
+    </form>
+
+    {% if no_results %}
+    <div class="trakaido-empty">
+        No sentences are available with decompositions in both
+        <strong>{{ interface_lang }}</strong> and <strong>{{ foreign_lang }}</strong>.
+    </div>
+    {% elif sentence %}
+
+    {% if show_gloss_block %}
+    <section class="trakaido-card">
+        <div class="trakaido-section-header">
+            <h2 class="trakaido-section-title">Word-by-word gloss</h2>
+            {% if foreign_audio_url %}
+            <button type="button" class="trakaido-audio-button" data-audio-url="{{ foreign_audio_url }}"
+                    {% if foreign_audio_voice %}title="Play audio ({{ foreign_audio_voice }})"{% else %}title="Play audio"{% endif %}>
+                <span class="trakaido-audio-icon">▶</span>
+                <span>Play {{ foreign_lang|upper }}</span>
+            </button>
+            {% endif %}
+        </div>
+        <div class="trakaido-gloss-row">
+            <span class="trakaido-lang-tag">{{ foreign_lang }}</span>
+            <div class="trakaido-gloss-words">
+                {% for w in foreign_words %}
+                <div class="trakaido-glossed-word">
+                    <div class="trakaido-glossed-native">{{ w.text or '—' }}</div>
+                    <div class="trakaido-glossed-gloss">{{ w.gloss or '—' }}</div>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    {% endif %}
+
+    <section class="trakaido-card">
+        <div class="trakaido-section-header">
+            <h2 class="trakaido-section-title">Side-by-side comparison</h2>
+            {% if foreign_audio_url and not show_gloss_block %}
+            <button type="button" class="trakaido-audio-button" data-audio-url="{{ foreign_audio_url }}"
+                    {% if foreign_audio_voice %}title="Play audio ({{ foreign_audio_voice }})"{% else %}title="Play audio"{% endif %}>
+                <span class="trakaido-audio-icon">▶</span>
+                <span>Play {{ foreign_lang|upper }}</span>
+            </button>
+            {% endif %}
+        </div>
+        <div class="trakaido-compare" id="tk-compare">
+            <div class="trakaido-compare-row" data-row="interface">
+                <span class="trakaido-lang-tag">{{ interface_lang }}</span>
+                <div class="trakaido-compare-words">
+                    {% for w in interface_words %}{{ word_chip(w) }}{% endfor %}
+                </div>
+            </div>
+            {% if show_lines %}
+            <svg class="trakaido-lines" id="tk-lines" aria-hidden="true"></svg>
+            {% endif %}
+            <div class="trakaido-compare-row" data-row="foreign">
+                <span class="trakaido-lang-tag">{{ foreign_lang }}</span>
+                <div class="trakaido-compare-words">
+                    {% for w in foreign_words %}
+                    <div class="tk-chip-stack">
+                        {{ word_chip(w) }}
+                        <span class="tk-chip-gram">{{ w.gram_label or ' ' }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/trakaido_compare.js') }}"></script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/compare.html
+++ b/src/barsukas/templates/trakaido/compare.html
@@ -67,10 +67,20 @@
             <span class="trakaido-lang-tag">{{ foreign_lang }}</span>
             <div class="trakaido-gloss-words">
                 {% for w in foreign_words %}
+                {% if w.lemma_id %}
+                <a class="trakaido-glossed-word trakaido-glossed-link"
+                   href="{{ url_for('lemmas.view_lemma', lemma_id=w.lemma_id) }}"
+                   target="_blank" rel="noopener"
+                   title="View lemma">
+                    <div class="trakaido-glossed-native">{{ w.text or '—' }}</div>
+                    <div class="trakaido-glossed-gloss">{{ w.gloss or '—' }}</div>
+                </a>
+                {% else %}
                 <div class="trakaido-glossed-word">
                     <div class="trakaido-glossed-native">{{ w.text or '—' }}</div>
                     <div class="trakaido-glossed-gloss">{{ w.gloss or '—' }}</div>
                 </div>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>

--- a/src/barsukas/templates/trakaido/index.html
+++ b/src/barsukas/templates/trakaido/index.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Trakaido{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-hero">
+        <h1>Trakaido</h1>
+        <p class="trakaido-subtitle">Language-learning activities, served from Barsukas.</p>
+    </div>
+
+    <div class="trakaido-activity-grid">
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido.compare_random') }}">
+            <div class="trakaido-activity-icon">↔</div>
+            <h2>Sentence Comparison</h2>
+            <p>Word-by-word interlinear view of a random sentence in two languages.</p>
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/index.html
+++ b/src/barsukas/templates/trakaido/index.html
@@ -19,6 +19,11 @@
             <h2>Sentence Comparison</h2>
             <p>Word-by-word interlinear view of a random sentence in two languages.</p>
         </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido.lemma_search') }}">
+            <div class="trakaido-activity-icon">📖</div>
+            <h2>Lemma View</h2>
+            <p>Look up a lemma to see its translation, forms, and audio in two languages.</p>
+        </a>
     </div>
 </div>
 {% endblock %}

--- a/src/barsukas/templates/trakaido/lemma.html
+++ b/src/barsukas/templates/trakaido/lemma.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+
+{% block title %}{{ lemma.lemma_text }} · Trakaido{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-header">
+        <h1>{{ foreign_text or lemma.lemma_text }}</h1>
+        <div class="trakaido-meta">
+            Lemma #{{ lemma.id }}
+            {% if lemma.pos_type %} · {{ lemma.pos_type }}{% if lemma.pos_subtype %} ({{ lemma.pos_subtype }}){% endif %}{% endif %}
+            {% if lemma.disambiguation %} · <em>{{ lemma.disambiguation }}</em>{% endif %}
+        </div>
+    </div>
+
+    <form class="trakaido-controls" method="get" action="{{ url_for('trakaido.lemma_view', lemma_id=lemma.id) }}">
+        <label class="trakaido-control">
+            <span>Interface language</span>
+            <select name="interface_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == interface_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label class="trakaido-control">
+            <span>Foreign language</span>
+            <select name="foreign_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == foreign_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button class="trakaido-button" type="submit">Update</button>
+    </form>
+
+    <section class="trakaido-card">
+        <div class="trakaido-section-header">
+            <h2 class="trakaido-section-title">Lemma</h2>
+            {% if foreign_audio_url %}
+            <button type="button" class="trakaido-audio-button" data-audio-url="{{ foreign_audio_url }}"
+                    {% if foreign_audio_voice %}title="Play audio ({{ foreign_audio_voice }})"{% else %}title="Play audio"{% endif %}>
+                <span class="trakaido-audio-icon">▶</span>
+                <span>Play {{ foreign_lang|upper }}</span>
+            </button>
+            {% endif %}
+        </div>
+
+        <div class="trakaido-lemma-grid">
+            <div class="trakaido-lemma-cell">
+                <div class="trakaido-lang-tag">{{ foreign_lang }}</div>
+                {% if foreign_text %}
+                    <div class="trakaido-lemma-text">{{ foreign_text }}</div>
+                    {% if foreign_disambiguation %}
+                        <div class="trakaido-lemma-disambig">({{ foreign_disambiguation }})</div>
+                    {% endif %}
+                    {% if foreign_definition %}
+                        <div class="trakaido-lemma-definition">{{ foreign_definition }}</div>
+                    {% endif %}
+                {% else %}
+                    <div class="trakaido-empty-inline">No translation in {{ foreign_lang }}.</div>
+                {% endif %}
+            </div>
+
+            <div class="trakaido-lemma-cell">
+                <div class="trakaido-lang-tag">{{ interface_lang }}</div>
+                {% if interface_text %}
+                    <div class="trakaido-lemma-text">{{ interface_text }}</div>
+                    {% if interface_disambiguation %}
+                        <div class="trakaido-lemma-disambig">({{ interface_disambiguation }})</div>
+                    {% endif %}
+                    {% if interface_definition %}
+                        <div class="trakaido-lemma-definition">{{ interface_definition }}</div>
+                    {% endif %}
+                {% else %}
+                    <div class="trakaido-empty-inline">No translation in {{ interface_lang }}.</div>
+                {% endif %}
+            </div>
+        </div>
+    </section>
+
+    {% if foreign_forms %}
+    <section class="trakaido-card">
+        <div class="trakaido-section-header">
+            <h2 class="trakaido-section-title">Forms in {{ supported_languages.get(foreign_lang, foreign_lang) }}</h2>
+        </div>
+        <table class="trakaido-forms-table">
+            <thead>
+                <tr>
+                    <th>Form</th>
+                    <th>Grammatical form</th>
+                    <th>IPA</th>
+                    <th>Base</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for form in foreign_forms %}
+                {% set _gf = form.grammatical_form or '' %}
+                {% set _features = _gf.split('/', 1)[1] if '/' in _gf else _gf %}
+                {% set _prefix = foreign_lang ~ '_' %}
+                {% if _features.startswith(_prefix) %}{% set _features = _features[_prefix|length:] %}{% endif %}
+                <tr>
+                    <td><strong>{{ form.derivative_form_text }}</strong></td>
+                    <td>{{ _features.replace('_', ' ') }}</td>
+                    <td>{{ form.ipa_pronunciation or '—' }}</td>
+                    <td>{% if form.is_base_form %}✓{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/trakaido_audio.js') }}"></script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/lemma_search.html
+++ b/src/barsukas/templates/trakaido/lemma_search.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}Find a Lemma · Trakaido{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-header">
+        <h1>Find a Lemma</h1>
+        <div class="trakaido-meta">Search by English text or by translation in the chosen languages.</div>
+    </div>
+
+    <form class="trakaido-controls" method="get" action="{{ url_for('trakaido.lemma_search') }}">
+        <label class="trakaido-control">
+            <span>Search</span>
+            <input type="text" name="search" value="{{ search }}" autofocus>
+        </label>
+        <label class="trakaido-control">
+            <span>Interface language</span>
+            <select name="interface_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == interface_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label class="trakaido-control">
+            <span>Foreign language</span>
+            <select name="foreign_lang">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == foreign_lang %}selected{% endif %}>{{ name }} ({{ code }})</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button class="trakaido-button" type="submit">Search</button>
+    </form>
+
+    {% if search and not results %}
+    <div class="trakaido-empty">No lemmas match <strong>{{ search }}</strong>.</div>
+    {% elif results %}
+    <section class="trakaido-card">
+        <div class="trakaido-section-header">
+            <h2 class="trakaido-section-title">Results</h2>
+        </div>
+        <ul class="trakaido-result-list">
+            {% for r in results %}
+            <li class="trakaido-result">
+                <a href="{{ url_for('trakaido.lemma_view', lemma_id=r.id, interface_lang=interface_lang, foreign_lang=foreign_lang) }}">
+                    <strong>{{ r.lemma_text }}</strong>
+                    {% if r.disambiguation %}<em class="trakaido-result-disambig">({{ r.disambiguation }})</em>{% endif %}
+                    {% if r.pos_type %}<span class="trakaido-result-pos">{{ r.pos_type }}</span>{% endif %}
+                </a>
+                {% if r.definition_text %}
+                <div class="trakaido-result-def">{{ r.definition_text }}</div>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+    </section>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Some per-sentence activities more naturally live as directly-served HTML pages rather than a data-export to allow a client app to generate the activities.  This starts the process of building these.

(( Brand divisions TBD ))