### PR TITLE
Support .xcstrings upload/export, add Veidrodis agent, and update GYVATE UI

### DIFF
--- a/src/agents/veidrodis/__init__.py
+++ b/src/agents/veidrodis/__init__.py
@@ -1,0 +1,5 @@
+"""VEIDRODIS agent package."""
+
+from agents.veidrodis.agent import VeidrodisAgent, VeidrodisRunResult
+
+__all__ = ["VeidrodisAgent", "VeidrodisRunResult"]

--- a/src/agents/veidrodis/agent.py
+++ b/src/agents/veidrodis/agent.py
@@ -1,0 +1,65 @@
+"""VEIDRODIS agent for generating Barsukas base STRINGS files from templates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from strings import generate_barsukas_strings as barsukas_generator
+
+
+@dataclass(frozen=True)
+class VeidrodisRunResult:
+    replacements_total: int
+    templates_changed: int
+    new_key_count: int
+    reused_common_count: int
+    collisions_resolved: int
+
+
+@dataclass
+class VeidrodisAgent:
+    """Generate or update base Barsukas string catalogs and template references."""
+
+    def run(
+        self, *, templates_root: str, strings_root: str, write_mode: bool
+    ) -> VeidrodisRunResult:
+        original_templates_root = barsukas_generator.TEMPLATES_ROOT
+        original_strings_root = barsukas_generator.STRINGS_ROOT
+        original_namespace_alias = barsukas_generator.NAMESPACE_ALIAS
+        try:
+            barsukas_generator.TEMPLATES_ROOT = Path(templates_root).resolve()
+            barsukas_generator.STRINGS_ROOT = Path(strings_root).resolve()
+            barsukas_generator.NAMESPACE_ALIAS = {}
+            (
+                template_plans,
+                standard_catalog_state,
+                _cstr_catalog_state,
+                standard_stats,
+                _cstr_stats,
+            ) = barsukas_generator.compute_plan()
+
+            if write_mode:
+                for template_file, replacements in template_plans.items():
+                    original_content = template_file.read_text(encoding="utf-8")
+                    updated_content = barsukas_generator.apply_replacements(
+                        original_content, replacements
+                    )
+                    template_file.write_text(updated_content, encoding="utf-8")
+                standard_catalog_state.write()
+
+            replacements_total = sum(len(items) for items in template_plans.values())
+            return VeidrodisRunResult(
+                replacements_total=replacements_total,
+                templates_changed=len(template_plans),
+                new_key_count=standard_stats.new_key_count,
+                reused_common_count=standard_stats.reused_common_count,
+                collisions_resolved=standard_stats.collisions_resolved,
+            )
+        finally:
+            barsukas_generator.TEMPLATES_ROOT = original_templates_root
+            barsukas_generator.STRINGS_ROOT = original_strings_root
+            barsukas_generator.NAMESPACE_ALIAS = original_namespace_alias
+
+
+__all__ = ["VeidrodisAgent", "VeidrodisRunResult"]

--- a/src/barsukas/routes/strings_export.py
+++ b/src/barsukas/routes/strings_export.py
@@ -16,7 +16,7 @@ from agents.gyvate import GyvateAgent
 from storage.backend.config import DataSourceConfig
 
 bp = Blueprint("gyvate", __name__, url_prefix="/gyvate")
-DEFAULT_SCOPES = ["templates"]
+DEFAULT_SCOPES: list[str] = []
 DEFAULT_TARGET_LANGUAGES = ["lt"]
 DEFAULT_TEMPLATE_PATH = "src/barsukas/templates"
 DEFAULT_STRINGS_PATH = "strings/barsukas"
@@ -60,6 +60,38 @@ def _parse_uploaded_catalog_json(raw_bytes: bytes, source_name: str) -> dict[str
     return {str(key_name): str(value_text) for key_name, value_text in loaded.items()}
 
 
+def _parse_uploaded_xcstrings(raw_bytes: bytes, source_name: str) -> dict[str, str]:
+    loaded = json.loads(raw_bytes.decode("utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{source_name} must contain a JSON object")
+    strings_payload = loaded.get("strings")
+    if not isinstance(strings_payload, dict):
+        raise ValueError(f'{source_name} must contain a "strings" object')
+
+    source_language = str(loaded.get("sourceLanguage") or "en")
+    extracted_catalog: dict[str, str] = {}
+    for translation_key, translation_entry in strings_payload.items():
+        if not isinstance(translation_entry, dict):
+            continue
+        localization_map = translation_entry.get("localizations")
+        if not isinstance(localization_map, dict):
+            continue
+        source_entry = localization_map.get(source_language) or localization_map.get("en")
+        if not isinstance(source_entry, dict):
+            continue
+        string_unit = source_entry.get("stringUnit")
+        if not isinstance(string_unit, dict):
+            continue
+        value_text = string_unit.get("value")
+        if not isinstance(value_text, str):
+            continue
+        extracted_catalog[str(translation_key)] = value_text
+
+    if not extracted_catalog:
+        raise ValueError(f"{source_name} did not contain extractable source-language strings")
+    return extracted_catalog
+
+
 def _load_uploaded_english_catalogs() -> dict[str, dict[str, str]]:
     uploaded_catalogs: dict[str, dict[str, str]] = {}
 
@@ -69,10 +101,15 @@ def _load_uploaded_english_catalogs() -> dict[str, dict[str, str]]:
     for uploaded_file in uploaded_files:
         assert uploaded_file.filename is not None
         namespace = _normalize_namespace_from_path(uploaded_file.filename)
-        uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
-            uploaded_file.read(),
-            uploaded_file.filename,
-        )
+        source_bytes = uploaded_file.read()
+        if uploaded_file.filename.endswith(".xcstrings"):
+            uploaded_catalogs[namespace] = _parse_uploaded_xcstrings(
+                source_bytes, uploaded_file.filename
+            )
+        else:
+            uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
+                source_bytes, uploaded_file.filename
+            )
 
     zip_bundle = request.files.get("english_strings_bundle")
     if not zip_bundle or not zip_bundle.filename:
@@ -81,14 +118,22 @@ def _load_uploaded_english_catalogs() -> dict[str, dict[str, str]]:
     zip_data = zip_bundle.read()
     with zipfile.ZipFile(BytesIO(zip_data)) as zip_handle:
         for entry_name in zip_handle.namelist():
-            if entry_name.endswith("/") or not entry_name.endswith("en.json"):
+            if entry_name.endswith("/"):
                 continue
-            namespace = _normalize_namespace_from_path(entry_name)
+            if not (entry_name.endswith("en.json") or entry_name.endswith(".xcstrings")):
+                continue
+            namespace = _normalize_namespace_from_path(entry_name.replace(".xcstrings", "/en.json"))
             with zip_handle.open(entry_name) as zip_entry:
-                uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
-                    zip_entry.read(),
-                    entry_name,
-                )
+                source_bytes = zip_entry.read()
+                if entry_name.endswith(".xcstrings"):
+                    uploaded_catalogs[namespace] = _parse_uploaded_xcstrings(
+                        source_bytes, entry_name
+                    )
+                else:
+                    uploaded_catalogs[namespace] = _parse_uploaded_catalog_json(
+                        source_bytes,
+                        entry_name,
+                    )
     return uploaded_catalogs
 
 
@@ -109,10 +154,6 @@ def export_page() -> ResponseReturnValue:
 def export_strings() -> ResponseReturnValue:
     """Run STRINGS extraction/generation via the GYVATE service layer."""
     selected_scopes = request.form.getlist("scopes")
-    if not selected_scopes:
-        flash("Select at least one scope (templates/modules).", "error")
-        return redirect(url_for("gyvate.export_page"))
-
     project_root = request.form.get("project_root", _default_project_root()).strip()
     template_path = request.form.get("template_path", DEFAULT_TEMPLATE_PATH).strip()
     strings_path = request.form.get("strings_path", DEFAULT_STRINGS_PATH).strip()

--- a/src/barsukas/templates/gyvate/export.html
+++ b/src/barsukas/templates/gyvate/export.html
@@ -6,7 +6,7 @@
 <div class="row mb-4">
     <div class="col">
         <h2><i class="bi bi-translate"></i> GYVATE STRINGS Export</h2>
-        <p class="text-muted">Generate STRINGS keys and language catalogs for Barsukas or any similarly-structured project.</p>
+        <p class="text-muted">General-purpose translation catalog generation. Optional template/module scans can be enabled for Barsukas workflows.</p>
     </div>
 </div>
 
@@ -36,9 +36,9 @@
                     <div class="mb-4">
                         <label class="form-label">Scope</label>
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="scope_templates" name="scopes" value="templates" checked>
+                            <input class="form-check-input" type="checkbox" id="scope_templates" name="scopes" value="templates">
                             <label class="form-check-label" for="scope_templates">
-                                Templates (<code>*.html</code>)
+                                Templates (<code>*.html</code> extract/replace for Barsukas LSTR/SSTR/CSTR)
                             </label>
                         </div>
                         <div class="form-check">
@@ -85,11 +85,11 @@
                             name="english_strings_files"
                             type="file"
                             multiple
-                            accept=".json"
+                            accept=".json,.xcstrings"
                         >
                         <small class="form-text text-muted">
-                            Upload one or more <code>en.json</code> files. File names may include paths like
-                            <code>common/en.json</code> to map namespaces.
+                            Upload one or more <code>en.json</code> or <code>*.xcstrings</code> files. File names may include paths like
+                            <code>common/en.json</code> (or <code>common.xcstrings</code>) to map namespaces.
                         </small>
                     </div>
 
@@ -103,7 +103,7 @@
                             accept=".zip"
                         >
                         <small class="form-text text-muted">
-                            ZIP should contain one or more <code>*/en.json</code> files. Uploaded catalogs can be used as source input for translation catalog generation.
+                            ZIP should contain one or more <code>*/en.json</code> or <code>*.xcstrings</code> files. Uploaded catalogs can be used as source input for translation catalog generation.
                         </small>
                     </div>
 

--- a/src/strings/gyvate_service.py
+++ b/src/strings/gyvate_service.py
@@ -213,7 +213,14 @@ class GyvateStringsExportService:
             barsukas_generator.TEMPLATES_ROOT = templates_root
             barsukas_generator.STRINGS_ROOT = strings_root
             barsukas_generator.NAMESPACE_ALIAS = {}
-            return barsukas_generator.compute_plan()
+            (
+                template_plans,
+                standard_catalog_state,
+                _cstr_catalog_state,
+                standard_stats,
+                _cstr_stats,
+            ) = barsukas_generator.compute_plan()
+            return (template_plans, standard_catalog_state, standard_stats)
         finally:
             barsukas_generator.TEMPLATES_ROOT = original_templates_root
             barsukas_generator.STRINGS_ROOT = original_strings_root
@@ -271,6 +278,15 @@ class GyvateStringsExportService:
                             sorted_localized_catalog, localized_handle, ensure_ascii=False, indent=2
                         )
                         localized_handle.write("\n")
+                    self._write_xcstrings_catalog(
+                        namespace_dir=namespace_dir,
+                        english_catalog={
+                            str(key_name): str(value_text)
+                            for key_name, value_text in english_catalog.items()
+                        },
+                        localized_catalog=sorted_localized_catalog,
+                        language_code=language_code,
+                    )
 
             status = "updated" if write_mode else "would-update"
             statuses.append(
@@ -299,3 +315,28 @@ class GyvateStringsExportService:
         if not barsukas_src.exists():
             return 0
         return sum(1 for _ in barsukas_src.rglob("*.py"))
+
+    def _write_xcstrings_catalog(
+        self,
+        *,
+        namespace_dir: Path,
+        english_catalog: dict[str, str],
+        localized_catalog: dict[str, str],
+        language_code: str,
+    ) -> None:
+        xcstrings_data: dict[str, Any] = {"sourceLanguage": "en", "version": "1.0", "strings": {}}
+        for key_name, english_text in english_catalog.items():
+            translated_text = localized_catalog.get(key_name, english_text)
+            xcstrings_data["strings"][key_name] = {
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": english_text}},
+                    language_code: {
+                        "stringUnit": {"state": "translated", "value": translated_text}
+                    },
+                }
+            }
+
+        xcstrings_path = namespace_dir / f"{language_code}.xcstrings"
+        with xcstrings_path.open("w", encoding="utf-8") as xcstrings_handle:
+            json.dump(xcstrings_data, xcstrings_handle, ensure_ascii=False, indent=2)
+            xcstrings_handle.write("\n")

--- a/src/tests/barsukas/routes/test_strings_export_xcstrings.py
+++ b/src/tests/barsukas/routes/test_strings_export_xcstrings.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from barsukas.routes.strings_export import _parse_uploaded_xcstrings
+from storage.backend.config import BackendType, DataSourceConfig
+from strings.gyvate_service import GyvateStringsExportService
+
+
+def test_parse_uploaded_xcstrings_extracts_source_language_strings() -> None:
+    sample_xcstrings = {
+        "sourceLanguage": "en",
+        "strings": {
+            "landing.learnLanguage": {
+                "comment": "Landing Page",
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": "Learn {targetLanguage}"}}
+                },
+            },
+            "landing.moreModes": {
+                "comment": "Landing Page",
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": "More Modes"}}
+                },
+            },
+            "landing.statistics": {
+                "comment": "Landing Page",
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": "Statistics"}}
+                },
+            },
+            "landing.studyMaterials": {
+                "comment": "Landing Page",
+                "localizations": {
+                    "en": {"stringUnit": {"state": "translated", "value": "Study Materials"}}
+                },
+            },
+        },
+        "version": "1.0",
+    }
+
+    parsed_catalog = _parse_uploaded_xcstrings(
+        json.dumps(sample_xcstrings).encode("utf-8"), "landing.xcstrings"
+    )
+
+    assert parsed_catalog["landing.learnLanguage"] == "Learn {targetLanguage}"
+    assert parsed_catalog["landing.moreModes"] == "More Modes"
+    assert parsed_catalog["landing.statistics"] == "Statistics"
+    assert parsed_catalog["landing.studyMaterials"] == "Study Materials"
+
+
+def test_export_strings_write_mode_emits_xcstrings_output(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    templates_root = project_root / "src" / "barsukas" / "templates"
+    strings_root = project_root / "strings" / "barsukas"
+    templates_root.mkdir(parents=True, exist_ok=True)
+    strings_root.mkdir(parents=True, exist_ok=True)
+
+    service = GyvateStringsExportService(
+        config=DataSourceConfig(
+            backend_type=BackendType.SQLITE, sqlite_path=str(tmp_path / "test.sqlite")
+        )
+    )
+    uploaded_catalogs = {
+        "landing": {
+            "landing.learnLanguage": "Learn {targetLanguage}",
+            "landing.moreModes": "More Modes",
+        }
+    }
+
+    result = service.export_strings(
+        project_root=str(project_root),
+        template_path="src/barsukas/templates",
+        strings_path="strings/barsukas",
+        scopes=["modules"],
+        target_languages=["lt"],
+        uploaded_english_catalogs=uploaded_catalogs,
+        write_mode=True,
+    )
+
+    assert result.success is True
+    assert (strings_root / "landing" / "lt.xcstrings").exists()


### PR DESCRIPTION
### Motivation

- Add support for Apple-style `.xcstrings` bundles as input/output so exported catalogs can interoperate with Xcode localization tools.
- Relax the GYVATE export form defaults and text to be more general-purpose and allow optional template/module scanning rather than forcing a scope selection.  
- Introduce a small service-layer agent (`VeidrodisAgent`) to generate Barsukas base STRINGS files from templates as a reusable component.

### Description

- Add a new `agents.veidrodis` package with `VeidrodisAgent` and `VeidrodisRunResult` to run Barsukas string generation via `strings.generate_barsukas_strings` with temporary path overrides.  
- Extend `barsukas/routes/strings_export.py` with `_parse_uploaded_xcstrings` and update `_load_uploaded_english_catalogs` to accept `.xcstrings` files both from direct uploads and inside ZIP bundles, using `_normalize_namespace_from_path` for namespace mapping.  
- Update the export template `barsukas/templates/gyvate/export.html` to accept `.xcstrings` in the file input, adjust copy to be more general, change the `templates` scope checkbox to be optional, and set `DEFAULT_SCOPES` to an empty list.  
- Modify `strings.gyvate_service.GyvateStringsExportService` to unpack the extended `compute_plan()` result, add `_write_xcstrings_catalog` to emit `.xcstrings` files alongside JSON when writing localized catalogs, and invoke it from `_update_target_languages`.  
- Add unit tests in `src/tests/barsukas/routes/test_strings_export_xcstrings.py` covering `_parse_uploaded_xcstrings` and verifying `.xcstrings` output is produced by the export service in write mode.  

### Testing

- Executed the new unit tests `test_parse_uploaded_xcstrings_extracts_source_language_strings` and `test_export_strings_write_mode_emits_xcstrings_output` via `pytest` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc2cb1b3c8327bf19ae0ebcec4819)