### PR TITLE
Add Wireword group label resolver and replace direct subtype formatting in export paths

### DIFF
--- a/src/wireword/export_wireword.py
+++ b/src/wireword/export_wireword.py
@@ -37,7 +37,7 @@ from wireword.readings import (
     build_target_reading_fields,
     build_target_reading_list_fields,
 )
-from wireword.text_rendering import format_subtype_display_name
+from wireword.text_rendering import resolve_group_label
 from wireword.helpers import (
     convert_to_wireword_grammatical_form_key,
     extract_conjugation_slot,
@@ -801,7 +801,9 @@ class WirewordExporter:
                 wireword.update(
                     {
                         "corpus": assigned_corpus,
-                        "group": format_subtype_display_name(entry["subtype"]),
+                        "group": resolve_group_label(
+                            entry["subtype"], self.source_language, session
+                        ),
                         "level": entry["trakaido_level"],
                         "word_type": normalize_pos_type(entry["pos_type"]),
                     }
@@ -1561,7 +1563,9 @@ class WirewordExporter:
                 wireword.update(
                     {
                         "corpus": "VERBS",
-                        "group": format_subtype_display_name(lemma.pos_subtype or "action"),
+                        "group": resolve_group_label(
+                            lemma.pos_subtype or "action", self.source_language, session
+                        ),
                         "level": effective_lemma_level,
                         "word_type": "verb",
                     }

--- a/src/wireword/text_rendering.py
+++ b/src/wireword/text_rendering.py
@@ -5,6 +5,8 @@ Text rendering and formatting utilities for wireword exports.
 Provides reusable functions for formatting display names and text output.
 """
 
+from typing import Any
+
 
 def format_subtype_display_name(subtype: str) -> str:
     """
@@ -97,3 +99,21 @@ def format_subtype_display_name(subtype: str) -> str:
 
     # Default: title case each word
     return formatted.title()
+
+
+def resolve_group_label(subtype: str, interface_language: str, session: Any | None = None) -> str:
+    """
+    Resolve localized group labels for Wireword exports.
+
+    Args:
+        subtype: Raw subtype value from database (e.g. "food", "tool_machine")
+        interface_language: Interface language code used by Wireword.
+            For current exports this should be the source language.
+        session: Optional database/session handle for future translation lookup support.
+
+    Returns:
+        Localized group label string. Currently falls back to English for all languages.
+    """
+    _ = interface_language
+    _ = session
+    return format_subtype_display_name(subtype)


### PR DESCRIPTION
### Motivation
- Introduce a single resolver that can return localized group labels and accept an `interface_language` and optional `session` for future translation lookups.
- Preserve current output while enabling future i18n support by falling back to English until translations are added to the schema.

### Description
- Add `resolve_group_label(subtype, interface_language, session=None)` in `src/wireword/text_rendering.py` which currently delegates to `format_subtype_display_name`.
- Replace the import of `format_subtype_display_name` with `resolve_group_label` in `src/wireword/export_wireword.py`.
- Use `resolve_group_label(entry["subtype"], self.source_language, session)` for noun exports and `resolve_group_label(lemma.pos_subtype or "action", self.source_language, session)` for verb exports.
- No change to the visible formatting output is introduced by this change; it only centralizes the resolution point for future localization.

### Testing
- Ran `PYTHONPATH=src black src/wireword/text_rendering.py src/wireword/export_wireword.py` and it succeeded.
- Ran `PYTHONPATH=src mypy src/wireword/text_rendering.py src/wireword/export_wireword.py` and it succeeded.
- Ran `PYTHONPATH=src pytest -q src/tests/wireword/test_export_wireword.py -k subtype` which exited with code 5 because no tests matched the `-k` selection.
- Ran `PYTHONPATH=src pytest -q src/tests/wireword/test_export_wireword.py` and the test module passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df353fd088327acb962588f0b1ebb)