### PR TITLE
Generate localized categorychoice files from EN + SUBTYPE_DISPLAY

### DIFF
--- a/data/categorychoice-es.json
+++ b/data/categorychoice-es.json
@@ -4,7 +4,7 @@
       "id": "family-relation",
       "label": "Familiar",
       "groups": [
-        "Family Relation"
+        "Familiar"
       ],
       "avoidDecoys": [
         "human",
@@ -15,7 +15,7 @@
       "id": "occupation",
       "label": "Profesión",
       "groups": [
-        "Occupation"
+        "Profesión"
       ],
       "avoidDecoys": [
         "human",
@@ -26,7 +26,7 @@
       "id": "animal",
       "label": "Animales",
       "groups": [
-        "Animals"
+        "Animales"
       ],
       "avoidDecoys": []
     },
@@ -34,7 +34,7 @@
       "id": "body-part",
       "label": "Parte del cuerpo",
       "groups": [
-        "Body Part"
+        "Parte del cuerpo"
       ],
       "avoidDecoys": []
     },
@@ -42,7 +42,7 @@
       "id": "disease-condition",
       "label": "Enfermedad",
       "groups": [
-        "Disease/Condition"
+        "Enfermedad"
       ],
       "avoidDecoys": []
     },
@@ -50,7 +50,7 @@
       "id": "plant",
       "label": "Plantas",
       "groups": [
-        "Plants"
+        "Plantas"
       ],
       "avoidDecoys": []
     },
@@ -58,7 +58,7 @@
       "id": "food",
       "label": "Comida",
       "groups": [
-        "Food"
+        "Comida"
       ],
       "avoidDecoys": [
         "beverage"
@@ -68,7 +68,7 @@
       "id": "beverage",
       "label": "Bebida",
       "groups": [
-        "Beverage"
+        "Bebida"
       ],
       "avoidDecoys": [
         "food"
@@ -78,7 +78,7 @@
       "id": "building-structure",
       "label": "Edificio",
       "groups": [
-        "Building/Structure"
+        "Edificio"
       ],
       "avoidDecoys": [
         "furniture"
@@ -88,7 +88,7 @@
       "id": "furniture",
       "label": "Mueble",
       "groups": [
-        "Furniture"
+        "Mueble"
       ],
       "avoidDecoys": [
         "building-structure"
@@ -98,7 +98,7 @@
       "id": "clothing-accessory",
       "label": "Ropa/Accesorio",
       "groups": [
-        "Clothing/Accessory"
+        "Ropa/Accesorio"
       ],
       "avoidDecoys": []
     },
@@ -106,7 +106,7 @@
       "id": "natural-feature",
       "label": "Elemento natural",
       "groups": [
-        "Natural Feature"
+        "Elemento natural"
       ],
       "avoidDecoys": []
     },
@@ -114,7 +114,7 @@
       "id": "tool",
       "label": "Herramienta",
       "groups": [
-        "Tool"
+        "Herramienta"
       ],
       "avoidDecoys": [
         "vehicle",
@@ -127,7 +127,7 @@
       "id": "electronic-device",
       "label": "Dispositivo electrónico",
       "groups": [
-        "Electronic Device"
+        "Dispositivo electrónico"
       ],
       "avoidDecoys": [
         "tool",
@@ -138,7 +138,7 @@
       "id": "appliance",
       "label": "Electrodoméstico",
       "groups": [
-        "Appliance"
+        "Electrodoméstico"
       ],
       "avoidDecoys": [
         "tool",
@@ -149,7 +149,7 @@
       "id": "weapon",
       "label": "Arma",
       "groups": [
-        "Weapon"
+        "Arma"
       ],
       "avoidDecoys": [
         "tool"
@@ -159,7 +159,7 @@
       "id": "vehicle",
       "label": "Vehículo",
       "groups": [
-        "Vehicle"
+        "Vehículo"
       ],
       "avoidDecoys": [
         "tool"
@@ -169,7 +169,7 @@
       "id": "emotion-feeling",
       "label": "Emoción/Sentimiento",
       "groups": [
-        "Emotion/Feeling"
+        "Emoción/Sentimiento"
       ],
       "avoidDecoys": []
     },
@@ -177,7 +177,7 @@
       "id": "shape",
       "label": "Forma",
       "groups": [
-        "Shape"
+        "Forma"
       ],
       "avoidDecoys": []
     },
@@ -193,7 +193,7 @@
       "id": "time-period",
       "label": "Periodo de tiempo",
       "groups": [
-        "Time Period"
+        "Periodo de tiempo"
       ],
       "avoidDecoys": [
         "temporal-name"
@@ -203,7 +203,7 @@
       "id": "temporal-name",
       "label": "Nombre temporal",
       "groups": [
-        "Temporal Name"
+        "Nombre temporal"
       ],
       "avoidDecoys": [
         "time-period"
@@ -213,7 +213,7 @@
       "id": "country",
       "label": "País",
       "groups": [
-        "Country"
+        "País"
       ],
       "avoidDecoys": [
         "city",
@@ -224,7 +224,7 @@
       "id": "city",
       "label": "Ciudad",
       "groups": [
-        "City"
+        "Ciudad"
       ],
       "avoidDecoys": [
         "country",
@@ -235,7 +235,7 @@
       "id": "nationality",
       "label": "Nacionalidad",
       "groups": [
-        "Nationality"
+        "Nacionalidad"
       ],
       "avoidDecoys": [
         "country",
@@ -246,7 +246,7 @@
       "id": "definite-quantity",
       "label": "Cardinal",
       "groups": [
-        "Definite Quantity"
+        "Cardinal"
       ],
       "avoidDecoys": [
         "sequence"
@@ -256,7 +256,7 @@
       "id": "sequence",
       "label": "Secuencia",
       "groups": [
-        "Sequence"
+        "Secuencia"
       ],
       "avoidDecoys": [
         "definite-quantity"

--- a/data/categorychoice-fr.json
+++ b/data/categorychoice-fr.json
@@ -4,7 +4,7 @@
       "id": "family-relation",
       "label": "Lien familial",
       "groups": [
-        "Family Relation"
+        "Lien familial"
       ],
       "avoidDecoys": [
         "human",
@@ -15,7 +15,7 @@
       "id": "occupation",
       "label": "Profession",
       "groups": [
-        "Occupation"
+        "Profession"
       ],
       "avoidDecoys": [
         "human",
@@ -26,7 +26,7 @@
       "id": "animal",
       "label": "Animaux",
       "groups": [
-        "Animals"
+        "Animaux"
       ],
       "avoidDecoys": []
     },
@@ -34,7 +34,7 @@
       "id": "body-part",
       "label": "Partie du corps",
       "groups": [
-        "Body Part"
+        "Partie du corps"
       ],
       "avoidDecoys": []
     },
@@ -42,7 +42,7 @@
       "id": "disease-condition",
       "label": "Maladie",
       "groups": [
-        "Disease/Condition"
+        "Maladie"
       ],
       "avoidDecoys": []
     },
@@ -50,7 +50,7 @@
       "id": "plant",
       "label": "Plantes",
       "groups": [
-        "Plants"
+        "Plantes"
       ],
       "avoidDecoys": []
     },
@@ -58,7 +58,7 @@
       "id": "food",
       "label": "Nourriture",
       "groups": [
-        "Food"
+        "Nourriture"
       ],
       "avoidDecoys": [
         "beverage"
@@ -68,7 +68,7 @@
       "id": "beverage",
       "label": "Boisson",
       "groups": [
-        "Beverage"
+        "Boisson"
       ],
       "avoidDecoys": [
         "food"
@@ -78,7 +78,7 @@
       "id": "building-structure",
       "label": "Bâtiment",
       "groups": [
-        "Building/Structure"
+        "Bâtiment"
       ],
       "avoidDecoys": [
         "furniture"
@@ -88,7 +88,7 @@
       "id": "furniture",
       "label": "Meuble",
       "groups": [
-        "Furniture"
+        "Meuble"
       ],
       "avoidDecoys": [
         "building-structure"
@@ -98,7 +98,7 @@
       "id": "clothing-accessory",
       "label": "Vêtement/Accessoire",
       "groups": [
-        "Clothing/Accessory"
+        "Vêtement/Accessoire"
       ],
       "avoidDecoys": []
     },
@@ -106,7 +106,7 @@
       "id": "natural-feature",
       "label": "Élément naturel",
       "groups": [
-        "Natural Feature"
+        "Élément naturel"
       ],
       "avoidDecoys": []
     },
@@ -114,7 +114,7 @@
       "id": "tool",
       "label": "Outil",
       "groups": [
-        "Tool"
+        "Outil"
       ],
       "avoidDecoys": [
         "vehicle",
@@ -127,7 +127,7 @@
       "id": "electronic-device",
       "label": "Appareil électronique",
       "groups": [
-        "Electronic Device"
+        "Appareil électronique"
       ],
       "avoidDecoys": [
         "tool",
@@ -138,7 +138,7 @@
       "id": "appliance",
       "label": "Électroménager",
       "groups": [
-        "Appliance"
+        "Électroménager"
       ],
       "avoidDecoys": [
         "tool",
@@ -149,7 +149,7 @@
       "id": "weapon",
       "label": "Arme",
       "groups": [
-        "Weapon"
+        "Arme"
       ],
       "avoidDecoys": [
         "tool"
@@ -159,7 +159,7 @@
       "id": "vehicle",
       "label": "Véhicule",
       "groups": [
-        "Vehicle"
+        "Véhicule"
       ],
       "avoidDecoys": [
         "tool"
@@ -169,7 +169,7 @@
       "id": "emotion-feeling",
       "label": "Émotion/Sentiment",
       "groups": [
-        "Emotion/Feeling"
+        "Émotion/Sentiment"
       ],
       "avoidDecoys": []
     },
@@ -177,7 +177,7 @@
       "id": "shape",
       "label": "Forme",
       "groups": [
-        "Shape"
+        "Forme"
       ],
       "avoidDecoys": []
     },
@@ -185,7 +185,7 @@
       "id": "color",
       "label": "Couleur",
       "groups": [
-        "Color"
+        "Couleur"
       ],
       "avoidDecoys": []
     },
@@ -193,7 +193,7 @@
       "id": "time-period",
       "label": "Période",
       "groups": [
-        "Time Period"
+        "Période"
       ],
       "avoidDecoys": [
         "temporal-name"
@@ -203,7 +203,7 @@
       "id": "temporal-name",
       "label": "Nom temporel",
       "groups": [
-        "Temporal Name"
+        "Nom temporel"
       ],
       "avoidDecoys": [
         "time-period"
@@ -213,7 +213,7 @@
       "id": "country",
       "label": "Pays",
       "groups": [
-        "Country"
+        "Pays"
       ],
       "avoidDecoys": [
         "city",
@@ -224,7 +224,7 @@
       "id": "city",
       "label": "Ville",
       "groups": [
-        "City"
+        "Ville"
       ],
       "avoidDecoys": [
         "country",
@@ -235,7 +235,7 @@
       "id": "nationality",
       "label": "Nationalité",
       "groups": [
-        "Nationality"
+        "Nationalité"
       ],
       "avoidDecoys": [
         "country",
@@ -246,7 +246,7 @@
       "id": "definite-quantity",
       "label": "Cardinal",
       "groups": [
-        "Definite Quantity"
+        "Cardinal"
       ],
       "avoidDecoys": [
         "sequence"
@@ -256,7 +256,7 @@
       "id": "sequence",
       "label": "Séquence",
       "groups": [
-        "Sequence"
+        "Séquence"
       ],
       "avoidDecoys": [
         "definite-quantity"

--- a/data/categorychoice-zh.json
+++ b/data/categorychoice-zh.json
@@ -4,7 +4,7 @@
       "id": "family-relation",
       "label": "家庭关系",
       "groups": [
-        "Family Relation"
+        "家庭关系"
       ],
       "avoidDecoys": [
         "human",
@@ -15,7 +15,7 @@
       "id": "occupation",
       "label": "职业",
       "groups": [
-        "Occupation"
+        "职业"
       ],
       "avoidDecoys": [
         "human",
@@ -26,7 +26,7 @@
       "id": "animal",
       "label": "动物",
       "groups": [
-        "Animals"
+        "动物"
       ],
       "avoidDecoys": []
     },
@@ -34,7 +34,7 @@
       "id": "body-part",
       "label": "身体部位",
       "groups": [
-        "Body Part"
+        "身体部位"
       ],
       "avoidDecoys": []
     },
@@ -42,7 +42,7 @@
       "id": "disease-condition",
       "label": "疾病",
       "groups": [
-        "Disease/Condition"
+        "疾病"
       ],
       "avoidDecoys": []
     },
@@ -50,7 +50,7 @@
       "id": "plant",
       "label": "植物",
       "groups": [
-        "Plants"
+        "植物"
       ],
       "avoidDecoys": []
     },
@@ -58,7 +58,7 @@
       "id": "food",
       "label": "食物",
       "groups": [
-        "Food"
+        "食物"
       ],
       "avoidDecoys": [
         "beverage"
@@ -68,7 +68,7 @@
       "id": "beverage",
       "label": "饮料",
       "groups": [
-        "Beverage"
+        "饮料"
       ],
       "avoidDecoys": [
         "food"
@@ -78,7 +78,7 @@
       "id": "building-structure",
       "label": "建筑",
       "groups": [
-        "Building/Structure"
+        "建筑"
       ],
       "avoidDecoys": [
         "furniture"
@@ -88,7 +88,7 @@
       "id": "furniture",
       "label": "家具",
       "groups": [
-        "Furniture"
+        "家具"
       ],
       "avoidDecoys": [
         "building-structure"
@@ -98,7 +98,7 @@
       "id": "clothing-accessory",
       "label": "服装/配饰",
       "groups": [
-        "Clothing/Accessory"
+        "服装/配饰"
       ],
       "avoidDecoys": []
     },
@@ -106,7 +106,7 @@
       "id": "natural-feature",
       "label": "自然地貌",
       "groups": [
-        "Natural Feature"
+        "自然地貌"
       ],
       "avoidDecoys": []
     },
@@ -114,7 +114,7 @@
       "id": "tool",
       "label": "工具",
       "groups": [
-        "Tool"
+        "工具"
       ],
       "avoidDecoys": [
         "vehicle",
@@ -127,7 +127,7 @@
       "id": "electronic-device",
       "label": "电子设备",
       "groups": [
-        "Electronic Device"
+        "电子设备"
       ],
       "avoidDecoys": [
         "tool",
@@ -138,7 +138,7 @@
       "id": "appliance",
       "label": "家用电器",
       "groups": [
-        "Appliance"
+        "家用电器"
       ],
       "avoidDecoys": [
         "tool",
@@ -149,7 +149,7 @@
       "id": "weapon",
       "label": "武器",
       "groups": [
-        "Weapon"
+        "武器"
       ],
       "avoidDecoys": [
         "tool"
@@ -159,7 +159,7 @@
       "id": "vehicle",
       "label": "交通工具",
       "groups": [
-        "Vehicle"
+        "交通工具"
       ],
       "avoidDecoys": [
         "tool"
@@ -169,7 +169,7 @@
       "id": "emotion-feeling",
       "label": "情感",
       "groups": [
-        "Emotion/Feeling"
+        "情感"
       ],
       "avoidDecoys": []
     },
@@ -177,7 +177,7 @@
       "id": "shape",
       "label": "形状",
       "groups": [
-        "Shape"
+        "形状"
       ],
       "avoidDecoys": []
     },
@@ -185,7 +185,7 @@
       "id": "color",
       "label": "颜色",
       "groups": [
-        "Color"
+        "颜色"
       ],
       "avoidDecoys": []
     },
@@ -193,7 +193,7 @@
       "id": "time-period",
       "label": "时间段",
       "groups": [
-        "Time Period"
+        "时间段"
       ],
       "avoidDecoys": [
         "temporal-name"
@@ -203,7 +203,7 @@
       "id": "temporal-name",
       "label": "时间名称",
       "groups": [
-        "Temporal Name"
+        "时间名称"
       ],
       "avoidDecoys": [
         "time-period"
@@ -213,7 +213,7 @@
       "id": "country",
       "label": "国家",
       "groups": [
-        "Country"
+        "国家"
       ],
       "avoidDecoys": [
         "city",
@@ -224,7 +224,7 @@
       "id": "city",
       "label": "城市",
       "groups": [
-        "City"
+        "城市"
       ],
       "avoidDecoys": [
         "country",
@@ -235,7 +235,7 @@
       "id": "nationality",
       "label": "国籍",
       "groups": [
-        "Nationality"
+        "国籍"
       ],
       "avoidDecoys": [
         "country",
@@ -246,7 +246,7 @@
       "id": "definite-quantity",
       "label": "基数",
       "groups": [
-        "Definite Quantity"
+        "基数"
       ],
       "avoidDecoys": [
         "sequence"
@@ -256,7 +256,7 @@
       "id": "sequence",
       "label": "顺序",
       "groups": [
-        "Sequence"
+        "顺序"
       ],
       "avoidDecoys": [
         "definite-quantity"

--- a/data/categorychoice.json
+++ b/data/categorychoice.json
@@ -153,7 +153,7 @@
     {
       "id": "definite-quantity",
       "label": "Numbers",
-      "groups": ["Definite Quantity"],
+      "groups": ["Cardinal"],
       "avoidDecoys": ["sequence"]
     },
     {

--- a/src/agents/ungurys/agent.py
+++ b/src/agents/ungurys/agent.py
@@ -31,6 +31,10 @@ from storage.translation_helpers import (
 )
 from storage.backend.factory import create_session
 from wireword.export_manager import TrakaidoExporter
+from wireword.generate_categorychoice import (
+    build_reverse_subtype_map,
+    generate_for_language,
+)
 from wordfreq.tools.country_word_priorities import (
     get_supported_languages as get_country_override_languages,
 )
@@ -618,11 +622,15 @@ class UngurysAgent:
 
             logger.info(f"Successfully exported {category_count} categories to {output_path}")
 
-            # Also copy language-specific variants if present.
+            # Regenerate localized variants from the English source via
+            # SUBTYPE_DISPLAY so groups[] stays in sync with wireword exports.
+            reverse_map = build_reverse_subtype_map()
             for lang in ("es", "fr", "zh"):
+                lang_data = generate_for_language(data, reverse_map, lang)
                 lang_source = os.path.join(project_root, "data", f"categorychoice-{lang}.json")
-                if not os.path.exists(lang_source):
-                    continue
+                with open(lang_source, "w", encoding="utf-8") as f:
+                    json.dump(lang_data, f, ensure_ascii=False, indent=2)
+                    f.write("\n")
                 lang_output = os.path.join(output_dir, f"categorychoice-{lang}.json")
                 shutil.copy2(lang_source, lang_output)
                 logger.info(f"  Exported {lang_output}")

--- a/src/wireword/generate_categorychoice.py
+++ b/src/wireword/generate_categorychoice.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Generate localized categorychoice-{lang}.json files from the English source.
+
+The English ``data/categorychoice.json`` is the source of truth. For each
+target source-language, this script translates the ``label`` and each entry
+in ``groups`` via ``storage.models.enum_translations``.
+
+Mapping rule for ``groups``: each English group string must match a value in
+``en.SUBTYPE_DISPLAY``. We reverse that map to find the subtype key, then look
+it up in the target language's ``SUBTYPE_DISPLAY`` to get the localized group
+string. If any English group has no reverse mapping, we fail loudly — that
+indicates drift between ``categorychoice.json`` and ``en.SUBTYPE_DISPLAY``
+that must be reconciled at the source.
+
+Mapping rule for ``label``: set ``label = SUBTYPE_DISPLAY[subtype]`` in the
+target language. This loses the nicer plural/prose phrasing of the English
+labels but keeps the file fully automatable. The ``id`` and ``avoidDecoys``
+fields are preserved verbatim.
+
+Usage:
+    PYTHONPATH=src python src/wireword/generate_categorychoice.py
+    PYTHONPATH=src python src/wireword/generate_categorychoice.py --langs fr es
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+if str(Path(__file__).parent.parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from storage.models.enum_translations import en as en_translations
+from storage.models.enum_translations import get_subtype_display_name
+
+DEFAULT_LANGS = ("es", "fr", "zh")
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = PROJECT_ROOT / "data"
+EN_SOURCE = DATA_DIR / "categorychoice.json"
+
+
+def build_reverse_subtype_map() -> Dict[str, str]:
+    """Build a value -> subtype key map from en.SUBTYPE_DISPLAY.
+
+    Raises if there are duplicate display values that would make the reverse
+    mapping ambiguous (excluding the ``__other__`` alias).
+    """
+    reverse: Dict[str, str] = {}
+    duplicates: Dict[str, List[str]] = {}
+    for subtype, display in en_translations.SUBTYPE_DISPLAY.items():
+        if subtype == "__other__":
+            continue
+        if display in reverse:
+            duplicates.setdefault(display, [reverse[display]]).append(subtype)
+        else:
+            reverse[display] = subtype
+    if duplicates:
+        msg = "\n".join(f"  {disp!r}: {keys}" for disp, keys in duplicates.items())
+        raise ValueError(f"Ambiguous reverse mapping in en.SUBTYPE_DISPLAY:\n{msg}")
+    return reverse
+
+
+def generate_for_language(
+    en_data: Dict[str, Any], reverse_map: Dict[str, str], lang: str
+) -> Dict[str, Any]:
+    """Build the localized config dict for *lang*."""
+    out_categories: List[Dict[str, Any]] = []
+    for entry in en_data.get("categories", []):
+        en_groups: List[str] = entry["groups"]
+        if not en_groups:
+            raise ValueError(f"Category {entry['id']!r} has empty groups[]")
+
+        subtypes: List[str] = []
+        for g in en_groups:
+            if g not in reverse_map:
+                raise ValueError(
+                    f"Category {entry['id']!r}: group {g!r} not found in "
+                    f"en.SUBTYPE_DISPLAY values. Fix categorychoice.json or "
+                    f"en.SUBTYPE_DISPLAY so they agree."
+                )
+            subtypes.append(reverse_map[g])
+
+        localized_groups = [get_subtype_display_name(s, lang) for s in subtypes]
+        # Use the first subtype's display as the localized label.
+        localized_label = get_subtype_display_name(subtypes[0], lang)
+
+        out_categories.append(
+            {
+                "id": entry["id"],
+                "label": localized_label,
+                "groups": localized_groups,
+                "avoidDecoys": list(entry.get("avoidDecoys", [])),
+            }
+        )
+    return {"categories": out_categories}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--langs",
+        nargs="+",
+        default=list(DEFAULT_LANGS),
+        help=f"Target language codes (default: {' '.join(DEFAULT_LANGS)})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DATA_DIR,
+        help="Directory to write categorychoice-{lang}.json files (default: data/)",
+    )
+    args = parser.parse_args()
+
+    if not EN_SOURCE.exists():
+        print(f"error: missing source file {EN_SOURCE}", file=sys.stderr)
+        return 1
+
+    with EN_SOURCE.open("r", encoding="utf-8") as f:
+        en_data = json.load(f)
+
+    reverse_map = build_reverse_subtype_map()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    for lang in args.langs:
+        if lang == "en":
+            print("skipping 'en' (source file)")
+            continue
+        out = generate_for_language(en_data, reverse_map, lang)
+        out_path = args.output_dir / f"categorychoice-{lang}.json"
+        with out_path.open("w", encoding="utf-8") as f:
+            json.dump(out, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        print(f"wrote {out_path} ({len(out['categories'])} categories)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The categorychoice-{es,fr,zh}.json files had their `label` translated but `groups[]` still in English. CategoryChoiceGenerator.matches() does a case-insensitive equality check against wireword `group` strings (which are localized via SUBTYPE_DISPLAY), so every match failed and the quiz view fell through to generationFailureView.

Add src/wireword/generate_categorychoice.py: reverse-map each English group string to a subtype key via en.SUBTYPE_DISPLAY, then emit localized groups[] and label via the target language's SUBTYPE_DISPLAY. Fails loudly if categorychoice.json drifts from the enum source.

Wire it into ungurys export_category_choice so the localized files are regenerated on every export. Also fix one silent drift in the English source: "Definite Quantity" -> "Cardinal" (the actual subtype display).