### PR TITLE
Add Dockerfile/Procfile and /healthz for hosted Barsukas deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONPATH=/app/src \
+    BARSUKAS_PERSONA=hosted \
+    STORAGE_BACKEND=jsonl \
+    JSONL_DATA_DIR=/app/data/release
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/greenland-requirements.txt
+COPY src/barsukas/requirements.txt /tmp/barsukas-requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/greenland-requirements.txt -r /tmp/barsukas-requirements.txt
+
+COPY . .
+
+EXPOSE 5555
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import os, urllib.request; urllib.request.urlopen(f'http://127.0.0.1:{os.environ.get(\"PORT\", \"5555\")}/healthz', timeout=3).read()"
+
+CMD ["sh", "-c", "python src/barsukas/unified_app.py --host 0.0.0.0 --port ${PORT:-5555} --persona hosted"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: PYTHONPATH=src BARSUKAS_PERSONA=hosted STORAGE_BACKEND=jsonl JSONL_DATA_DIR=data/release python src/barsukas/unified_app.py --host 0.0.0.0 --port ${PORT:-5555} --persona hosted

--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -364,12 +364,16 @@ def create_app(
 
     @app.before_request
     def before_request() -> None:
-        """Set up database session and start request timing for metrics."""
-        g.db = app.db_session_factory()
+        """Set up request context and start timing for metrics."""
         g.ui_lang = resolve_ui_language(request)
         endpoint_name = request.endpoint or "common"
         g.strings_default_module = endpoint_name.split(".", 1)[0]
         RequestMetricsMiddleware.before_request()
+
+        if endpoint_name == "healthz":
+            return
+
+        g.db = app.db_session_factory()
 
     @app.teardown_appcontext
     def shutdown_session(exception: Optional[BaseException]) -> None:
@@ -404,6 +408,11 @@ def create_app(
         if not next_url.startswith("/"):
             next_url = url_for("index")
         return redirect(next_url)
+
+    @app.get("/healthz")
+    def healthz() -> Response:
+        """Return a lightweight health check for process supervisors."""
+        return Response("ok\n", mimetype="text/plain; charset=utf-8")
 
     @app.route("/metrics")
     def metrics() -> Response:

--- a/src/tests/barsukas/test_routes_smoke.py
+++ b/src/tests/barsukas/test_routes_smoke.py
@@ -95,3 +95,13 @@ class TestHomeRoute:
     def test_home_returns_200(self, client: FlaskClient) -> None:
         response = client.get("/")
         assert response.status_code == 200
+
+
+class TestHealthRoute:
+    """Smoke test for the health check endpoint."""
+
+    def test_healthz_returns_ok(self, client: FlaskClient) -> None:
+        response = client.get("/healthz")
+        assert response.status_code == 200
+        assert response.text == "ok\n"
+        assert response.mimetype == "text/plain"


### PR DESCRIPTION
### Motivation
- Provide a simple way to run Barsukas in a hosted (read-only, JSONL/data/release) persona suitable for scalers (Railway, Heroku-like) with a container and Procfile entry.
- Expose a lightweight /healthz endpoint for process supervisors that does not open DB sessions, so health probes do not contend with SQLite or require full metrics.

### Description
- Added a repository-level `Dockerfile` that installs dependencies, sets environment defaults for the `hosted` persona (JSONL backend pointing at `data/release`), exposes port `5555`, adds a Docker `HEALTHCHECK` that probes `/healthz`, and runs the unified Barsukas launcher on `0.0.0.0` using `${PORT:-5555}`.
- Added a `Procfile` with a `web` process line suitable for Railway/Heroku, launching Barsukas in `hosted` persona and pointing `JSONL_DATA_DIR` to `data/release`.
- Added a lightweight `/healthz` route in `src/barsukas/app.py` returning `ok\n` with `text/plain`, and adjusted request lifecycle so `/healthz` will not allocate a DB session.
- Added a smoke test `TestHealthRoute` in `src/tests/barsukas/test_routes_smoke.py` asserting the `/healthz` response body, status, and MIME type.

### Testing
- Ran `black` formatting on the modified test file and confirmed formatting succeeded.
- Ran `mypy` on the modified source files with `PYTHONPATH=src` and received no type issues for the changed files.
- Ran the relevant pytest smoke tests: `PYTHONPATH=src python -m pytest src/tests/barsukas/test_routes_smoke.py -q`, and all tests passed (including the new `/healthz` smoke test).
- Started the hosted server locally with `PYTHONPATH=src BARSUKAS_PERSONA=hosted STORAGE_BACKEND=jsonl JSONL_DATA_DIR=data/release python src/barsukas/unified_app.py --host 127.0.0.1 --port 5678 --persona hosted` and verified `GET /healthz` returned `200 ok` with `text/plain`.
- Attempted to build the Docker image locally, but `docker` is not available in this environment so the image build was not executed here (the `Dockerfile` and `HEALTHCHECK` are included for use on CI or deployment platforms).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1850e7c1008327840fb36967a8073c)