### PR TITLE
Combine Barsukas deps into root requirements and add `audio` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,20 @@ authors = [
 ]
 dependencies = [
     "sqlalchemy>=2.0.0",
+    "psycopg2-binary>=2.9.0",
+    "jinja2>=3.0.0",
+    "requests>=2.25.0",
+    "tiktoken>=0.5.0",
     "pydantic>=2.0.0",
-    "requests>=2.31.0",
-    "jinja2>=3.1.0",
+    "Flask>=3.0.0",
+    "prometheus_client>=0.19.0",
+    "psutil>=5.9.0",
+    "markdown>=3.3.0",
+    "simplejson>=3.17.0",
+    "pypinyin>=0.53.0",
+    "jieba>=0.42.1",
+    "opencc-python-reimplemented>=0.1.0",
+    "pykakasi>=2.3.0",
 ]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -21,6 +32,14 @@ dev = [
     "mypy>=1.0.0",
 ]
 # Core audio/TTS dependencies for audioshoe module
+audio = [
+    "torch>=2.0.0",
+    "numpy>=1.24.0",
+    "scipy>=1.10.0",
+    "librosa>=0.10.0",
+    "pydub>=0.25.0",
+]
+# Backward-compatible alias for the older extra name. Prefer greenland[audio].
 audioshoe = [
     "torch>=2.0.0",
     "numpy>=1.24.0",
@@ -28,9 +47,9 @@ audioshoe = [
     "librosa>=0.10.0",
     "pydub>=0.25.0",
 ]
-# Extended ML dependencies (includes audioshoe + more)
+# Extended ML dependencies (includes audio + more)
 ml = [
-    "greenland[audioshoe]",
+    "greenland[audio]",
     "transformers>=4.35.0",
     "whisper>=1.0",
     "accelerate>=0.25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,23 @@
+# Combined Greenland + Barsukas base dependencies.
+#
+# Install with:
+#   pip install -r requirements.txt
+#
+# Optional dependency groups are declared in pyproject.toml. For audio/TTS
+# support, install the project with the audio extra:
+#   pip install -e ".[audio]"
+
 # Core dependencies
 sqlalchemy>=2.0.0
 psycopg2-binary>=2.9.0
 jinja2>=3.0.0
 requests>=2.25.0
 tiktoken>=0.5.0
+
+# Barsukas web interface
+Flask>=3.0.0
+prometheus_client>=0.19.0
+psutil>=5.9.0
 
 # For HTML/report generation
 markdown>=3.3.0
@@ -14,7 +28,8 @@ simplejson>=3.17.0
 # Testing
 pytest>=7.0.0
 
-# Chinese
+# Language processing
 pypinyin>=0.53.0
 jieba>=0.42.1
 opencc-python-reimplemented>=0.1.0
+pykakasi>=2.3.0

--- a/src/barsukas/requirements.txt
+++ b/src/barsukas/requirements.txt
@@ -1,7 +1,0 @@
-Flask>=3.0.0
-SQLAlchemy>=2.0.0
-pypinyin>=0.53.0
-jieba>=0.42.1
-pykakasi>=2.3.0
-prometheus_client>=0.19.0
-psutil>=5.9.0

--- a/src/barsukas/setup.sh
+++ b/src/barsukas/setup.sh
@@ -7,6 +7,7 @@ set -e
 
 # Default venv location
 VENV_PATH=""
+EXTRAS=""
 
 # Parse command-line arguments
 while [[ $# -gt 0 ]]; do
@@ -15,19 +16,29 @@ while [[ $# -gt 0 ]]; do
             VENV_PATH="$2"
             shift 2
             ;;
+        --extras)
+            EXTRAS="$2"
+            shift 2
+            ;;
+        --with-audio)
+            EXTRAS="${EXTRAS:+$EXTRAS,}audio"
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 --venv PATH"
+            echo "Usage: $0 --venv PATH [--extras EXTRA[,EXTRA...]] [--with-audio]"
             echo ""
             echo "Creates a Python virtual environment and installs dependencies for Barsukas."
             echo ""
             echo "Options:"
-            echo "  --venv PATH    Path where the venv should be created (required)"
-            echo "  -h, --help     Show this help message"
+            echo "  --venv PATH       Path where the venv should be created (required)"
+            echo "  --extras EXTRAS   Optional pyproject extras to install, e.g. audio or audio,dev"
+            echo "  --with-audio      Shortcut for --extras audio"
+            echo "  -h, --help        Show this help message"
             exit 0
             ;;
         *)
             echo "Error: Unknown option '$1'"
-            echo "Usage: $0 --venv PATH"
+            echo "Usage: $0 --venv PATH [--extras EXTRA[,EXTRA...]] [--with-audio]"
             exit 1
             ;;
     esac
@@ -35,7 +46,7 @@ done
 
 if [[ -z "$VENV_PATH" ]]; then
     echo "Error: --venv PATH is required"
-    echo "Usage: $0 --venv PATH"
+    echo "Usage: $0 --venv PATH [--extras EXTRA[,EXTRA...]] [--with-audio]"
     exit 1
 fi
 
@@ -50,6 +61,9 @@ echo "Setting up Barsukas environment"
 echo "=========================================="
 echo "Venv path: $VENV_PATH"
 echo "Repo root: $REPO_ROOT"
+if [[ -n "$EXTRAS" ]]; then
+    echo "Optional extras: $EXTRAS"
+fi
 echo ""
 
 # Create venv if it doesn't exist
@@ -70,8 +84,13 @@ pip install --upgrade pip
 
 # Install requirements
 echo ""
-echo "Installing dependencies from requirements.txt files..."
-pip install -r "$REPO_ROOT/requirements.txt" -r "$SCRIPT_DIR/requirements.txt"
+echo "Installing dependencies from combined requirements.txt..."
+pip install -r "$REPO_ROOT/requirements.txt"
+
+if [[ -n "$EXTRAS" ]]; then
+    echo "Installing optional extras: $EXTRAS"
+    pip install -e "$REPO_ROOT[$EXTRAS]"
+fi
 
 echo ""
 echo "=========================================="


### PR DESCRIPTION
### Motivation
- Remove duplicate dependency lists and centralize installation by folding `src/barsukas/requirements.txt` into the repo-root `requirements.txt` so Barsukas and core packages are installed from a single source. 
- Provide an explicit optional extra for audio/TTS support and maintain backward compatibility for existing workflows that referenced the old `audioshoe` extra.

### Description
- Merged Barsukas-specific packages into the root `requirements.txt` and deleted `src/barsukas/requirements.txt`. 
- Added a new `audio` optional dependency in `pyproject.toml` containing core audio/TTS packages and kept `audioshoe` as a backward-compatible alias, and changed the `ml` optional to depend on `greenland[audio]`. 
- Updated `pyproject.toml` top-level `dependencies` to include Barsukas/runtime deps used by the web UI. 
- Modified `src/barsukas/setup.sh` to install the combined `requirements.txt` and to accept `--extras` and `--with-audio` flags which will run `pip install -e "[<extras>]"` when requested. 

### Testing
- Ran a small TOML verification script (`python - <<'PY' ... PY`) which validated the `pyproject.toml` optional-dependencies shape and succeeded. 
- Validated shell syntax with `bash -n src/barsukas/setup.sh` which returned no errors. 
- Performed a dry-run install of the combined requirements with `python -m pip install --dry-run -r requirements.txt` which succeeded in the CI environment. 
- Attempted to dry-run `python -m pip install --dry-run -e ".[audio]"` which failed due to external network / package-index access while resolving build dependencies (environment limitation). 
- Ran `git diff --check` which returned no whitespace or diff-check issues, and noted that `black --check` was not applicable to the non-Python files attempted and therefore reported as not run for formatting on TOML/requirements/shell files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18518e89388327a4769f3b2e9f3b9e)