### PR TITLE
Fix root Dockerfile requirements install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,9 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-COPY requirements.txt /tmp/greenland-requirements.txt
-COPY src/barsukas/requirements.txt /tmp/barsukas-requirements.txt
+COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r /tmp/greenland-requirements.txt -r /tmp/barsukas-requirements.txt
+    && pip install --no-cache-dir -r /tmp/requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
### Motivation
- Railway uses the repository root `Dockerfile`, which previously copied and installed `src/barsukas/requirements.txt` that does not exist in this checkout, causing Docker builds to fail; the root `requirements.txt` already contains the Barsukas dependencies.

### Description
- Modify `Dockerfile` to `COPY requirements.txt /tmp/requirements.txt` and install with `pip install -r /tmp/requirements.txt`, removing the `src/barsukas/requirements.txt` copy/install step.

### Testing
- Ran a small Python assertion that confirmed the `Dockerfile` now contains `COPY requirements.txt /tmp/requirements.txt`, no longer references `src/barsukas/requirements.txt`, and uses `pip install -r /tmp/requirements.txt`, and the assertion passed.
- Ran `git diff --check`, which passed.
- Attempted `docker build` but the Docker CLI is not available in this environment, so an image build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185570ae9c8327a5d0daf73c1a49aa)