### PR TITLE
Allow configuring host/port via environment variables and simplify container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.12-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=/app/src \
+    PORT=5555 \
+    BARSUKAS_HOST=0.0.0.0 \
     BARSUKAS_PERSONA=hosted \
     STORAGE_BACKEND=jsonl \
     JSONL_DATA_DIR=/app/data/release
@@ -20,4 +22,4 @@ EXPOSE 5555
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "import os, urllib.request; urllib.request.urlopen(f'http://127.0.0.1:{os.environ.get(\"PORT\", \"5555\")}/healthz', timeout=3).read()"
 
-CMD ["sh", "-c", "python src/barsukas/unified_app.py --host 0.0.0.0 --port ${PORT:-5555} --persona hosted"]
+CMD ["python", "src/barsukas/unified_app.py"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: PYTHONPATH=src BARSUKAS_PERSONA=hosted STORAGE_BACKEND=jsonl JSONL_DATA_DIR=data/release python src/barsukas/unified_app.py --host 0.0.0.0 --port ${PORT:-5555} --persona hosted
+web: sh -c 'export PYTHONPATH=src BARSUKAS_HOST=0.0.0.0 BARSUKAS_PERSONA=hosted STORAGE_BACKEND=jsonl JSONL_DATA_DIR=data/release; exec python src/barsukas/unified_app.py'

--- a/src/barsukas/config.py
+++ b/src/barsukas/config.py
@@ -14,8 +14,8 @@ class Config:
     SECRET_KEY = os.environ.get("BARSUKAS_SECRET_KEY", "dev-secret-key-change-in-production")
 
     # Server settings
-    HOST = "127.0.0.1"  # Localhost only for security
-    PORT = int(os.environ.get("BARSUKAS_PORT", 5555))
+    HOST = os.environ.get("BARSUKAS_HOST", "127.0.0.1")  # Localhost only by default
+    PORT = int(os.environ.get("BARSUKAS_PORT", os.environ.get("PORT", 5555)))
     DEBUG = os.environ.get("BARSUKAS_DEBUG", "False").lower() == "true"
 
     # Database settings


### PR DESCRIPTION
### Motivation

- Allow the web server host and port to be configured via environment variables instead of hard-coded CLI arguments to support containerized and hosted deployments.
- Simplify container and Procfile startup commands by delegating host/port configuration to the application config.
- Ensure the healthcheck and defaults continue to work with the new env-driven configuration.

### Description

- Updated `src/barsukas/config.py` to read `HOST` from `BARSUKAS_HOST` and `PORT` from `BARSUKAS_PORT` or fallback to the `PORT` environment variable, and kept `DEBUG` reading from `BARSUKAS_DEBUG`.
- Modified `Dockerfile` to add `PORT` and `BARSUKAS_HOST` environment variables and changed the container `CMD` to run `python src/barsukas/unified_app.py` without explicit `--host`/`--port` flags, while keeping the existing `HEALTHCHECK` using the `PORT` env var.
- Updated `Procfile` to export `BARSUKAS_HOST=0.0.0.0` and other environment variables and to run the app via `exec python src/barsukas/unified_app.py` instead of passing host/port CLI args.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185d3455148327a8e5b000a5414f17)