### PR TITLE
Restructure sentence release storage to add collection as top-level directory

### DIFF
--- a/src/barsukas/routes/sync/sync_sentence_release.py
+++ b/src/barsukas/routes/sync/sync_sentence_release.py
@@ -338,6 +338,7 @@ def apply_additions() -> ResponseReturnValue:
 
             sentence = Sentence(
                 guid=guid,
+                sentence_collection=release_data.get("collection") or None,
                 pattern_type=release_data.get("pattern_type"),
                 tense=release_data.get("tense"),
                 minimum_level=release_data.get("minimum_level"),
@@ -1458,7 +1459,7 @@ def _normalize_release_sentence_for_compare(release_data: Dict[str, Any]) -> Dic
     """Normalize release JSONL sentence data for comparison with DB export records."""
     normalized: Dict[str, Any] = {"guid": release_data.get("guid")}
 
-    for field_name in ("pattern_type", "tense", "minimum_level", "notes"):
+    for field_name in ("collection", "pattern_type", "tense", "minimum_level", "notes"):
         if field_name in release_data:
             normalized[field_name] = release_data[field_name]
 
@@ -1649,25 +1650,26 @@ def apply_export() -> ResponseReturnValue:
         return redirect(url_for("sync_sentence_release.export"))
 
     # Group new sentences by category, merging with existing release data
-    # {(pos_type, pos_subtype): {guid: record}}
-    category_records: Dict[Tuple[str, str], Dict[str, Dict[str, Any]]] = defaultdict(dict)
+    # {(collection, pos_type, pos_subtype): {guid: record}}
+    category_records: Dict[Tuple[str, str, str], Dict[str, Dict[str, Any]]] = defaultdict(dict)
 
     # Pre-load existing release records grouped by category
     for base_file in release_dir.rglob("base.jsonl"):
-        # Determine category from path: release_dir/pos_dir/subtype/base.jsonl
+        # Determine category from path: release_dir/collection/pos_dir/subtype/base.jsonl
         rel_path = base_file.relative_to(release_dir)
-        parts = rel_path.parts  # e.g. ("verbs", "motion", "base.jsonl")
-        if len(parts) < 3:
+        parts = rel_path.parts  # e.g. ("beginner", "verbs", "motion", "base.jsonl")
+        if len(parts) < 4:
             continue
-        pos_dir = parts[0]
-        subtype = parts[1]
+        collection_dir = parts[0]
+        pos_dir = parts[1]
+        subtype = parts[2]
         # Reverse-map directory name to pos_type
         pos_type = pos_dir
         for pt, dn in _TYPE_TO_DIR.items():
             if dn == pos_dir:
                 pos_type = pt
                 break
-        category_key = (pos_type, subtype)
+        category_key: Tuple[str, str, str] = (collection_dir, pos_type, subtype)
         try:
             with open(base_file, "r", encoding="utf-8") as f:
                 for line in f:
@@ -1688,23 +1690,25 @@ def apply_export() -> ResponseReturnValue:
     exported_count = 0
     for sentence in db_sentences:
         record = _sentence_to_release_record(sentence)
-        category = _resolve_primary_lemma_category(sentence)
-        category_records[category][sentence.guid] = record
+        collection = sentence.sentence_collection or "general"
+        pos_type, pos_subtype = _resolve_primary_lemma_category(sentence)
+        category_records[(collection, pos_type, pos_subtype)][sentence.guid] = record
         exported_count += 1
 
     # Write out all affected categories
-    for (pos_type, pos_subtype), guid_to_record in category_records.items():
+    for (collection, pos_type, pos_subtype), guid_to_record in category_records.items():
         # Only write categories that contain newly exported sentences
         has_new = any(
             s.guid in guid_to_record
             for s in db_sentences
             if _resolve_primary_lemma_category(s) == (pos_type, pos_subtype)
+            and (s.sentence_collection or "general") == collection
         )
         if not has_new:
             continue
 
         dir_name = _TYPE_TO_DIR.get(pos_type, pos_type)
-        category_dir = release_dir / dir_name / pos_subtype
+        category_dir = release_dir / collection / dir_name / pos_subtype
         category_dir.mkdir(parents=True, exist_ok=True)
 
         records = sorted(guid_to_record.values(), key=lambda r: r["guid"])
@@ -1770,9 +1774,10 @@ def apply_export_sync_back() -> ResponseReturnValue:
 
         # If no existing file is found (unexpected for sync-back), append via export category.
         if not release_file:
-            category = _resolve_primary_lemma_category(sentence)
-            dir_name = _TYPE_TO_DIR.get(category[0], category[0])
-            category_dir = release_dir / dir_name / category[1]
+            collection = sentence.sentence_collection or "general"
+            pos_type, pos_subtype = _resolve_primary_lemma_category(sentence)
+            dir_name = _TYPE_TO_DIR.get(pos_type, pos_type)
+            category_dir = release_dir / collection / dir_name / pos_subtype
             category_dir.mkdir(parents=True, exist_ok=True)
             release_file = category_dir / "base.jsonl"
 

--- a/src/storage/migrate.py
+++ b/src/storage/migrate.py
@@ -576,9 +576,11 @@ def export_sqlite_to_release(sqlite_path: str, release_dir: str) -> None:
 def export_sqlite_to_sentence_release(sqlite_path: str, release_dir: str) -> None:
     """Export sentences from SQLite to data/release/sentences format.
 
-    Sentences are grouped by their **primary lemma** — the noun with the lowest
-    GUID among the sentence's pattern words.  Falls back to any lemma with the
-    lowest GUID, then to ``misc/``.
+    Sentences are grouped first by their **collection** (sentence_collection field,
+    defaulting to "general"), then by primary lemma pos_type/pos_subtype — the noun
+    with the lowest GUID among pattern words, falling back to misc/misc.
+
+    Structure: {release_dir}/{collection}/{pos_dir}/{pos_subtype}/base.jsonl
 
     Conversation sentences are excluded.
 
@@ -639,25 +641,26 @@ def export_sqlite_to_sentence_release(sqlite_path: str, release_dir: str) -> Non
         sentences = [s for s in sentences if s.id not in conversation_ids]
         print(f"Found {len(sentences)} non-conversation sentences to export")
 
-        # Group sentences by primary lemma category
-        sentences_by_category: Dict[Tuple[str, str], List[Dict[str, Any]]] = defaultdict(list)
+        # Group sentences by (collection, pos_type, pos_subtype)
+        sentences_by_category: Dict[Tuple[str, str, str], List[Dict[str, Any]]] = defaultdict(list)
 
         for sentence in sentences:
             record = _sentence_to_release_record(sentence)
-            category = _resolve_primary_lemma_category(sentence)
-            sentences_by_category[category].append(record)
+            collection = sentence.sentence_collection or "general"
+            pos_type, pos_subtype = _resolve_primary_lemma_category(sentence)
+            sentences_by_category[(collection, pos_type, pos_subtype)].append(record)
 
         print(f"Organized into {len(sentences_by_category)} categories")
 
-        for (pos_type, pos_subtype), records in sentences_by_category.items():
+        for (collection, pos_type, pos_subtype), records in sentences_by_category.items():
             dir_name = type_to_dir.get(pos_type, pos_type)
-            category_dir = Path(release_dir) / dir_name / pos_subtype
+            category_dir = Path(release_dir) / collection / dir_name / pos_subtype
             category_dir.mkdir(parents=True, exist_ok=True)
 
             # Sort by GUID within each file
             records.sort(key=lambda r: r["guid"])
 
-            print(f"Exporting {len(records)} sentences to {dir_name}/{pos_subtype}...")
+            print(f"Exporting {len(records)} sentences to {collection}/{dir_name}/{pos_subtype}...")
             _write_jsonl_atomic(category_dir / "base.jsonl", records)
 
         print("Sentence export complete!")
@@ -720,6 +723,8 @@ def _sentence_to_release_record(sentence: Any) -> Dict[str, Any]:
     record: Dict[str, Any] = {
         "guid": sentence.guid,
     }
+    if sentence.sentence_collection:
+        record["collection"] = sentence.sentence_collection
     if sentence.pattern_type:
         record["pattern_type"] = sentence.pattern_type
     if sentence.tense:

--- a/src/storage/models/schema.py
+++ b/src/storage/models/schema.py
@@ -405,6 +405,9 @@ class Sentence(Base):
     # NULL means difficulty hasn't been calculated yet
     minimum_level: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
 
+    # Collection — which sentence set this belongs to (e.g., "beginner", "gutenberg")
+    sentence_collection: Mapped[Optional[str]] = mapped_column(String, nullable=True, index=True)
+
     # Source tracking
     source_filename: Mapped[Optional[str]] = mapped_column(
         String, nullable=True


### PR DESCRIPTION
New layout: data/release/sentences/{collection}/{pos_dir}/{pos_subtype}/base.jsonl

- Add sentence_collection field to Sentence model
- Include collection in JSONL records (as "collection" key)
- Group export by (collection, pos_type, pos_subtype); default collection is "general"
- Update sync route path construction accordingly; rglob-based loaders require no changes

https://claude.ai/code/session_01CeLjwJs6pNJr7RC7VrNYnM