### PR TITLE
Improve documentation: add per-directory READMEs, fix stale docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,12 +18,21 @@ pip install -e ".[dev]"
 pip install -e ".[ml]"
 ```
 
+## Submodules (Optional)
+
+`audio/`, `data/greenland_input/`, and `data/trakaido_wordlists/` are git
+submodules. Initialize them only if you need their contents:
+
+```bash
+git submodule update --init <path>
+```
+
 ## Pre-commit Hooks
 
 Enable black formatting checks on commit:
 
 ```bash
-git config core.hooksPath hooks
+git config core.hooksPath .githooks
 ```
 
 ## Database Initialization

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Greenland is the core data and tooling repository for the **Trakaido** language-
 It combines a multilingual linguistic database, editing interfaces, automation agents,
 and language-model evaluation tools.
 
-**Python 3.12+** | **SQLite-backed** | **14 supported languages**
+**Python 3.12+** | **SQLite-backed** | **15 supported languages**
 
 ## Main Components
 
@@ -16,8 +16,9 @@ and language-model evaluation tools.
 
 ## Supported Languages
 
-English, Lithuanian, Chinese (Simplified), French, German, Spanish, Portuguese,
-Korean, Swahili, Vietnamese, Japanese, Italian, Dutch, Swedish.
+English, Lithuanian, Chinese (Simplified), Chinese (Traditional), French,
+German, Spanish, Portuguese, Korean, Swahili, Vietnamese, Japanese, Italian,
+Dutch, Swedish.
 
 ## Quick Start
 
@@ -39,12 +40,23 @@ python run_tests.py
 ```text
 greenland/
 ├── src/                 # Application and tooling source code
-├── data/release/        # Versioned release data files
+├── api/                 # Typed HTTP client facade over the Barsukas API
+├── data/                # Source corpora and versioned release data
+├── audio/               # Audio tooling (git submodule: powera/audiotools)
 ├── prompts/             # Prompt templates used by agents/tools
 ├── docs/                # Project documentation
-├── hooks/               # Git hooks (pre-commit config)
+├── scripts/             # Bootstrap, pipeline, and pre-commit check scripts
+├── strings/             # Localized UI string catalogs for Barsukas
+├── prod/                # Production deployment configuration
+├── .githooks/           # Git hooks (pre-commit config)
 ├── pyproject.toml       # Python/tooling configuration
 └── run_tests.py         # Test runner entry point
 ```
 
-For source-level structure, see [src/README.md](src/README.md).
+## Documentation
+
+- [INSTALL.md](INSTALL.md) — setup, database initialization, running tests
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contribution guidelines
+- [src/README.md](src/README.md) — source-level structure and agent list
+- [docs/](docs/README.md) — design documents and API reference
+- Most directories have a short README describing their contents.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,27 @@
+# data
+
+Source corpora, vocabulary profiles, and release data for the linguistic
+database.
+
+## Subdirectories
+
+- `release/` — canonical JSONL export of the lemma database, organized as
+  `lemmas/{pos_type}/{pos_subtype}/*.jsonl`. See `release/README.md` for the
+  record format and editing rules.
+- `wordfreq/` — word frequency corpora (books, Wikipedia vital articles,
+  SUBTLEX; see `wordfreq/subtlex.md`). Also the default home of the working
+  database, `linguistics.sqlite` (gitignored).
+- `basic_english/` — Ogden's Basic English extended wordlist
+- `cambridge/` — Cambridge Young Learners English (YLE) vocabulary profile
+- `cefr/` — CEFR-J (A1–B2) and Octanove (C1–C2) vocabulary profiles
+- `greenland_input/` — git submodule (`powera/greenland-input`) with input
+  files for import
+- `trakaido_wordlists/` — git submodule (`powera/trakaido-wordlists`) holding
+  the generated WireWord wordlists for the Trakaido app
+
+Top-level files include `categorychoice*.json` (category metadata for
+Trakaido exports) and `lt_sample_*.txt` (Lithuanian sample texts).
+
+Frequency corpora are loaded into the database by the `pradzia` agent;
+`data/release` is round-tripped via the Barsukas `/sync` UI and
+`storage/migrate.py`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# docs
+
+Design documents and reference documentation.
+
+- `API.md` — read-only REST API endpoints (lemma search, detail, metadata)
+- `barsukas_agents.md` — agent dependency graph and pipeline workflow
+  (`barsukas_agents.gv` is the Graphviz source)
+- `barsukas_prometheus_metrics.md` — Prometheus metrics exposed by Barsukas
+- `difficulty_overrides.md` — per-language difficulty level overrides
+- `sentence_sync_design.md` — design for syncing sentences between SQLite and
+  `data/release`
+- `word2vec_pgvector_plan.md` — plan for word embeddings with PostgreSQL
+  pgvector

--- a/ephemera/README.md
+++ b/ephemera/README.md
@@ -1,0 +1,5 @@
+# ephemera
+
+Archived experimental data that is not part of any production workflow.
+Currently holds 2024 model-evaluation artifacts (prompt/response/critique
+JSON files and related test output).

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,23 @@
+# prompts
+
+Prompt templates used by agents and tools, loaded via
+`src/util/prompt_loader.py`. Each task directory contains a `prompt.txt`
+and/or `context.txt`.
+
+## Subdirectories
+
+- `analysis/` — word/sentence analysis and disambiguation
+- `audio/` — context for TTS audio generation
+- `benchmarks/` — coding benchmark prompts
+- `classification/` — POS subtype and word categorization
+- `conversations/` — dialog and definition generation
+- `grammar/` — grammar facts (animacy, gender, declension, transitivity, …)
+- `language_forms/` — per-language morphological form generation, organized
+  by language code and POS subtype
+- `pronunciation/` — IPA and pronunciation generation
+- `sentence_decomposition/` — sentence parsing and translation breakdown
+- `sentences/` — example sentence generation by difficulty level
+- `synonyms/` — synonym discovery
+- `translation/` — word, definition, and sentence translation
+- `validation/` — definition/lemma/translation validation
+- `verbalator/` — text analysis prompts for the verbalator tooling

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# scripts
+
+Repo-level utility scripts: pre-commit checks, bootstrap, and pipeline
+helpers. (Database maintenance scripts live in `src/scripts/` instead.)
+
+- `bootstrap.sh` — initialize the database from scratch (create tables, load
+  frequency corpora, calculate ranks)
+- `activate_guid.py` / `activate_guid.sh` — run the full agent pipeline for a
+  single lemma GUID
+- `check_duplicate_guids.py` — pre-commit check for duplicate GUIDs in
+  `data/release`
+- `check_api_mirror_routes.py` — pre-commit check that `api/` facades match
+  `src/barsukas` routes
+- `check_langtools_required_functions.py` — pre-commit check that required
+  langtools functions exist per language
+- `migrate_synonym_uniqueness.py` — report cross-lemma synonym duplicates

--- a/src/README.md
+++ b/src/README.md
@@ -9,9 +9,8 @@ src/
 │   ├── translation/       # LLM-based translation and form generation
 │   ├── frequency/         # Word frequency analysis
 │   ├── dictionary/        # Word list management and export
-│   ├── prompts/           # LLM prompt templates
+│   ├── tiers/             # Difficulty tier importers (CEFR, Cambridge YLE)
 │   ├── tools/             # CLI utilities
-│   ├── trakaido/          # Trakaido app integration
 │   └── data/              # Python data modules (family_relations)
 │
 ├── agents/                # Autonomous data quality agents
@@ -21,10 +20,14 @@ src/
 ├── util/                  # General utilities
 ├── wireword/              # WireWord format export
 ├── langtools/             # Language processing tools
-├── audioshoe/             # Audio generation (eSpeak, Piper, Coqui)
-├── scripts/               # Standalone scripts
+├── ipa/                   # IPA pronunciation utilities
+├── audioshoe/             # Audio generation (eSpeak, Piper, Coqui, Qwen)
+├── scripts/               # Standalone maintenance scripts
 ├── sentences/             # Sentence processing
-├── workqueue/             # Work queue infrastructure
+├── strings/               # Barsukas UI string localization tooling
+├── words/                 # Word-level LLM helpers
+├── verbalator/            # Text analysis tooling
+├── workqueue/             # Background task queue
 ├── tests/                 # Tests
 └── constants.py           # Centralized path configuration
 ```
@@ -58,6 +61,8 @@ usage and arguments.
 | elnias | Deer | WireWord bootstrap export |
 | erelis | Eagle | False lemma match detection in sentences |
 | gandras | Stork | Audio manifest downloader |
+| genys | Woodpecker | Document parser and pending import stager |
+| seskas | Ferret | Multi-model verb-conjugation consensus |
 
 ---
 

--- a/src/agents/README.md
+++ b/src/agents/README.md
@@ -30,6 +30,9 @@ As of the queue-first transition, agent CLIs are moving toward **work discovery 
 | **strazdas** | thrush | Audio generation (eSpeak-NG) |
 | **vieversys** | lark | Audio generation (OpenAI TTS) |
 | **seskas** | ferret | Multi-model verb-conjugation consensus generator |
+| **erelis** | eagle | False lemma match detection in sentences |
+| **gandras** | stork | Audio manifest downloader (S3 staging) |
+| **genys** | woodpecker | Document parser and pending import stager |
 
 ## Common Arguments
 
@@ -214,6 +217,29 @@ seskas.py --language lt --verbs-file data/verbs/lt.txt
 seskas.py --language es --verbs-file /tmp/es_verbs.txt --output src/langtools/es/generated_conjugations.py
 seskas.py --language pl --verbs-file /tmp/pl_verbs.txt --model-paths qwen3-4b-lms phi-4-lms gemma-3-12b-lms
 seskas.py --language lt --verbs-file /tmp/lt_verbs.txt --on-existing merge
+```
+
+### erelis (False Lemma Matches)
+
+```bash
+erelis.py --language zh               # Detect false lemma matches in Chinese
+erelis.py --language zh --limit 100   # Limit number of sentences checked
+erelis.py --language zh --guid V03_007
+```
+
+### gandras (Audio Manifest Downloader)
+
+```bash
+gandras.py --mode list                # Show available S3 manifests
+gandras.py --mode report --language lt
+gandras.py --mode download --language lt --voice ruta --output-dir audio/
+```
+
+### genys (Document Import)
+
+```bash
+genys.py --input document.txt --language en
+genys.py --input document.txt --language zh --store-sentences
 ```
 
 ## Creating New Agents

--- a/src/audioshoe/README.md
+++ b/src/audioshoe/README.md
@@ -1,0 +1,18 @@
+# audioshoe
+
+Text-to-speech (TTS) audio generation with support for multiple engines.
+Used to generate word and sentence audio for the Trakaido app.
+
+## Layout
+
+- `coqui/` — Coqui TTS (neural synthesis, voice cloning)
+- `piper/` — Piper TTS (lightweight local inference)
+- `espeak/` — eSpeak-NG CLI wrapper (phonetic synthesis)
+- `qwen/` — Qwen TTS integration
+- `driver.py`, `sample_driver.py` — Whisper speech-to-text drivers for audio
+  regression testing
+- `split_file.py` — audio segmentation and transcription utilities
+
+Each engine subdirectory has its own README with setup and usage details.
+Audio generation is normally driven by the `strazdas` and `vieversys` agents
+(see `src/agents/README.md`).

--- a/src/ipa/README.md
+++ b/src/ipa/README.md
@@ -1,0 +1,17 @@
+# ipa
+
+Utilities for working with IPA (International Phonetic Alphabet)
+pronunciations: generation, normalization, and rhyme key computation.
+
+## Layout
+
+- `generation.py` — LLM-based IPA pronunciation generation with schema
+  validation
+- `normalization.py` — IPA string normalization, character validation, and
+  similarity scoring
+- `rhyme_keys.py` — language-specific rhyme key computation (vowel/stress
+  detection)
+- `ipa_chars.json` — reference data of valid IPA characters
+
+The public API is exported from `__init__.py` (e.g.,
+`generate_ipa_pronunciation`, `normalize_ipa`, `compute_rhyme_key`).

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,23 @@
+# scripts (src)
+
+One-off administrative and maintenance scripts for data cleanup, migration,
+and validation. Run with:
+
+```bash
+PYTHONPATH=src python src/scripts/<script>.py --help
+```
+
+- `check_duplicates.py` — classify word collisions in release data
+- `find_duplicates.py` — find partial duplicates across non-English
+  translations
+- `accept_approved_sentence_audio.py` — promote staged sentence audio to
+  production S3
+- `backfill_derivative_form_tokens.py` — fix missing `word_token_id` links on
+  derivative forms
+- `migrate_staging_audio_paths.py` — migrate audio files to the
+  language/voice directory layout
+- `update_prominence.py` — set `sense_prominence` from Trakaido difficulty
+  levels
+
+For repo-level checks and deployment helpers, see the top-level `scripts/`
+directory instead.

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -1,0 +1,25 @@
+# storage
+
+Database access layer for the linguistic database (default:
+`data/wordfreq/linguistics.sqlite`). Provides the SQLAlchemy schema, CRUD
+operations, query helpers, and a pluggable backend abstraction.
+
+## Layout
+
+- `models/` — SQLAlchemy ORM schema (`Lemma`, `WordToken`, `DerivativeForm`,
+  `Sentence`, grammar facts, enums) plus GUID prefix definitions
+- `crud/` — create/read/update/delete functions for lemmas, tokens, sentences,
+  translations, grammar facts, and embeddings
+- `queries/` — read-only query helpers (lemma lookup, POS filtering, statistics)
+- `backend/` — pluggable storage backends (SQLite, JSONL) and
+  `DataSourceConfig`, the standard way to pass db/model configuration around
+- `migrations/`, `migrate.py` — schema migrations and release-data export
+- `translation_helpers.py` — all language code constants and conversion
+  functions; import from here instead of defining local mappings
+- `connection_pool.py` — thread-safe session pooling
+- `legacy.py` — backward-compatibility wrapper for the old `Word` model
+
+## Conventions
+
+Pass configuration via `storage.backend.config.DataSourceConfig` rather than
+passing `db_path` or `model_name` directly.

--- a/src/strings/README.md
+++ b/src/strings/README.md
@@ -1,0 +1,12 @@
+# strings (src)
+
+Tooling for Barsukas UI string localization. The string catalogs themselves
+live in the top-level `strings/` directory (see `strings/README.md` and
+`strings/NAMING.md`); this package contains the code that extracts, loads,
+and tracks them.
+
+- `generate_barsukas_strings.py` — extract hardcoded strings from Barsukas
+  templates into localization catalogs
+- `barsukas_helpers.py` — load UI strings by namespace for Barsukas
+- `gyvate_service.py` — string export service and template change tracking
+- `count_barsukas_pending_strings.py` — report strings awaiting translation

--- a/src/util/README.md
+++ b/src/util/README.md
@@ -1,0 +1,13 @@
+# util
+
+General-purpose utilities shared across the codebase. These modules are
+imported as libraries; there are no CLI entry points here.
+
+- `prompt_loader.py` — loads prompt templates from the top-level `prompts/`
+  directory (with caching)
+- `telemetry.py` — LLM usage metrics and cost estimation
+- `logging_config.py` — centralized logging setup
+- `optional_imports.py` — graceful handling of optional dependencies
+- `flesch_kincaid.py` — readability scoring
+- `stopwords.py` — stopword lists
+- `wiki_loader.py` — indexing and querying Wikimedia dump files

--- a/src/wireword/README.md
+++ b/src/wireword/README.md
@@ -1,0 +1,21 @@
+# wireword
+
+Exporters that convert linguistic data into the WireWord JSON format consumed
+by the Trakaido language-learning app.
+
+## Layout
+
+- `export_wireword.py` — main word/lemma exporter
+- `export_wireword_sentences.py` — sentence exports with translations and
+  audio metadata
+- `export_wireword_conversations.py` — conversation exports
+- `export_manager.py` — orchestrates exports across formats
+- `generate_manifest.py` — manifest files for audio and data exports
+- `generate_categorychoice.py` — category-choice metadata for the app
+- `helpers.py`, `readings.py`, `text_rendering.py`, `data_models.py` —
+  formatting, pronunciation/reading data, and transfer objects
+
+## Usage
+
+Exports are normally run via the `ungurys` and `elnias` agents (see
+`src/agents/README.md`) or workqueue handlers, rather than invoked directly.

--- a/src/wordfreq/README.md
+++ b/src/wordfreq/README.md
@@ -1,154 +1,61 @@
 # WordFreq
 
-A system for linguistic analysis, word frequency tracking, and multi-language translations for the Greenland project.
+Core linguistic database system: word frequency tracking, difficulty tiers,
+and LLM-based translation and analysis for the Greenland project.
+
+Related code that used to live here has moved: database models are in
+`src/storage/`, agents in `src/agents/`, and prompt templates in the
+top-level `prompts/` directory (loaded via `util.prompt_loader`).
 
 ## Directory Structure
 
-### `agents/`
-Autonomous agents for data quality and maintenance tasks. See [agents/README.md](agents/README.md) for details.
-
-### `data/`
-Source data files for word frequency analysis:
-- `*.json` - Word frequency data from various corpora (19th/20th century books, cooking recipes, etc.)
-- `subtlex.txt` - SUBTLEX subtitle corpus frequencies
-- `wiki_vital.json` - Wikipedia vital articles word frequencies
-- `compare.py` - Scripts for comparing frequency data across corpora
-
-### `dictionary/`
-Word list export and review tools:
-- `export_wordlist.py` - Export words to plain text lists
-- `reviewer.py` - Interactive word review and verification interface
-
 ### `frequency/`
 Frequency analysis and corpus management:
-- `analysis.py` - Word frequency analysis and ranking calculations
-- `importer.py` - Import frequency data from external sources
-- `corpus.py` - Corpus loading and processing
-  - `load_all_corpora()` - Load all corpus data into the database
-- `tools/create_wordfreq_simple.py` - Simplified frequency list generation
+- `corpus.py` — corpus loading and processing (`load_all_corpora()`)
+- `importer.py` — import frequency data from external sources
+- `combined_rank.py` — aggregate frequency rank calculations
 
-### `output/`
-Generated output files from exports and analysis (not tracked in git)
-
-### `prompts/`
-LLM prompt templates for linguistic analysis:
-- `definitions/` - Word definition generation prompts
-- `chinese_translation/` - Chinese translation prompts
-- `pos_subtype/` - Part-of-speech subtype classification prompts
-- `pronunciation/` - Pronunciation generation prompts
-- `word_forms/` - Word form generation prompts
-- `word_analysis/` - Comprehensive word analysis prompts
-- `word_categorizer/` - Word categorization prompts
-- `lithuanian_noun_declensions/` - Lithuanian noun declension prompts
-
-Each prompt directory contains:
-- `context.txt` - System context for the LLM
-- `prompt.txt` - User prompt template with placeholders
-
-### `storage/`
-Database models and connection management:
-- `database.py` - Database operations and queries
-- `connection_pool.py` - Thread-safe database connection pooling
-- `models/` - SQLAlchemy ORM models for the database schema
-  - `schema.py` - Core database models (WordToken, Lemma, DerivativeForm, etc.)
-  - `enums.py` - Enumeration types for database fields
-  - `translations.py` - Translation model structures
-  - `query_log.py` - LLM query logging
-
-### `templates/`
-HTML templates for web-based word browsing:
-- `pos_index.html` - Part-of-speech index page
-- `pos_type.html` - POS type listing page
-- `pos_subtype.html` - POS subtype detail page
-- CSS and JavaScript for interactive features
-
-### `tools/`
-Specialized utilities:
-- `word_categorizer.py` - Categorize words from frequency lists using LLM analysis
-
-### `trakaido/`
-Trakaido language learning system integration:
-- `utils/` - Core utilities for trakaido word management
-  - `word_manager.py` - Add, update, and manage trakaido words
-  - `cli.py` - Command-line interface
-  - `data_models.py` - Data structures for word data
-  - `text_rendering.py` - Display and formatting utilities
-- `migrate_static_data.py` - Import static word lists into the database
+### `tiers/`
+Difficulty tier annotations from external sources (CEFR, Cambridge YLE,
+Basic English). Each source supplies a `TierImporter`; imports run via
+`runner.run_import`.
 
 ### `translation/`
-LLM-based linguistic analysis and translation:
-- `client.py` - Main client for querying LLMs for word analysis
-- `processor.py` - Batch processing workflows
-- `noun_forms.py` - Lithuanian noun form data structures
-- `wiki.py` - Wiktionary scraping for Lithuanian declensions
-- `generate_lithuanian_noun_forms.py` - Generate Lithuanian noun declensions
+LLM-based linguistic analysis: word translation, definitions, pronunciation,
+POS subtype classification, and form generation (`client.py`,
+`processor.py`, `generate_forms_*.py`, `wiktionary_forms.py`).
+
+### `dictionary/`
+Word list export and review tools (`export_wordlist.py`, `reviewer.py`).
+
+### `tools/`
+CLI utilities: difficulty override management, release reports,
+sentence/word linking, vocabulary budgets, country and family-relation
+overrides, Chinese conversion, word categorization.
+
+### `data/`
+Python data modules and corpus comparison helpers (`compare.py`,
+family-relations generators).
+
+### `templates/`
+HTML templates for web-based POS browsing.
+
+### Top-level modules
+- `golden_loader.py` — load frequency and tier data into the JSONL backend's
+  in-memory database
+- `lexeme_frequency.py` — lexeme-level frequency rollups over external
+  lexeme annotations
 
 ## Key Concepts
 
-### Database Schema
-The system uses a relational model with these core entities:
-- **WordToken** - Individual word forms (tokens) with frequency data
-- **Lemma** - Base word meanings with definitions and translations
-- **DerivativeForm** - Links tokens to lemmas with grammatical information
-- **Corpus** - Source corpora for frequency data
-- **WordFrequency** - Frequency counts per word per corpus
-
-### Frequency Rankings
-Words are ranked by:
-- Individual corpus frequencies
-- Harmonic mean across multiple corpora
-- Combined frequency rank (aggregate score)
-
-### LLM Integration
-All LLM queries go through `clients.unified_client.UnifiedLLMClient` and use prompt templates from the `prompts/` directory. Prompts are loaded via `util.prompt_loader.get_context()` and `get_prompt()`.
-
-## CLI Tools & Scripts
-
-### Data Analysis
-- **`data/compare.py`** - Compare word frequency rankings across multiple corpus files
-  - Usage: `python compare.py file1.json file2.json [--csv] [--top 50]`
-  - Outputs harmonic mean rankings and maximum rank differences
-
-### Dictionary Export
-- **`dictionary/export_wordlist.py`** - Export words to plain text lists
-- **`dictionary/reviewer.py`** - Interactive word review and verification interface
-
-### Word Categorization
-- **`tools/word_categorizer.py`** - Categorize words from frequency lists using LLM analysis
-  - Usage: `python word_categorizer.py "category" [--limit 1000] [--save-json output.json]`
-  - Example: `python word_categorizer.py "animals" --limit 500`
-
-### Trakaido System
-- **`trakaido/utils.py`** - Main entry point for trakaido word management
-  - Usage: `python utils.py <command> [options]`
-
-  **Commands:**
-  - `utils.py add <word> [--lithuanian LT] [--level N]` - Add new word with LLM analysis
-  - `utils.py update <guid|word> [--model MODEL]` - Update existing word entry
-  - `utils.py set-level <guid|word> <level> [--reason REASON]` - Set difficulty level
-  - `utils.py move-words <from_level> <subtype> <to_level>` - Bulk move words by level and subtype
-  - `utils.py list [--level N] [--subtype TYPE]` - List words with optional filters
-  - `utils.py subtypes` - List all POS subtypes with word counts
-  - `utils.py export json [--output PATH]` - Export to JSON format
-  - `utils.py export wireword [--output PATH]` - Export to WireWord API format
-  - `utils.py export lang-lt [--output-dir DIR]` - Export to lang_lt directory structure
-  - `utils.py export text <subtype> [--output PATH]` - Export simple text for specific subtype
-  - `utils.py export all` - Export to all formats at once
-
-- **`trakaido/dict_generator.py`** - Generate structure and dictionary files for trakaido wordlists
-  - Usage: `python dict_generator.py [--language lithuanian|chinese] [--level N] [--subtype SUBTYPE]`
-  - Generates Python files with word data organized by difficulty level and subtype
-
-- **`trakaido/json_to_database.py`** - Import trakaido data from JSON into the database
-  - Usage: `python json_to_database.py [path/to/nouns.json] [--no-update-difficulty]`
-  - Migrates English/Lithuanian word pairs with GUIDs and difficulty levels
-
-### Translation
-- **`translation/generate_lithuanian_noun_forms.py`** - Generate Lithuanian noun declensions
-  - Batch generation of all 14 declension forms (7 cases × 2 numbers) for Lithuanian nouns
-
-### Autonomous Agents
-See [agents/README.md](agents/README.md) for autonomous data quality and maintenance agents.
+- **Frequency rankings** — words are ranked per corpus, by harmonic mean
+  across corpora, and by combined aggregate rank.
+- **LLM integration** — all LLM queries go through
+  `clients.unified_client.UnifiedLLMClient`, with prompt templates loaded
+  from `prompts/` via `util.prompt_loader.get_context()` / `get_prompt()`.
 
 ## Database Location
-The default SQLite database is at `data/wordfreq/linguistics.sqlite` (or as configured in `constants.WORDFREQ_DB_PATH`).
+
+The default SQLite database is at `data/wordfreq/linguistics.sqlite` (or as
+configured in `constants.WORDFREQ_DB_PATH`). See `src/storage/README.md` for
+the schema.

--- a/src/workqueue/README.md
+++ b/src/workqueue/README.md
@@ -1,0 +1,26 @@
+# workqueue
+
+Background task queue used by Barsukas to defer expensive work (LLM calls,
+audio synthesis, exports) so the web UI stays responsive. Tasks are stored in
+the database and executed by a worker daemon.
+
+## Layout
+
+- `task_queue.py` — task status/type enums and queue operations (enqueue,
+  claim, complete, fail)
+- `registry.py` — maps task names (e.g., `words.translations`) to handler
+  functions
+- `pipeline_order.py` — dependency ordering so prerequisites run first
+  (e.g., translations before pronunciations)
+- `handlers/` — handler implementations grouped by capability (`words/`,
+  `sentences/`, `audio/`, `wireword/`, conversations)
+- `worker.py` — daemon that claims and executes tasks
+- `tools.py` — shared handler utilities (config building, session management)
+
+## Usage
+
+```bash
+PYTHONPATH=src python src/workqueue/worker.py --help
+```
+
+Tasks are normally enqueued from Barsukas via `enqueue_task()`.


### PR DESCRIPTION
- Add short READMEs to previously undocumented directories: data/, docs/,
  ephemera/, prompts/, scripts/, src/audioshoe, src/ipa, src/scripts,
  src/storage, src/strings, src/util, src/wireword, src/workqueue
- Rewrite src/wordfreq/README.md, removing sections for agents/, prompts/,
  storage/, output/, and trakaido/ which no longer live there, and
  documenting the current tiers/, tools/, and top-level modules
- Fix stale claims: hooks path is .githooks (README.md, INSTALL.md),
  15 release languages including Traditional Chinese (README.md)
- Add missing agents (erelis, gandras, genys, seskas) to the agent tables
  in src/README.md and src/agents/README.md, with usage examples
- Update src/README.md directory tree (add ipa/, strings/, words/,
  verbalator/, tiers/; remove nonexistent wordfreq subdirs)
- Document git submodules (audio/, data/greenland_input/,
  data/trakaido_wordlists/) in INSTALL.md and data/README.md
- Expand repository layout and add a documentation index in README.md

https://claude.ai/code/session_01PTwKqMb69Hn5eZa2iGcZ9j