### PR TITLE
langtools: add adjective forms for es/fr/de/sv/nl and standardize conjugation API

### DIFF
--- a/src/langtools/LANGUAGE_MODULE_FORMAT.md
+++ b/src/langtools/LANGUAGE_MODULE_FORMAT.md
@@ -130,14 +130,29 @@ Contract expectations:
 
 ### `conjugation.py` (optional)
 
-Expected callable pattern:
+Expected callable pattern (standard cross-language entrypoint):
 
 ```python
-# def mechanically_conjugate_<lang>_verb(lemma: str, ...) -> Optional[Dict[str, str]]: ...
+def conjugate(lemma: str, **kwargs: str) -> Optional[Dict[str, str]]: ...
 ```
 
+- Returns a ``{form_key: form}`` dict for the lemma, or ``None`` when the verb
+  cannot be conjugated mechanically (unrecognised ending, irregular not in
+  table, etc.).
 - Deterministic verb conjugation logic for languages that support it.
-- May be called directly by dispatcher or from `llm_forms.py` fast paths.
+- Called from `llm_forms.py` mechanical fast paths (with LLM fallback).
+- Language notes:
+  - Most languages take just the lemma (`es`, `pt`, `de`, `nl`, `sv`, `it`;
+    `it` also accepts optional `present_1s`/`past_1s`/`future_1s` principal
+    parts).
+  - `lt` additionally **requires** the 3rd-person present and past principal
+    parts: `conjugate(infinitive, present_3, past_3)` (legacy alias:
+    `conjugate_verb`).
+  - `fr` also exposes `conjugate_detailed(lemma) -> Tuple[VerbConjugation, bool]`
+    when confidence/notes metadata is needed.
+  - `en` derives the table from the infinitive; the richer
+    `expand_verb_forms(base_forms)` is preferred when canonical past /
+    past-participle base forms are already stored.
 
 ### `grammatical_words.py` (optional)
 

--- a/src/langtools/LANGUAGE_STATUS.md
+++ b/src/langtools/LANGUAGE_STATUS.md
@@ -39,6 +39,20 @@ Legend:
 5. Dispatcher standardization at top-level `src/langtools/*.py` should continue
    to converge toward language-first dynamic import entrypoints.
 
+## Adjective coverage + conjugation API (2026-06-15)
+
+- **Adjective forms** are now configured for all core languages. `es`, `fr`,
+  `de`, `nl` use the `singular_m/f` × `plural_m/f` agreement axis; `sv` uses the
+  Swedish `common`/`neuter`/`plural` axis (no grammatical gender). `es` and `fr`
+  additionally have mechanical adjective helpers (`inflection.py`) with LLM
+  fallback; `de`/`sv`/`nl` adjectives are LLM-only. (`en`, `it`, `pt`, `lt`
+  already had adjective configs.)
+- **Mechanical conjugation API standardized** on
+  `conjugate(lemma, ...) -> Optional[Dict[str, str]]` across the core languages.
+  `fr.conjugate` now returns the forms dict (use `conjugate_detailed` for
+  confidence/notes); `lt.conjugate` is the canonical name (`conjugate_verb`
+  retained as alias); `en` adds a `conjugate` wrapper over `expand_verb_forms`.
+
 ## FIGS+LT directory-shape verification (2026-05-13)
 
 Checked against `LANGUAGE_MODULE_FORMAT.md` and `STRUCTURE.md`:

--- a/src/langtools/de/forms_config.py
+++ b/src/langtools/de/forms_config.py
@@ -27,6 +27,16 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "GermanVerbConjugations",
 }
 
+# German adjective declension is highly context-dependent (strong/weak/mixed ×
+# case × gender). For the learning app we capture a simplified gender/number
+# agreement set, generated via the LLM. The enum members already exist below.
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "german_adjective_forms",
+    "schema_name": "GermanAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_DE_PLURAL_F": "adjective/de_plural_f",
     "ADJ_DE_PLURAL_M": "adjective/de_plural_m",

--- a/src/langtools/en/__init__.py
+++ b/src/langtools/en/__init__.py
@@ -26,6 +26,7 @@ from langtools.en.types import (
 )
 from langtools.en.conjugation import (
     IRREGULAR_CONJUGATIONS,
+    conjugate,
     expand_verb_forms,
 )
 from langtools.en.utils import (
@@ -59,6 +60,7 @@ __all__ = [
     "get_english_noun_forms",
     "get_english_verb_forms",
     # Conjugation expansion
+    "conjugate",
     "expand_verb_forms",
     "IRREGULAR_CONJUGATIONS",
     # Utilities

--- a/src/langtools/en/conjugation.py
+++ b/src/langtools/en/conjugation.py
@@ -329,3 +329,19 @@ def expand_verb_forms(
         result["2p_imp"] = infinitive
 
     return result
+
+
+def conjugate(lemma: str) -> Optional[Dict[str, str]]:
+    """Conjugate an English verb from its infinitive.
+
+    Standard cross-language mechanical-conjugation entrypoint (matching
+    ``langtools.<lang>.conjugation.conjugate`` in the other languages).  English
+    derives the regular/irregular person-tense table from the infinitive alone;
+    use :func:`expand_verb_forms` directly when canonical past / past-participle
+    base forms are already known.
+    """
+    cleaned = lemma.strip()
+    if not cleaned:
+        return None
+    forms = expand_verb_forms({"infinitive": cleaned})
+    return forms or None

--- a/src/langtools/es/forms_config.py
+++ b/src/langtools/es/forms_config.py
@@ -19,6 +19,13 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "SpanishVerbConjugations",
 }
 
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "spanish_adjective_forms",
+    "schema_name": "SpanishAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_ES_PLURAL_F": "adjective/es_plural_f",
     "ADJ_ES_PLURAL_M": "adjective/es_plural_m",

--- a/src/langtools/es/inflection.py
+++ b/src/langtools/es/inflection.py
@@ -1,0 +1,53 @@
+"""Rule-based Spanish adjective inflection helpers.
+
+Spanish adjectives agree with their noun in gender and number.  This module
+covers only the high-confidence regular endings (-o, -a, -e, -z); ambiguous
+endings (most consonants, accented vowels, agent endings such as -or) return
+``None`` so the caller can fall back to the LLM.
+"""
+
+from typing import Dict, Optional
+
+
+def build_adjective_forms(adjective: str) -> Optional[Dict[str, str]]:
+    """Build m/f × singular/plural agreement forms from the masculine singular.
+
+    Returns ``None`` when the ending is not one of the reliably regular
+    patterns, leaving those cases to the LLM.
+    """
+    singular_m = adjective.strip().lower()
+    if not singular_m:
+        return None
+
+    # -o adjectives: four distinct forms (rojo / roja / rojos / rojas).
+    if singular_m.endswith("o"):
+        stem = singular_m[:-1]
+        return {
+            "singular_m": singular_m,
+            "singular_f": stem + "a",
+            "plural_m": stem + "os",
+            "plural_f": stem + "as",
+        }
+
+    # -e / -a adjectives: invariant for gender, +s for plural
+    # (grande / grandes, belga / belgas).
+    if singular_m.endswith(("e", "a")):
+        plural = singular_m + "s"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_m,
+            "plural_m": plural,
+            "plural_f": plural,
+        }
+
+    # -z adjectives: invariant for gender, z → ces for plural (feliz / felices).
+    if singular_m.endswith("z"):
+        plural = singular_m[:-1] + "ces"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_m,
+            "plural_m": plural,
+            "plural_f": plural,
+        }
+
+    return None

--- a/src/langtools/es/llm_forms.py
+++ b/src/langtools/es/llm_forms.py
@@ -8,6 +8,7 @@ from typing import Callable, Dict, Tuple
 
 from clients.unified_client import UnifiedLLMClient
 from langtools.es.conjugation import conjugate
+from langtools.es.inflection import build_adjective_forms
 from langtools.form_registry import FORM_SPECS
 from langtools.llm_forms_base import query_forms
 from sqlalchemy.orm import Session
@@ -17,6 +18,7 @@ from storage.translation_helpers import get_translation
 
 logger = logging.getLogger(__name__)
 
+ADJECTIVE_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("es", "adjective")].form_mapping
 NOUN_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("es", "noun")].form_mapping
 VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("es", "verb")].form_mapping
 
@@ -80,11 +82,50 @@ def get_verb_forms(
     return query_forms(FORM_SPECS[("es", "verb")], client, lemma_id, get_session_func)
 
 
+def get_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Generate Spanish adjective forms mechanically when possible, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "adjective":
+        spanish_adjective = get_translation(session, lemma, "es")
+        if spanish_adjective:
+            adjective_forms = build_adjective_forms(spanish_adjective)
+            if adjective_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=spanish_adjective,
+                    query_type="spanish_adjective_forms",
+                    prompt="[mechanical langtools.es.inflection]",
+                    response=json.dumps(
+                        {
+                            "forms": adjective_forms,
+                            "notes": "mechanical adjective agreement generation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return adjective_forms, True
+            logger.info("Falling back to LLM for Spanish adjective '%s'", spanish_adjective)
+
+    return query_forms(FORM_SPECS[("es", "adjective")], client, lemma_id, get_session_func)
+
+
 def query_spanish_noun_forms(
     client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
 ) -> Tuple[Dict[str, str], bool]:
     """Backward-compatible alias for noun form generation."""
     return get_noun_forms(client, lemma_id, get_session_func)
+
+
+def query_spanish_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Backward-compatible alias for adjective form generation."""
+    return get_adjective_forms(client, lemma_id, get_session_func)
 
 
 def query_spanish_verb_conjugations(

--- a/src/langtools/fr/__init__.py
+++ b/src/langtools/fr/__init__.py
@@ -36,6 +36,7 @@ from langtools.fr.utils import (
 )
 from langtools.fr.conjugation import (
     conjugate,
+    conjugate_detailed,
     is_known_irregular,
     list_irregular_verbs,
 )
@@ -58,6 +59,7 @@ __all__ = [
     "VerbConjugation",
     # Rule-based conjugation
     "conjugate",
+    "conjugate_detailed",
     "is_known_irregular",
     "list_irregular_verbs",
     # Convenience functions

--- a/src/langtools/fr/conjugation.py
+++ b/src/langtools/fr/conjugation.py
@@ -542,7 +542,21 @@ del _verb, _entry, _prefix, _base
 # ---------------------------------------------------------------------------
 
 
-def conjugate(infinitive: str) -> Tuple[VerbConjugation, bool]:
+def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
+    """Conjugate a French verb, returning a ``{form_key: form}`` dict or ``None``.
+
+    This is the standard cross-language mechanical-conjugation entrypoint
+    (matching ``langtools.<lang>.conjugation.conjugate`` in the other
+    languages).  Use :func:`conjugate_detailed` when the confidence/notes
+    metadata is needed.
+    """
+    conjugation, success = conjugate_detailed(infinitive)
+    if not success or not conjugation.forms:
+        return None
+    return conjugation.forms
+
+
+def conjugate_detailed(infinitive: str) -> Tuple[VerbConjugation, bool]:
     """Conjugate a French verb using rule-based logic.
 
     Returns ``(VerbConjugation, True)`` on success, or

--- a/src/langtools/fr/forms_config.py
+++ b/src/langtools/fr/forms_config.py
@@ -30,6 +30,13 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "FrenchVerbConjugations",
 }
 
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "french_adjective_forms",
+    "schema_name": "FrenchAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_FR_PLURAL_F": "adjective/fr_plural_f",
     "ADJ_FR_PLURAL_M": "adjective/fr_plural_m",

--- a/src/langtools/fr/inflection.py
+++ b/src/langtools/fr/inflection.py
@@ -1,0 +1,167 @@
+"""Rule-based French adjective inflection helpers.
+
+French adjectives agree with their noun in gender and number.  This module
+handles a small table of common irregular adjectives plus the high-confidence
+regular endings (-e, -eux, -er, -f, vowel, -t, -d).  Endings whose feminine is
+unpredictable (e.g. -s, -x, -l, -n, -c, -on, -eur) return ``None`` so the caller
+can fall back to the LLM.
+"""
+
+from typing import Dict, Optional
+
+# Masculine singular → full agreement table for irregular adjectives.
+_IRREGULAR: Dict[str, Dict[str, str]] = {
+    "beau": {
+        "singular_m": "beau",
+        "singular_f": "belle",
+        "plural_m": "beaux",
+        "plural_f": "belles",
+    },
+    "nouveau": {
+        "singular_m": "nouveau",
+        "singular_f": "nouvelle",
+        "plural_m": "nouveaux",
+        "plural_f": "nouvelles",
+    },
+    "vieux": {
+        "singular_m": "vieux",
+        "singular_f": "vieille",
+        "plural_m": "vieux",
+        "plural_f": "vieilles",
+    },
+    "fou": {"singular_m": "fou", "singular_f": "folle", "plural_m": "fous", "plural_f": "folles"},
+    "mou": {"singular_m": "mou", "singular_f": "molle", "plural_m": "mous", "plural_f": "molles"},
+    "blanc": {
+        "singular_m": "blanc",
+        "singular_f": "blanche",
+        "plural_m": "blancs",
+        "plural_f": "blanches",
+    },
+    "sec": {"singular_m": "sec", "singular_f": "sèche", "plural_m": "secs", "plural_f": "sèches"},
+    "doux": {"singular_m": "doux", "singular_f": "douce", "plural_m": "doux", "plural_f": "douces"},
+    "faux": {
+        "singular_m": "faux",
+        "singular_f": "fausse",
+        "plural_m": "faux",
+        "plural_f": "fausses",
+    },
+    "roux": {
+        "singular_m": "roux",
+        "singular_f": "rousse",
+        "plural_m": "roux",
+        "plural_f": "rousses",
+    },
+    "long": {
+        "singular_m": "long",
+        "singular_f": "longue",
+        "plural_m": "longs",
+        "plural_f": "longues",
+    },
+    "frais": {
+        "singular_m": "frais",
+        "singular_f": "fraîche",
+        "plural_m": "frais",
+        "plural_f": "fraîches",
+    },
+    "favori": {
+        "singular_m": "favori",
+        "singular_f": "favorite",
+        "plural_m": "favoris",
+        "plural_f": "favorites",
+    },
+    "gentil": {
+        "singular_m": "gentil",
+        "singular_f": "gentille",
+        "plural_m": "gentils",
+        "plural_f": "gentilles",
+    },
+    "gros": {
+        "singular_m": "gros",
+        "singular_f": "grosse",
+        "plural_m": "gros",
+        "plural_f": "grosses",
+    },
+    "bas": {"singular_m": "bas", "singular_f": "basse", "plural_m": "bas", "plural_f": "basses"},
+    "bon": {"singular_m": "bon", "singular_f": "bonne", "plural_m": "bons", "plural_f": "bonnes"},
+    "public": {
+        "singular_m": "public",
+        "singular_f": "publique",
+        "plural_m": "publics",
+        "plural_f": "publiques",
+    },
+}
+
+_VOWEL_ENDINGS = ("é", "i", "u", "ai", "y")
+
+
+def _masculine_plural(singular_m: str) -> str:
+    """Masculine plural: +s unless the form already ends in -s or -x."""
+    if singular_m.endswith(("s", "x")):
+        return singular_m
+    return singular_m + "s"
+
+
+def build_adjective_forms(adjective: str) -> Optional[Dict[str, str]]:
+    """Build m/f × singular/plural agreement forms from the masculine singular.
+
+    Returns ``None`` when the feminine form cannot be derived reliably,
+    leaving those cases to the LLM.
+    """
+    singular_m = adjective.strip().lower()
+    if not singular_m or len(singular_m) < 2:
+        return None
+
+    if singular_m in _IRREGULAR:
+        return dict(_IRREGULAR[singular_m])
+
+    # -eux → -euse (heureux / heureuse).
+    if singular_m.endswith("eux"):
+        singular_f = singular_m[:-1] + "se"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_f,
+            "plural_m": singular_m,
+            "plural_f": singular_f + "s",
+        }
+
+    # -er → -ère (cher / chère, premier / première).
+    if singular_m.endswith("er"):
+        singular_f = singular_m[:-2] + "ère"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_f,
+            "plural_m": singular_m + "s",
+            "plural_f": singular_f + "s",
+        }
+
+    # -f → -ve (vif / vive, actif / active).
+    if singular_m.endswith("f"):
+        singular_f = singular_m[:-1] + "ve"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_f,
+            "plural_m": singular_m + "s",
+            "plural_f": singular_f + "s",
+        }
+
+    # -e (not -é): invariant for gender, +s for plural (rouge / rouges).
+    if singular_m.endswith("e"):
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_m,
+            "plural_m": singular_m + "s",
+            "plural_f": singular_m + "s",
+        }
+
+    # Regular feminine in -e: vowel-final (joli / jolie) and -t / -d
+    # (petit / petite, grand / grande).
+    if singular_m.endswith(_VOWEL_ENDINGS) or singular_m.endswith(("t", "d")):
+        singular_f = singular_m + "e"
+        return {
+            "singular_m": singular_m,
+            "singular_f": singular_f,
+            "plural_m": _masculine_plural(singular_m),
+            "plural_f": singular_f + "s",
+        }
+
+    return None

--- a/src/langtools/fr/llm_forms.py
+++ b/src/langtools/fr/llm_forms.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, Tuple
 from clients.unified_client import UnifiedLLMClient
 from langtools.form_registry import FORM_SPECS
 from langtools.fr.conjugation import conjugate
+from langtools.fr.inflection import build_adjective_forms
 from langtools.llm_forms_base import query_forms
 from sqlalchemy.orm import Session
 from storage import database as linguistic_db
@@ -17,6 +18,7 @@ from storage.translation_helpers import get_translation
 
 logger = logging.getLogger(__name__)
 
+ADJECTIVE_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("fr", "adjective")].form_mapping
 NOUN_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("fr", "noun")].form_mapping
 VERB_FORM_MAPPING: Dict[str, GrammaticalForm] = FORM_SPECS[("fr", "verb")].form_mapping
 
@@ -38,8 +40,8 @@ def get_verb_forms(
     if lemma and lemma.pos_type.lower() == "verb":
         french_verb = get_translation(session, lemma, "fr")
         if french_verb:
-            conjugation, mechanical_success = conjugate(french_verb)
-            if mechanical_success and conjugation.forms:
+            conjugation_forms = conjugate(french_verb)
+            if conjugation_forms:
                 linguistic_db.log_query(
                     session,
                     word=french_verb,
@@ -47,18 +49,49 @@ def get_verb_forms(
                     prompt="[mechanical langtools.fr.conjugation]",
                     response=json.dumps(
                         {
-                            "forms": conjugation.forms,
-                            "confidence": conjugation.confidence,
-                            "notes": conjugation.notes,
+                            "forms": conjugation_forms,
+                            "notes": "mechanical regular conjugation",
                             "mechanical": True,
                         }
                     ),
                     model=client.default_model,
                 )
-                return conjugation.forms, True
+                return conjugation_forms, True
             logger.info("Falling back to LLM for French verb '%s'", french_verb)
 
     return query_forms(FORM_SPECS[("fr", "verb")], client, lemma_id, get_session_func)
+
+
+def get_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Generate French adjective forms mechanically when possible, else use LLM."""
+    session = get_session_func()
+    lemma = session.query(linguistic_db.Lemma).filter(linguistic_db.Lemma.id == lemma_id).first()
+
+    if lemma and lemma.pos_type.lower() == "adjective":
+        french_adjective = get_translation(session, lemma, "fr")
+        if french_adjective:
+            adjective_forms = build_adjective_forms(french_adjective)
+            if adjective_forms:
+                linguistic_db.log_query(
+                    session,
+                    word=french_adjective,
+                    query_type="french_adjective_forms",
+                    prompt="[mechanical langtools.fr.inflection]",
+                    response=json.dumps(
+                        {
+                            "forms": adjective_forms,
+                            "notes": "mechanical adjective agreement generation",
+                            "mechanical": True,
+                        }
+                    ),
+                    model=client.default_model,
+                )
+                return adjective_forms, True
+            logger.info("Falling back to LLM for French adjective '%s'", french_adjective)
+
+    return query_forms(FORM_SPECS[("fr", "adjective")], client, lemma_id, get_session_func)
 
 
 def query_french_noun_forms(
@@ -73,3 +106,10 @@ def query_french_verb_conjugations(
 ) -> Tuple[Dict[str, str], bool]:
     """Backward-compatible alias for verb form generation."""
     return get_verb_forms(client, lemma_id, get_session_func)
+
+
+def query_french_adjective_forms(
+    client: UnifiedLLMClient, lemma_id: int, get_session_func: Callable[[], Session]
+) -> Tuple[Dict[str, str], bool]:
+    """Backward-compatible alias for adjective form generation."""
+    return get_adjective_forms(client, lemma_id, get_session_func)

--- a/src/langtools/lt/__init__.py
+++ b/src/langtools/lt/__init__.py
@@ -18,7 +18,7 @@ Or using convenience functions:
     forms, success = get_lithuanian_noun_forms("vilkas")
 """
 
-from langtools.lt.conjugation import conjugate_verb
+from langtools.lt.conjugation import conjugate, conjugate_verb
 from langtools.lt.declension import (
     decline_noun,
     get_declension_requirements,
@@ -52,6 +52,7 @@ __all__ = [
     "NounDeclension",
     "VerbConjugation",
     # Conjugation / declension
+    "conjugate",
     "conjugate_verb",
     "decline_noun",
     "get_declension_requirements",

--- a/src/langtools/lt/conjugation.py
+++ b/src/langtools/lt/conjugation.py
@@ -294,7 +294,7 @@ def _conjugate_habitual_past(infinitive: str) -> Optional[Dict[str, str]]:
     }
 
 
-def conjugate_verb(infinitive: str, present_3: str, past_3: str) -> Optional[Dict[str, str]]:
+def conjugate(infinitive: str, present_3: str, past_3: str) -> Optional[Dict[str, str]]:
     """Generate all Lithuanian verb forms from three principal parts.
 
     Given the infinitive, 3rd person present, and 3rd person past,
@@ -352,3 +352,9 @@ def conjugate_verb(infinitive: str, present_3: str, past_3: str) -> Optional[Dic
     if habitual_past_forms is not None:
         all_forms.update(habitual_past_forms)
     return all_forms
+
+
+# Backward-compatible alias. ``conjugate`` is the standard cross-language
+# entrypoint name; Lithuanian additionally requires the 3rd-person present and
+# past principal parts as arguments.
+conjugate_verb = conjugate

--- a/src/langtools/lt/llm_forms.py
+++ b/src/langtools/lt/llm_forms.py
@@ -10,7 +10,7 @@ from typing import Callable, Dict, Tuple
 from clients.unified_client import UnifiedLLMClient
 from langtools.form_registry import FORM_SPECS
 from langtools.llm_forms_base import query_forms
-from langtools.lt.conjugation import conjugate_verb
+from langtools.lt.conjugation import conjugate
 from langtools.lt.declension import decline_noun
 from langtools.lt.principal_parts import get_principal_parts
 from sqlalchemy.orm import Session
@@ -150,7 +150,7 @@ def get_verb_forms(
                 principal_parts = _parse_principal_parts(lithuanian_verb)
 
             if principal_parts:
-                conjugation_forms = conjugate_verb(
+                conjugation_forms = conjugate(
                     infinitive=principal_parts[0],
                     present_3=principal_parts[1],
                     past_3=principal_parts[2],

--- a/src/langtools/nl/forms_config.py
+++ b/src/langtools/nl/forms_config.py
@@ -23,6 +23,16 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "DutchVerbConjugations",
 }
 
+# Dutch adjectives inflect mainly base vs. -e form; the gender/number set here
+# mirrors the cross-language agreement axis and is generated via the LLM. The
+# enum members already exist below.
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["singular_m", "singular_f", "plural_m", "plural_f"],
+    "query_type": "dutch_adjective_forms",
+    "schema_name": "DutchAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
     "ADJ_NL_PLURAL_F": "adjective/nl_plural_f",
     "ADJ_NL_PLURAL_M": "adjective/nl_plural_m",

--- a/src/langtools/sv/forms_config.py
+++ b/src/langtools/sv/forms_config.py
@@ -22,6 +22,18 @@ VERB_CONFIG: Dict[str, Any] = {
     "schema_name": "SwedishVerbConjugations",
 }
 
+# Swedish adjectives have no masculine/feminine gender; they agree by
+# common gender (en-words), neuter (ett-words), and plural/definite.
+ADJECTIVE_CONFIG: Dict[str, Any] = {
+    "type": "explicit",
+    "forms": ["common", "neuter", "plural"],
+    "query_type": "swedish_adjective_forms",
+    "schema_name": "SwedishAdjectiveForms",
+}
+
 GRAMMATICAL_FORM_OVERRIDES: Dict[str, str] = {
+    "ADJ_SV_COMMON": "adjective/sv_common",
+    "ADJ_SV_NEUTER": "adjective/sv_neuter",
+    "ADJ_SV_PLURAL": "adjective/sv_plural",
     "ADVERB_SV_BASE": "adverb/sv_base",
 }

--- a/src/tests/langtools/test_es_inflection.py
+++ b/src/tests/langtools/test_es_inflection.py
@@ -1,0 +1,52 @@
+"""Tests for rule-based Spanish adjective inflection."""
+
+import unittest
+
+from langtools.es.inflection import build_adjective_forms
+
+
+class TestSpanishAdjectiveForms(unittest.TestCase):
+    def test_o_adjective_four_forms(self) -> None:
+        self.assertEqual(
+            build_adjective_forms("rojo"),
+            {
+                "singular_m": "rojo",
+                "singular_f": "roja",
+                "plural_m": "rojos",
+                "plural_f": "rojas",
+            },
+        )
+
+    def test_e_adjective_invariant_gender(self) -> None:
+        self.assertEqual(
+            build_adjective_forms("grande"),
+            {
+                "singular_m": "grande",
+                "singular_f": "grande",
+                "plural_m": "grandes",
+                "plural_f": "grandes",
+            },
+        )
+
+    def test_a_adjective_invariant_gender(self) -> None:
+        forms = build_adjective_forms("belga")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "belga")
+        self.assertEqual(forms["plural_m"], "belgas")
+
+    def test_z_adjective_plural_ces(self) -> None:
+        forms = build_adjective_forms("feliz")
+        assert forms is not None
+        self.assertEqual(forms["plural_m"], "felices")
+        self.assertEqual(forms["plural_f"], "felices")
+
+    def test_uncertain_consonant_returns_none(self) -> None:
+        # -l adjectives (azul, español, ...) are left to the LLM.
+        self.assertIsNone(build_adjective_forms("azul"))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(build_adjective_forms(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/langtools/test_fr_conjugation.py
+++ b/src/tests/langtools/test_fr_conjugation.py
@@ -1,477 +1,448 @@
 """Tests for rule-based French verb conjugation."""
 
 import unittest
+from typing import Dict
 
-from langtools.fr.conjugation import conjugate, is_known_irregular, list_irregular_verbs
+from langtools.fr.conjugation import (
+    conjugate,
+    conjugate_detailed,
+    is_known_irregular,
+    list_irregular_verbs,
+)
 from langtools.fr.types import VerbConjugation
 
 
-class TestRegularErVerbs(unittest.TestCase):
+class _ConjugationTestBase(unittest.TestCase):
+    """Shared helper that returns the forms dict and asserts success."""
+
+    def _forms(self, verb: str) -> Dict[str, str]:
+        forms = conjugate(verb)
+        self.assertIsNotNone(forms, f"{verb} should conjugate successfully")
+        assert forms is not None  # narrow Optional for type-checkers
+        return forms
+
+
+class TestRegularErVerbs(_ConjugationTestBase):
     """Test first-group (-er) regular conjugation."""
 
     def test_parler_present(self) -> None:
-        result, ok = conjugate("parler")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "parle")
-        self.assertEqual(result.forms["2s_present"], "parles")
-        self.assertEqual(result.forms["3s_present"], "parle")
-        self.assertEqual(result.forms["1p_present"], "parlons")
-        self.assertEqual(result.forms["2p_present"], "parlez")
-        self.assertEqual(result.forms["3p_present"], "parlent")
+        forms = self._forms("parler")
+        self.assertEqual(forms["1s_present"], "parle")
+        self.assertEqual(forms["2s_present"], "parles")
+        self.assertEqual(forms["3s_present"], "parle")
+        self.assertEqual(forms["1p_present"], "parlons")
+        self.assertEqual(forms["2p_present"], "parlez")
+        self.assertEqual(forms["3p_present"], "parlent")
 
     def test_parler_imperfect(self) -> None:
-        result, ok = conjugate("parler")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "parlais")
-        self.assertEqual(result.forms["2s_impf"], "parlais")
-        self.assertEqual(result.forms["3s_impf"], "parlait")
-        self.assertEqual(result.forms["1p_impf"], "parlions")
-        self.assertEqual(result.forms["2p_impf"], "parliez")
-        self.assertEqual(result.forms["3p_impf"], "parlaient")
+        forms = self._forms("parler")
+        self.assertEqual(forms["1s_impf"], "parlais")
+        self.assertEqual(forms["2s_impf"], "parlais")
+        self.assertEqual(forms["3s_impf"], "parlait")
+        self.assertEqual(forms["1p_impf"], "parlions")
+        self.assertEqual(forms["2p_impf"], "parliez")
+        self.assertEqual(forms["3p_impf"], "parlaient")
 
     def test_parler_future(self) -> None:
-        result, ok = conjugate("parler")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_future"], "parlerai")
-        self.assertEqual(result.forms["2s_future"], "parleras")
-        self.assertEqual(result.forms["3s_future"], "parlera")
-        self.assertEqual(result.forms["1p_future"], "parlerons")
-        self.assertEqual(result.forms["2p_future"], "parlerez")
-        self.assertEqual(result.forms["3p_future"], "parleront")
+        forms = self._forms("parler")
+        self.assertEqual(forms["1s_future"], "parlerai")
+        self.assertEqual(forms["2s_future"], "parleras")
+        self.assertEqual(forms["3s_future"], "parlera")
+        self.assertEqual(forms["1p_future"], "parlerons")
+        self.assertEqual(forms["2p_future"], "parlerez")
+        self.assertEqual(forms["3p_future"], "parleront")
 
     def test_parler_past_participle(self) -> None:
-        result, ok = conjugate("parler")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["pc_m"], "parlé")
-        self.assertEqual(result.forms["pc_f"], "parlée")
+        forms = self._forms("parler")
+        self.assertEqual(forms["pc_m"], "parlé")
+        self.assertEqual(forms["pc_f"], "parlée")
 
     def test_parler_metadata(self) -> None:
-        result, ok = conjugate("parler")
+        conjugation, ok = conjugate_detailed("parler")
         self.assertTrue(ok)
-        self.assertEqual(result.word, "parler")
-        self.assertEqual(result.notes, "regular -er")
-        self.assertEqual(result.confidence, 1.0)
+        self.assertEqual(conjugation.word, "parler")
+        self.assertEqual(conjugation.notes, "regular -er")
+        self.assertEqual(conjugation.confidence, 1.0)
 
     def test_all_20_forms_present(self) -> None:
-        result, ok = conjugate("parler")
-        self.assertTrue(ok)
-        self.assertEqual(len(result.forms), 20)
+        forms = self._forms("parler")
+        self.assertEqual(len(forms), 20)
         for form_name in VerbConjugation.ALL_FORMS:
-            self.assertIn(form_name, result.forms)
+            self.assertIn(form_name, forms)
 
 
-class TestGerVerbs(unittest.TestCase):
+class TestGerVerbs(_ConjugationTestBase):
     """Test -ger orthographic adjustment."""
 
     def test_manger_present(self) -> None:
-        result, ok = conjugate("manger")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "mange")
-        self.assertEqual(result.forms["1p_present"], "mangeons")
-        self.assertEqual(result.forms["2p_present"], "mangez")
-        self.assertEqual(result.forms["3p_present"], "mangent")
+        forms = self._forms("manger")
+        self.assertEqual(forms["1s_present"], "mange")
+        self.assertEqual(forms["1p_present"], "mangeons")
+        self.assertEqual(forms["2p_present"], "mangez")
+        self.assertEqual(forms["3p_present"], "mangent")
 
     def test_manger_imperfect(self) -> None:
-        result, ok = conjugate("manger")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "mangeais")
-        self.assertEqual(result.forms["3s_impf"], "mangeait")
-        self.assertEqual(result.forms["1p_impf"], "mangions")
-        self.assertEqual(result.forms["2p_impf"], "mangiez")
-        self.assertEqual(result.forms["3p_impf"], "mangeaient")
+        forms = self._forms("manger")
+        self.assertEqual(forms["1s_impf"], "mangeais")
+        self.assertEqual(forms["3s_impf"], "mangeait")
+        self.assertEqual(forms["1p_impf"], "mangions")
+        self.assertEqual(forms["2p_impf"], "mangiez")
+        self.assertEqual(forms["3p_impf"], "mangeaient")
 
 
-class TestCerVerbs(unittest.TestCase):
+class TestCerVerbs(_ConjugationTestBase):
     """Test -cer orthographic adjustment."""
 
     def test_commencer_present(self) -> None:
-        result, ok = conjugate("commencer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "commence")
-        self.assertEqual(result.forms["1p_present"], "commençons")
-        self.assertEqual(result.forms["2p_present"], "commencez")
+        forms = self._forms("commencer")
+        self.assertEqual(forms["1s_present"], "commence")
+        self.assertEqual(forms["1p_present"], "commençons")
+        self.assertEqual(forms["2p_present"], "commencez")
 
     def test_commencer_imperfect(self) -> None:
-        result, ok = conjugate("commencer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "commençais")
-        self.assertEqual(result.forms["3s_impf"], "commençait")
-        self.assertEqual(result.forms["1p_impf"], "commencions")
-        self.assertEqual(result.forms["2p_impf"], "commenciez")
-        self.assertEqual(result.forms["3p_impf"], "commençaient")
+        forms = self._forms("commencer")
+        self.assertEqual(forms["1s_impf"], "commençais")
+        self.assertEqual(forms["3s_impf"], "commençait")
+        self.assertEqual(forms["1p_impf"], "commencions")
+        self.assertEqual(forms["2p_impf"], "commenciez")
+        self.assertEqual(forms["3p_impf"], "commençaient")
 
 
-class TestYerVerbs(unittest.TestCase):
+class TestYerVerbs(_ConjugationTestBase):
     """Test -yer stem change (y -> i before silent endings)."""
 
     def test_payer_present(self) -> None:
-        result, ok = conjugate("payer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "paie")
-        self.assertEqual(result.forms["2s_present"], "paies")
-        self.assertEqual(result.forms["3s_present"], "paie")
-        self.assertEqual(result.forms["1p_present"], "payons")
-        self.assertEqual(result.forms["2p_present"], "payez")
-        self.assertEqual(result.forms["3p_present"], "paient")
+        forms = self._forms("payer")
+        self.assertEqual(forms["1s_present"], "paie")
+        self.assertEqual(forms["2s_present"], "paies")
+        self.assertEqual(forms["3s_present"], "paie")
+        self.assertEqual(forms["1p_present"], "payons")
+        self.assertEqual(forms["2p_present"], "payez")
+        self.assertEqual(forms["3p_present"], "paient")
 
     def test_nettoyer_present(self) -> None:
-        result, ok = conjugate("nettoyer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "nettoie")
-        self.assertEqual(result.forms["1p_present"], "nettoyons")
-        self.assertEqual(result.forms["3p_present"], "nettoient")
+        forms = self._forms("nettoyer")
+        self.assertEqual(forms["1s_present"], "nettoie")
+        self.assertEqual(forms["1p_present"], "nettoyons")
+        self.assertEqual(forms["3p_present"], "nettoient")
 
     def test_payer_future(self) -> None:
-        result, ok = conjugate("payer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_future"], "paierai")
-        self.assertEqual(result.forms["3p_future"], "paieront")
+        forms = self._forms("payer")
+        self.assertEqual(forms["1s_future"], "paierai")
+        self.assertEqual(forms["3p_future"], "paieront")
 
     def test_payer_imperfect_keeps_y(self) -> None:
-        result, ok = conjugate("payer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "payais")
-        self.assertEqual(result.forms["1p_impf"], "payions")
+        forms = self._forms("payer")
+        self.assertEqual(forms["1s_impf"], "payais")
+        self.assertEqual(forms["1p_impf"], "payions")
 
     def test_payer_past_participle(self) -> None:
-        result, ok = conjugate("payer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["pc_m"], "payé")
-        self.assertEqual(result.forms["pc_f"], "payée")
+        forms = self._forms("payer")
+        self.assertEqual(forms["pc_m"], "payé")
+        self.assertEqual(forms["pc_f"], "payée")
 
 
-class TestRegularIrVerbs(unittest.TestCase):
+class TestRegularIrVerbs(_ConjugationTestBase):
     """Test second-group (-ir with -iss-) regular conjugation."""
 
     def test_finir_present(self) -> None:
-        result, ok = conjugate("finir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "finis")
-        self.assertEqual(result.forms["2s_present"], "finis")
-        self.assertEqual(result.forms["3s_present"], "finit")
-        self.assertEqual(result.forms["1p_present"], "finissons")
-        self.assertEqual(result.forms["2p_present"], "finissez")
-        self.assertEqual(result.forms["3p_present"], "finissent")
+        forms = self._forms("finir")
+        self.assertEqual(forms["1s_present"], "finis")
+        self.assertEqual(forms["2s_present"], "finis")
+        self.assertEqual(forms["3s_present"], "finit")
+        self.assertEqual(forms["1p_present"], "finissons")
+        self.assertEqual(forms["2p_present"], "finissez")
+        self.assertEqual(forms["3p_present"], "finissent")
 
     def test_finir_imperfect(self) -> None:
-        result, ok = conjugate("finir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "finissais")
-        self.assertEqual(result.forms["1p_impf"], "finissions")
+        forms = self._forms("finir")
+        self.assertEqual(forms["1s_impf"], "finissais")
+        self.assertEqual(forms["1p_impf"], "finissions")
 
     def test_finir_future(self) -> None:
-        result, ok = conjugate("finir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_future"], "finirai")
-        self.assertEqual(result.forms["3p_future"], "finiront")
+        forms = self._forms("finir")
+        self.assertEqual(forms["1s_future"], "finirai")
+        self.assertEqual(forms["3p_future"], "finiront")
 
     def test_finir_past_participle(self) -> None:
-        result, ok = conjugate("finir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["pc_m"], "fini")
-        self.assertEqual(result.forms["pc_f"], "finie")
+        forms = self._forms("finir")
+        self.assertEqual(forms["pc_m"], "fini")
+        self.assertEqual(forms["pc_f"], "finie")
 
     def test_choisir(self) -> None:
-        result, ok = conjugate("choisir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "choisis")
-        self.assertEqual(result.forms["1p_present"], "choisissons")
-        self.assertEqual(result.forms["1s_impf"], "choisissais")
+        forms = self._forms("choisir")
+        self.assertEqual(forms["1s_present"], "choisis")
+        self.assertEqual(forms["1p_present"], "choisissons")
+        self.assertEqual(forms["1s_impf"], "choisissais")
 
     def test_ir_confidence(self) -> None:
-        result, ok = conjugate("choisir")
+        conjugation, ok = conjugate_detailed("choisir")
         self.assertTrue(ok)
-        self.assertEqual(result.confidence, 0.8)
-        self.assertIn("assumed second group", result.notes or "")
+        self.assertEqual(conjugation.confidence, 0.8)
+        self.assertIn("assumed second group", conjugation.notes or "")
 
 
-class TestRegularReVerbs(unittest.TestCase):
+class TestRegularReVerbs(_ConjugationTestBase):
     """Test regular third-group (-re) conjugation."""
 
     def test_vendre_present(self) -> None:
-        result, ok = conjugate("vendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "vends")
-        self.assertEqual(result.forms["2s_present"], "vends")
-        self.assertEqual(result.forms["3s_present"], "vend")
-        self.assertEqual(result.forms["1p_present"], "vendons")
-        self.assertEqual(result.forms["2p_present"], "vendez")
-        self.assertEqual(result.forms["3p_present"], "vendent")
+        forms = self._forms("vendre")
+        self.assertEqual(forms["1s_present"], "vends")
+        self.assertEqual(forms["2s_present"], "vends")
+        self.assertEqual(forms["3s_present"], "vend")
+        self.assertEqual(forms["1p_present"], "vendons")
+        self.assertEqual(forms["2p_present"], "vendez")
+        self.assertEqual(forms["3p_present"], "vendent")
 
     def test_vendre_imperfect(self) -> None:
-        result, ok = conjugate("vendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_impf"], "vendais")
-        self.assertEqual(result.forms["1p_impf"], "vendions")
+        forms = self._forms("vendre")
+        self.assertEqual(forms["1s_impf"], "vendais")
+        self.assertEqual(forms["1p_impf"], "vendions")
 
     def test_vendre_future(self) -> None:
-        result, ok = conjugate("vendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_future"], "vendrai")
-        self.assertEqual(result.forms["3p_future"], "vendront")
+        forms = self._forms("vendre")
+        self.assertEqual(forms["1s_future"], "vendrai")
+        self.assertEqual(forms["3p_future"], "vendront")
 
     def test_vendre_past_participle(self) -> None:
-        result, ok = conjugate("vendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["pc_m"], "vendu")
-        self.assertEqual(result.forms["pc_f"], "vendue")
+        forms = self._forms("vendre")
+        self.assertEqual(forms["pc_m"], "vendu")
+        self.assertEqual(forms["pc_f"], "vendue")
 
     def test_attendre(self) -> None:
-        result, ok = conjugate("attendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "attends")
-        self.assertEqual(result.forms["3s_present"], "attend")
-        self.assertEqual(result.forms["1s_future"], "attendrai")
-        self.assertEqual(result.forms["pc_m"], "attendu")
+        forms = self._forms("attendre")
+        self.assertEqual(forms["1s_present"], "attends")
+        self.assertEqual(forms["3s_present"], "attend")
+        self.assertEqual(forms["1s_future"], "attendrai")
+        self.assertEqual(forms["pc_m"], "attendu")
 
 
-class TestIrregularVerbs(unittest.TestCase):
+class TestIrregularVerbs(_ConjugationTestBase):
     """Test hard-coded irregular verbs."""
 
     def test_etre(self) -> None:
-        result, ok = conjugate("être")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "suis")
-        self.assertEqual(result.forms["2s_present"], "es")
-        self.assertEqual(result.forms["3s_present"], "est")
-        self.assertEqual(result.forms["1p_present"], "sommes")
-        self.assertEqual(result.forms["2p_present"], "êtes")
-        self.assertEqual(result.forms["3p_present"], "sont")
+        forms = self._forms("être")
+        self.assertEqual(forms["1s_present"], "suis")
+        self.assertEqual(forms["2s_present"], "es")
+        self.assertEqual(forms["3s_present"], "est")
+        self.assertEqual(forms["1p_present"], "sommes")
+        self.assertEqual(forms["2p_present"], "êtes")
+        self.assertEqual(forms["3p_present"], "sont")
         # imperfect (special stem ét-)
-        self.assertEqual(result.forms["1s_impf"], "étais")
-        self.assertEqual(result.forms["1p_impf"], "étions")
-        self.assertEqual(result.forms["3p_impf"], "étaient")
+        self.assertEqual(forms["1s_impf"], "étais")
+        self.assertEqual(forms["1p_impf"], "étions")
+        self.assertEqual(forms["3p_impf"], "étaient")
         # future
-        self.assertEqual(result.forms["1s_future"], "serai")
-        self.assertEqual(result.forms["3p_future"], "seront")
+        self.assertEqual(forms["1s_future"], "serai")
+        self.assertEqual(forms["3p_future"], "seront")
         # past participle
-        self.assertEqual(result.forms["pc_m"], "été")
-        self.assertEqual(result.forms["pc_f"], "été")
+        self.assertEqual(forms["pc_m"], "été")
+        self.assertEqual(forms["pc_f"], "été")
 
     def test_avoir(self) -> None:
-        result, ok = conjugate("avoir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "ai")
-        self.assertEqual(result.forms["3s_present"], "a")
-        self.assertEqual(result.forms["3p_present"], "ont")
-        self.assertEqual(result.forms["1s_impf"], "avais")
-        self.assertEqual(result.forms["1s_future"], "aurai")
-        self.assertEqual(result.forms["pc_m"], "eu")
-        self.assertEqual(result.forms["pc_f"], "eue")
+        forms = self._forms("avoir")
+        self.assertEqual(forms["1s_present"], "ai")
+        self.assertEqual(forms["3s_present"], "a")
+        self.assertEqual(forms["3p_present"], "ont")
+        self.assertEqual(forms["1s_impf"], "avais")
+        self.assertEqual(forms["1s_future"], "aurai")
+        self.assertEqual(forms["pc_m"], "eu")
+        self.assertEqual(forms["pc_f"], "eue")
 
     def test_aller(self) -> None:
-        result, ok = conjugate("aller")
-        self.assertTrue(ok)
+        forms = self._forms("aller")
         # aller is irregular, NOT treated as regular -er
-        self.assertEqual(result.forms["1s_present"], "vais")
-        self.assertEqual(result.forms["3p_present"], "vont")
-        self.assertEqual(result.forms["1s_future"], "irai")
-        self.assertEqual(result.forms["pc_m"], "allé")
+        self.assertEqual(forms["1s_present"], "vais")
+        self.assertEqual(forms["3p_present"], "vont")
+        self.assertEqual(forms["1s_future"], "irai")
+        self.assertEqual(forms["pc_m"], "allé")
 
     def test_faire(self) -> None:
-        result, ok = conjugate("faire")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "fais")
-        self.assertEqual(result.forms["2p_present"], "faites")
-        self.assertEqual(result.forms["3p_present"], "font")
-        self.assertEqual(result.forms["1s_future"], "ferai")
-        self.assertEqual(result.forms["pc_m"], "fait")
+        forms = self._forms("faire")
+        self.assertEqual(forms["1s_present"], "fais")
+        self.assertEqual(forms["2p_present"], "faites")
+        self.assertEqual(forms["3p_present"], "font")
+        self.assertEqual(forms["1s_future"], "ferai")
+        self.assertEqual(forms["pc_m"], "fait")
 
     def test_pouvoir(self) -> None:
-        result, ok = conjugate("pouvoir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "peux")
-        self.assertEqual(result.forms["3p_present"], "peuvent")
-        self.assertEqual(result.forms["1s_future"], "pourrai")
-        self.assertEqual(result.forms["pc_m"], "pu")
+        forms = self._forms("pouvoir")
+        self.assertEqual(forms["1s_present"], "peux")
+        self.assertEqual(forms["3p_present"], "peuvent")
+        self.assertEqual(forms["1s_future"], "pourrai")
+        self.assertEqual(forms["pc_m"], "pu")
 
     def test_vouloir(self) -> None:
-        result, ok = conjugate("vouloir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "veux")
-        self.assertEqual(result.forms["3p_present"], "veulent")
-        self.assertEqual(result.forms["1s_future"], "voudrai")
+        forms = self._forms("vouloir")
+        self.assertEqual(forms["1s_present"], "veux")
+        self.assertEqual(forms["3p_present"], "veulent")
+        self.assertEqual(forms["1s_future"], "voudrai")
 
     def test_venir(self) -> None:
-        result, ok = conjugate("venir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "viens")
-        self.assertEqual(result.forms["1p_present"], "venons")
-        self.assertEqual(result.forms["3p_present"], "viennent")
-        self.assertEqual(result.forms["1s_impf"], "venais")
-        self.assertEqual(result.forms["1s_future"], "viendrai")
-        self.assertEqual(result.forms["pc_m"], "venu")
+        forms = self._forms("venir")
+        self.assertEqual(forms["1s_present"], "viens")
+        self.assertEqual(forms["1p_present"], "venons")
+        self.assertEqual(forms["3p_present"], "viennent")
+        self.assertEqual(forms["1s_impf"], "venais")
+        self.assertEqual(forms["1s_future"], "viendrai")
+        self.assertEqual(forms["pc_m"], "venu")
 
     def test_prendre(self) -> None:
-        result, ok = conjugate("prendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "prends")
-        self.assertEqual(result.forms["3s_present"], "prend")
-        self.assertEqual(result.forms["3p_present"], "prennent")
-        self.assertEqual(result.forms["1s_future"], "prendrai")
-        self.assertEqual(result.forms["pc_m"], "pris")
-        self.assertEqual(result.forms["pc_f"], "prise")
+        forms = self._forms("prendre")
+        self.assertEqual(forms["1s_present"], "prends")
+        self.assertEqual(forms["3s_present"], "prend")
+        self.assertEqual(forms["3p_present"], "prennent")
+        self.assertEqual(forms["1s_future"], "prendrai")
+        self.assertEqual(forms["pc_m"], "pris")
+        self.assertEqual(forms["pc_f"], "prise")
 
     def test_voir(self) -> None:
-        result, ok = conjugate("voir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "vois")
-        self.assertEqual(result.forms["1s_impf"], "voyais")
-        self.assertEqual(result.forms["1s_future"], "verrai")
-        self.assertEqual(result.forms["pc_m"], "vu")
+        forms = self._forms("voir")
+        self.assertEqual(forms["1s_present"], "vois")
+        self.assertEqual(forms["1s_impf"], "voyais")
+        self.assertEqual(forms["1s_future"], "verrai")
+        self.assertEqual(forms["pc_m"], "vu")
 
     def test_dire(self) -> None:
-        result, ok = conjugate("dire")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["2p_present"], "dites")
-        self.assertEqual(result.forms["pc_m"], "dit")
+        forms = self._forms("dire")
+        self.assertEqual(forms["2p_present"], "dites")
+        self.assertEqual(forms["pc_m"], "dit")
 
     def test_mettre(self) -> None:
-        result, ok = conjugate("mettre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["3s_present"], "met")
-        self.assertEqual(result.forms["1s_future"], "mettrai")
-        self.assertEqual(result.forms["pc_m"], "mis")
+        forms = self._forms("mettre")
+        self.assertEqual(forms["3s_present"], "met")
+        self.assertEqual(forms["1s_future"], "mettrai")
+        self.assertEqual(forms["pc_m"], "mis")
 
     def test_partir(self) -> None:
-        result, ok = conjugate("partir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "pars")
-        self.assertEqual(result.forms["1p_present"], "partons")
-        self.assertEqual(result.forms["1s_future"], "partirai")
-        self.assertEqual(result.forms["pc_m"], "parti")
+        forms = self._forms("partir")
+        self.assertEqual(forms["1s_present"], "pars")
+        self.assertEqual(forms["1p_present"], "partons")
+        self.assertEqual(forms["1s_future"], "partirai")
+        self.assertEqual(forms["pc_m"], "parti")
 
     def test_ouvrir(self) -> None:
-        result, ok = conjugate("ouvrir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "ouvre")
-        self.assertEqual(result.forms["1p_present"], "ouvrons")
-        self.assertEqual(result.forms["pc_m"], "ouvert")
+        forms = self._forms("ouvrir")
+        self.assertEqual(forms["1s_present"], "ouvre")
+        self.assertEqual(forms["1p_present"], "ouvrons")
+        self.assertEqual(forms["pc_m"], "ouvert")
 
     def test_mourir(self) -> None:
-        result, ok = conjugate("mourir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "meurs")
-        self.assertEqual(result.forms["1p_present"], "mourons")
-        self.assertEqual(result.forms["1s_future"], "mourrai")
+        forms = self._forms("mourir")
+        self.assertEqual(forms["1s_present"], "meurs")
+        self.assertEqual(forms["1p_present"], "mourons")
+        self.assertEqual(forms["1s_future"], "mourrai")
 
     def test_envoyer(self) -> None:
-        result, ok = conjugate("envoyer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "envoie")
-        self.assertEqual(result.forms["1p_present"], "envoyons")
-        self.assertEqual(result.forms["1s_future"], "enverrai")
+        forms = self._forms("envoyer")
+        self.assertEqual(forms["1s_present"], "envoie")
+        self.assertEqual(forms["1p_present"], "envoyons")
+        self.assertEqual(forms["1s_future"], "enverrai")
 
     def test_irregular_notes(self) -> None:
-        result, ok = conjugate("être")
+        conjugation, ok = conjugate_detailed("être")
         self.assertTrue(ok)
-        self.assertEqual(result.notes, "irregular")
+        self.assertEqual(conjugation.notes, "irregular")
 
     def test_all_irregulars_have_20_forms(self) -> None:
         for verb in list_irregular_verbs():
-            result, ok = conjugate(verb)
-            self.assertTrue(ok, f"{verb} should conjugate successfully")
+            forms = conjugate(verb)
+            self.assertIsNotNone(forms, f"{verb} should conjugate successfully")
+            assert forms is not None  # narrow Optional for type-checkers
             self.assertEqual(
-                len(result.forms),
+                len(forms),
                 20,
-                f"{verb} should have 20 forms, got {len(result.forms)}",
+                f"{verb} should have 20 forms, got {len(forms)}",
             )
 
 
-class TestCompoundVerbs(unittest.TestCase):
+class TestCompoundVerbs(_ConjugationTestBase):
     """Test compound verbs derived from irregular bases."""
 
     def test_comprendre(self) -> None:
-        result, ok = conjugate("comprendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "comprends")
-        self.assertEqual(result.forms["3p_present"], "comprennent")
-        self.assertEqual(result.forms["1s_impf"], "comprenais")
-        self.assertEqual(result.forms["1s_future"], "comprendrai")
-        self.assertEqual(result.forms["pc_m"], "compris")
-        self.assertEqual(result.forms["pc_f"], "comprise")
+        forms = self._forms("comprendre")
+        self.assertEqual(forms["1s_present"], "comprends")
+        self.assertEqual(forms["3p_present"], "comprennent")
+        self.assertEqual(forms["1s_impf"], "comprenais")
+        self.assertEqual(forms["1s_future"], "comprendrai")
+        self.assertEqual(forms["pc_m"], "compris")
+        self.assertEqual(forms["pc_f"], "comprise")
 
     def test_revenir(self) -> None:
-        result, ok = conjugate("revenir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "reviens")
-        self.assertEqual(result.forms["1p_present"], "revenons")
-        self.assertEqual(result.forms["3p_present"], "reviennent")
-        self.assertEqual(result.forms["1s_future"], "reviendrai")
-        self.assertEqual(result.forms["pc_m"], "revenu")
+        forms = self._forms("revenir")
+        self.assertEqual(forms["1s_present"], "reviens")
+        self.assertEqual(forms["1p_present"], "revenons")
+        self.assertEqual(forms["3p_present"], "reviennent")
+        self.assertEqual(forms["1s_future"], "reviendrai")
+        self.assertEqual(forms["pc_m"], "revenu")
 
     def test_permettre(self) -> None:
-        result, ok = conjugate("permettre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "permets")
-        self.assertEqual(result.forms["3s_present"], "permet")
-        self.assertEqual(result.forms["1s_future"], "permettrai")
-        self.assertEqual(result.forms["pc_m"], "permis")
+        forms = self._forms("permettre")
+        self.assertEqual(forms["1s_present"], "permets")
+        self.assertEqual(forms["3s_present"], "permet")
+        self.assertEqual(forms["1s_future"], "permettrai")
+        self.assertEqual(forms["pc_m"], "permis")
 
     def test_defaire(self) -> None:
-        result, ok = conjugate("défaire")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "défais")
-        self.assertEqual(result.forms["2p_present"], "défaites")
-        self.assertEqual(result.forms["3p_present"], "défont")
-        self.assertEqual(result.forms["1s_future"], "déferai")
+        forms = self._forms("défaire")
+        self.assertEqual(forms["1s_present"], "défais")
+        self.assertEqual(forms["2p_present"], "défaites")
+        self.assertEqual(forms["3p_present"], "défont")
+        self.assertEqual(forms["1s_future"], "déferai")
 
     def test_decouvrir(self) -> None:
-        result, ok = conjugate("découvrir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "découvre")
-        self.assertEqual(result.forms["1p_present"], "découvrons")
-        self.assertEqual(result.forms["pc_m"], "découvert")
+        forms = self._forms("découvrir")
+        self.assertEqual(forms["1s_present"], "découvre")
+        self.assertEqual(forms["1p_present"], "découvrons")
+        self.assertEqual(forms["pc_m"], "découvert")
 
     def test_obtenir(self) -> None:
-        result, ok = conjugate("obtenir")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "obtiens")
-        self.assertEqual(result.forms["3p_present"], "obtiennent")
-        self.assertEqual(result.forms["1s_future"], "obtiendrai")
-        self.assertEqual(result.forms["pc_m"], "obtenu")
+        forms = self._forms("obtenir")
+        self.assertEqual(forms["1s_present"], "obtiens")
+        self.assertEqual(forms["3p_present"], "obtiennent")
+        self.assertEqual(forms["1s_future"], "obtiendrai")
+        self.assertEqual(forms["pc_m"], "obtenu")
 
     def test_apprendre(self) -> None:
-        result, ok = conjugate("apprendre")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "apprends")
-        self.assertEqual(result.forms["3p_present"], "apprennent")
-        self.assertEqual(result.forms["pc_m"], "appris")
+        forms = self._forms("apprendre")
+        self.assertEqual(forms["1s_present"], "apprends")
+        self.assertEqual(forms["3p_present"], "apprennent")
+        self.assertEqual(forms["pc_m"], "appris")
 
     def test_renvoyer(self) -> None:
-        result, ok = conjugate("renvoyer")
-        self.assertTrue(ok)
-        self.assertEqual(result.forms["1s_present"], "renvoie")
-        self.assertEqual(result.forms["1p_present"], "renvoyons")
-        self.assertEqual(result.forms["1s_future"], "renverrai")
+        forms = self._forms("renvoyer")
+        self.assertEqual(forms["1s_present"], "renvoie")
+        self.assertEqual(forms["1p_present"], "renvoyons")
+        self.assertEqual(forms["1s_future"], "renverrai")
 
 
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and error handling."""
 
     def test_empty_string(self) -> None:
-        result, ok = conjugate("")
-        self.assertFalse(ok)
+        self.assertIsNone(conjugate(""))
 
     def test_whitespace_only(self) -> None:
-        result, ok = conjugate("   ")
-        self.assertFalse(ok)
+        self.assertIsNone(conjugate("   "))
 
     def test_unknown_ending(self) -> None:
-        result, ok = conjugate("xyz")
+        self.assertIsNone(conjugate("xyz"))
+        conjugation, ok = conjugate_detailed("xyz")
         self.assertFalse(ok)
-        self.assertEqual(result.word, "xyz")
+        self.assertEqual(conjugation.word, "xyz")
 
     def test_whitespace_stripped(self) -> None:
-        result, ok = conjugate("  parler  ")
+        forms = conjugate("  parler  ")
+        self.assertIsNotNone(forms)
+        assert forms is not None  # narrow Optional for type-checkers
+        self.assertEqual(forms["1s_present"], "parle")
+        conjugation, ok = conjugate_detailed("  parler  ")
         self.assertTrue(ok)
-        self.assertEqual(result.word, "parler")
-        self.assertEqual(result.forms["1s_present"], "parle")
+        self.assertEqual(conjugation.word, "parler")
 
     def test_two_char_er_not_conjugated(self) -> None:
         """A two-character 'er' is not a valid verb."""
-        result, ok = conjugate("er")
-        self.assertFalse(ok)
+        self.assertIsNone(conjugate("er"))
 
 
 class TestHelperFunctions(unittest.TestCase):

--- a/src/tests/langtools/test_fr_inflection.py
+++ b/src/tests/langtools/test_fr_inflection.py
@@ -1,0 +1,82 @@
+"""Tests for rule-based French adjective inflection."""
+
+import unittest
+
+from langtools.fr.inflection import build_adjective_forms
+
+
+class TestFrenchAdjectiveForms(unittest.TestCase):
+    def test_regular_consonant(self) -> None:
+        self.assertEqual(
+            build_adjective_forms("petit"),
+            {
+                "singular_m": "petit",
+                "singular_f": "petite",
+                "plural_m": "petits",
+                "plural_f": "petites",
+            },
+        )
+
+    def test_grand(self) -> None:
+        forms = build_adjective_forms("grand")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "grande")
+        self.assertEqual(forms["plural_f"], "grandes")
+
+    def test_e_invariant_gender(self) -> None:
+        self.assertEqual(
+            build_adjective_forms("rouge"),
+            {
+                "singular_m": "rouge",
+                "singular_f": "rouge",
+                "plural_m": "rouges",
+                "plural_f": "rouges",
+            },
+        )
+
+    def test_eux_to_euse(self) -> None:
+        forms = build_adjective_forms("heureux")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "heureuse")
+        self.assertEqual(forms["plural_m"], "heureux")
+        self.assertEqual(forms["plural_f"], "heureuses")
+
+    def test_er_to_ere(self) -> None:
+        forms = build_adjective_forms("cher")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "chère")
+        self.assertEqual(forms["plural_f"], "chères")
+
+    def test_f_to_ve(self) -> None:
+        forms = build_adjective_forms("vif")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "vive")
+        self.assertEqual(forms["plural_f"], "vives")
+
+    def test_vowel_final(self) -> None:
+        forms = build_adjective_forms("joli")
+        assert forms is not None
+        self.assertEqual(forms["singular_f"], "jolie")
+        self.assertEqual(forms["plural_f"], "jolies")
+
+    def test_irregular_table(self) -> None:
+        self.assertEqual(
+            build_adjective_forms("beau"),
+            {
+                "singular_m": "beau",
+                "singular_f": "belle",
+                "plural_m": "beaux",
+                "plural_f": "belles",
+            },
+        )
+
+    def test_uncertain_ending_returns_none(self) -> None:
+        # -l feminines are unpredictable (national/nationale vs nul/nulle).
+        self.assertIsNone(build_adjective_forms("national"))
+
+    def test_empty_returns_none(self) -> None:
+        self.assertIsNone(build_adjective_forms(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/langtools/test_fr_llm_forms.py
+++ b/src/tests/langtools/test_fr_llm_forms.py
@@ -36,12 +36,7 @@ class TestFrenchVerbLlmForms(unittest.TestCase):
             patch("langtools.fr.llm_forms.get_translation", return_value="parler"),
             patch(
                 "langtools.fr.llm_forms.conjugate",
-                return_value=(
-                    SimpleNamespace(
-                        forms={"1s_present": "parle"}, confidence=1.0, notes="regular -er"
-                    ),
-                    True,
-                ),
+                return_value={"1s_present": "parle"},
             ),
             patch("langtools.fr.llm_forms.query_forms") as mock_query_forms,
             patch("langtools.fr.llm_forms.linguistic_db.log_query") as mock_log_query,
@@ -62,7 +57,7 @@ class TestFrenchVerbLlmForms(unittest.TestCase):
             patch("langtools.fr.llm_forms.get_translation", return_value="xyz"),
             patch(
                 "langtools.fr.llm_forms.conjugate",
-                return_value=(SimpleNamespace(forms={}, confidence=0.0, notes=""), False),
+                return_value=None,
             ),
             patch(
                 "langtools.fr.llm_forms.query_forms", return_value=({"1s_present": "xyz"}, True)

--- a/src/wordfreq/translation/client.py
+++ b/src/wordfreq/translation/client.py
@@ -381,6 +381,10 @@ class LinguisticClient:
         """Query LLM for French verb conjugations."""
         return french.query_french_verb_conjugations(self.client, lemma_id, self.get_session)
 
+    def query_french_adjective_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
+        """Query LLM for French adjective forms."""
+        return french.query_french_adjective_forms(self.client, lemma_id, self.get_session)
+
     # Spanish forms
     def query_spanish_noun_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
         """Query LLM for Spanish noun forms."""
@@ -389,6 +393,10 @@ class LinguisticClient:
     def query_spanish_verb_conjugations(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
         """Query LLM for Spanish verb conjugations."""
         return spanish.query_spanish_verb_conjugations(self.client, lemma_id, self.get_session)
+
+    def query_spanish_adjective_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:
+        """Query LLM for Spanish adjective forms."""
+        return spanish.query_spanish_adjective_forms(self.client, lemma_id, self.get_session)
 
     # German forms
     def query_german_noun_forms(self, lemma_id: int) -> Tuple[Dict[str, str], bool]:

--- a/src/wordfreq/translation/generate_forms_tasks.py
+++ b/src/wordfreq/translation/generate_forms_tasks.py
@@ -89,6 +89,11 @@ _TASK_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
         "threshold": 25,
         "client_method": "query_french_verb_conjugations",
     },
+    ("fr", "adjective"): {
+        "fetcher": "translation",
+        "threshold": 4,
+        "client_method": "query_french_adjective_forms",
+    },
     # German — translation fetcher, gender on nouns
     ("de", "noun"): {
         "fetcher": "translation",
@@ -140,6 +145,11 @@ _TASK_OVERRIDES: Dict[Tuple[str, str], Dict[str, Any]] = {
         "fetcher": "translation",
         "threshold": 10,
         "client_method": "query_spanish_verb_conjugations",
+    },
+    ("es", "adjective"): {
+        "fetcher": "translation",
+        "threshold": 4,
+        "client_method": "query_spanish_adjective_forms",
     },
     # Italian — translation fetcher, gender on nouns
     ("it", "noun"): {"fetcher": "translation", "threshold": 2, "gender": True},


### PR DESCRIPTION
Adjectives (review item 1):
- Add ADJECTIVE_CONFIG to es, fr, de, sv, nl forms_config so all core
  languages now have noun + verb + adjective form support. es/fr/de/nl use
  the singular_m/f x plural_m/f agreement axis (enum members already
  provisioned); sv uses the linguistically correct common/neuter/plural axis.
- Add mechanical adjective helpers es/inflection.py and fr/inflection.py
  (conservative regular rules + irregular table, returning None so uncertain
  cases fall back to the LLM), wired mechanical-first into the respective
  llm_forms with LLM fallback. de/sv/nl adjectives are LLM-only.
- Register query_spanish_adjective_forms / query_french_adjective_forms client
  methods and task overrides so the mechanical paths are actually used.

Conjugation API consistency (review item 2):
- Standardize on conjugate(lemma, ...) -> Optional[Dict[str, str]] across core
  languages.
- fr.conjugate now returns the forms dict; the rich VerbConjugation/confidence
  result is available via conjugate_detailed.
- lt.conjugate is the canonical name (conjugate_verb kept as alias).
- en gains a conjugate() wrapper over expand_verb_forms.
- Update LANGUAGE_MODULE_FORMAT.md conjugation contract and LANGUAGE_STATUS.md.

Verbs and Lithuanian principal-parts work intentionally deferred.

https://claude.ai/code/session_01FuvShvgvAabnX9vHYraTHg