### PR TITLE
Add stem-change support for French, Italian, Spanish, Dutch, German, Portuguese

### DIFF
--- a/src/langtools/de/conjugation.py
+++ b/src/langtools/de/conjugation.py
@@ -109,6 +109,10 @@ def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
     # Insert linking -e- for stems ending in -t, -d, -chn, -ffn, -tm, -dm
     needs_e = stem.endswith(("t", "d")) or stem.endswith(("chn", "ffn", "tm", "dm"))
 
+    # Stems ending in a sibilant (s, ß, z, x, tz) absorb the s of the 2s -st
+    # ending: du tanzt (not "tanzst"), du reist (not "reisst").
+    sibilant_stem = stem.endswith(("s", "ß", "z", "x"))
+
     forms: Dict[str, str] = {}
     for index, person in enumerate(_PERSONS):
         pres_ending = _PRESENT_ENDINGS[index]
@@ -118,6 +122,8 @@ def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
         # past: before ALL endings (they all start with t-)
         if needs_e and pres_ending in ("st", "t"):
             pres_ending = "e" + pres_ending
+        elif sibilant_stem and pres_ending == "st":
+            pres_ending = "t"  # 2s: sibilant + -st -> -t
         if needs_e:
             past_ending = "e" + past_ending
         forms[f"{person}_present"] = stem + pres_ending

--- a/src/langtools/es/conjugation.py
+++ b/src/langtools/es/conjugation.py
@@ -489,6 +489,15 @@ _CER_ZCO_VERBS = {
 # ---------------------------------------------------------------------------
 
 
+def _is_uir_verb(inf: str) -> bool:
+    """True for -uir verbs with a consonantal y (construir, huir, incluir).
+
+    Excludes -guir/-quir, where the u is a silent digraph marker (seguir,
+    distinguir) and no y is inserted.
+    """
+    return inf.endswith("uir") and not inf.endswith(("guir", "quir"))
+
+
 def get_verb_class(infinitive: str) -> Optional[str]:
     """Return 'ar', 'er', or 'ir' based on verb ending, or None."""
     inf = infinitive.lower().strip()
@@ -623,6 +632,7 @@ def _conjugate_present(
     # Handle -cer/-cir zco pattern
     is_ucir = inf.endswith("ucir")
     is_zco = inf in _CER_ZCO_VERBS
+    is_uir = _is_uir_verb(inf)
 
     for i, person in enumerate(PERSONS):
         key = f"{person}_present"
@@ -637,6 +647,13 @@ def _conjugate_present(
             if sc_type and i in _BOOT_INDICES:
                 from_v, to_v = STEM_CHANGE_MAP[sc_type]
                 s = _apply_stem_change(stem, from_v, to_v)
+            # -uir verbs insert y in the boot (construyo, but construimos)
+            if is_uir and i in _BOOT_INDICES:
+                s = stem + "y"
+            # -guir verbs drop the silent u before -o (yo sigo / distingo);
+            # the u stays before -e endings (sigues, sigue, siguen).
+            if inf.endswith("guir") and endings[i].startswith("o") and s.endswith("u"):
+                s = s[:-1]
             forms[key] = s + endings[i]
 
 
@@ -666,6 +683,16 @@ def _conjugate_preterite(
         return
 
     endings = REGULAR_ENDINGS[verb_class]["preterite"]
+
+    # -uir verbs: unstressed i → y between vowels in 3s/3p (construyó,
+    # construyeron); other persons keep the regular endings.
+    if _is_uir_verb(inf):
+        for i, person in enumerate(PERSONS):
+            if i in (2, 5):
+                forms[f"{person}_preterite"] = stem + "y" + endings[i][1:]
+            else:
+                forms[f"{person}_preterite"] = stem + endings[i]
+        return
 
     # Stem-changing -ir verbs: e→i or o→u in 3s and 3p preterite
     ir_pret_change: Optional[Tuple[str, str]] = None
@@ -739,6 +766,13 @@ def _conjugate_subjunctive_present(
         subj_endings = REGULAR_ENDINGS[verb_class]["subjunctive_present"]
         for i, person in enumerate(PERSONS):
             forms[f"{person}_subjunctive_present"] = subj_stem + subj_endings[i]
+        return
+
+    if _is_uir_verb(inf):
+        # The y carries through every person: construya, construyamos, ...
+        subj_stem = stem + "y"
+        for i, person in enumerate(PERSONS):
+            forms[f"{person}_subjunctive_present"] = subj_stem + endings[i]
         return
 
     # Spelling adjustments for regular subjunctive

--- a/src/langtools/fr/conjugation.py
+++ b/src/langtools/fr/conjugation.py
@@ -7,7 +7,14 @@ common irregular verbs and automatic handling of compound verbs
 
 Regular patterns handled:
   - First group (-er): parler, with orthographic adjustments for
-    -ger (manger), -cer (commencer), and -yer (payer/nettoyer)
+    -ger (manger), -cer (commencer), -yer (payer/nettoyer), and the
+    common stem changes:
+      * e -> è before silent endings / throughout the future
+        (lever -> lève / lèverai, acheter -> achète / achèterai)
+      * é -> è before silent present endings only
+        (préférer -> préfère, future préférerai keeps the é)
+      * consonant doubling for appeler / jeter type verbs
+        (appelle / appellerai, jette / jetterai)
   - Second group (-ir with -iss-): finir, choisir, etc.
   - Third group (-re regular): vendre, attendre, etc.
 
@@ -44,8 +51,47 @@ _IMPERFECT = ["ais", "ais", "ait", "ions", "iez", "aient"]
 _FUTURE = ["ai", "as", "a", "ons", "ez", "ont"]
 
 # Indices in _PERSONS where the present-tense ending is "silent"
-# (relevant for -yer stem change: y -> i before silent endings)
+# (relevant for stem changes: y -> i / e -> è / consonant doubling before
+# these endings)
 _SILENT_PRESENT_INDICES = {0, 1, 2, 5}  # je, tu, il/elle, ils/elles
+
+# Vowels (including accented forms and y) used when detecting -er stem changes.
+_VOWELS = "aàâäeéèêëiîïoôöuùûüy"
+
+# -eler / -eter verbs that take è (gèle) rather than doubling their
+# consonant (appelle).  Everything else in -eler/-eter doubles.
+_ER_E_GRAVE_EXCEPTIONS = {
+    # -eter
+    "acheter",
+    "racheter",
+    "fureter",
+    "haleter",
+    "crocheter",
+    "corseter",
+    # -eler
+    "geler",
+    "congeler",
+    "dégeler",
+    "surgeler",
+    "regeler",
+    "peler",
+    "celer",
+    "déceler",
+    "receler",
+    "ciseler",
+    "démanteler",
+    "écarteler",
+    "marteler",
+    "modeler",
+    "remodeler",
+    "harceler",
+}
+
+
+def _is_consonant(ch: str) -> bool:
+    """Return True for an alphabetic character that is not a vowel (or y)."""
+    return ch.isalpha() and ch.lower() not in _VOWELS
+
 
 # ---------------------------------------------------------------------------
 # Helpers to assemble form dictionaries
@@ -84,26 +130,51 @@ def _imperfect_from_stem(stem: str) -> List[str]:
 
 
 def _conjugate_er(infinitive: str) -> Dict[str, str]:
-    """First-group (-er) conjugation with -ger / -cer / -yer adjustments."""
+    """First-group (-er) conjugation with orthographic and stem changes.
+
+    Handles -ger / -cer softening, -yer (y -> i), and the e/é/doubling
+    stem changes documented in the module docstring.
+    """
     stem = infinitive[:-2]
 
     is_ger = stem.endswith("g")
     is_cer = stem.endswith("c")
     is_yer = stem.endswith("y")
 
-    # -- present --
-    present: List[str] = []
-    for i, ending in enumerate(_PRESENT_ER):
-        s = stem
-        if is_yer and i in _SILENT_PRESENT_INDICES:
-            s = stem[:-1] + "i"
-        elif is_ger and ending.startswith("o"):
-            s = stem + "e"  # mangeons
-        elif is_cer and ending.startswith("o"):
-            s = stem[:-1] + "ç"  # commençons
-        present.append(s + ending)
+    # Detect a stem-changing vowel: 'e' or 'é' sitting at stem[-2], i.e.
+    # followed by exactly one consonant before the -er ending.  A stem ending
+    # in two consonants (rester) keeps its stable /ɛ/ and never changes.
+    change: Optional[str] = None  # "grave" (e->è) | "acute" (é->è) | "double"
+    if len(stem) >= 2 and stem[-2] in ("e", "é") and _is_consonant(stem[-1]):
+        if stem[-2] == "é":
+            change = "acute"
+        elif stem.endswith(("el", "et")):
+            change = "grave" if infinitive in _ER_E_GRAVE_EXCEPTIONS else "double"
+        else:
+            change = "grave"
 
-    # -- imperfect --
+    # Stems used by the various changes (only meaningful when ``change`` set).
+    grave_stem = stem[:-2] + "è" + stem[-1]  # lev -> lèv ; préfér -> préfèr
+    double_stem = stem + stem[-1:]  # appel -> appell ; jet -> jett
+
+    def _present_stem(index: int, ending: str) -> str:
+        silent = index in _SILENT_PRESENT_INDICES
+        if is_yer and silent:
+            return stem[:-1] + "i"
+        if change in ("grave", "acute") and silent:
+            return grave_stem
+        if change == "double" and silent:
+            return double_stem
+        if is_ger and ending.startswith("o"):
+            return stem + "e"  # mangeons / protégeons
+        if is_cer and ending.startswith("o"):
+            return stem[:-1] + "ç"  # commençons / dépeçons
+        return stem
+
+    # -- present --
+    present = [_present_stem(i, ending) + ending for i, ending in enumerate(_PRESENT_ER)]
+
+    # -- imperfect (nous-present stem; only -ger/-cer softening applies) --
     imperfect: List[str] = []
     for ending in _IMPERFECT:
         s = stem
@@ -111,16 +182,23 @@ def _conjugate_er(infinitive: str) -> Dict[str, str]:
             s = stem + "e"  # mangeais
         elif is_cer and ending.startswith("a"):
             s = stem[:-1] + "ç"  # commençais
-        # -yer: y stays before pronounced imperfect endings
+        # -yer/-e_er/-é_er keep their base stem before pronounced endings
         imperfect.append(s + ending)
 
-    # -- future (stem = full infinitive; -yer: y -> i) --
-    future_stem = infinitive
-    if is_yer:
+    # -- future stem --
+    if change == "grave":
+        future_stem = grave_stem + "er"  # lèver / achèter
+    elif change == "double":
+        future_stem = double_stem + "er"  # appeller / jetter
+    elif is_yer:
         future_stem = infinitive[:-3] + "ier"  # payer -> paier
+    else:
+        # "acute" (préférer) keeps its é in the future; plain -er/-ger/-cer
+        # build the future on the full infinitive.
+        future_stem = infinitive
     future = _future_from_stem(future_stem)
 
-    # -- past participle --
+    # -- past participle (always built from the base stem) --
     pp_m = stem + "é"
     pp_f = stem + "ée"
 

--- a/src/langtools/it/conjugation.py
+++ b/src/langtools/it/conjugation.py
@@ -120,6 +120,23 @@ def _infer_verb_class(infinitive: str) -> str:
     return ""
 
 
+def _adjust_are_stem(stem: str, ending: str, *, is_car_gar: bool, is_ci_gi: bool) -> str:
+    """Apply -care/-gare/-ciare/-giare orthography before a front-vowel ending.
+
+    -care/-gare insert an ``h`` to keep the hard c/g sound (cerco -> cerchi),
+    while -ciare/-giare drop the stem-final ``i`` that only softened the c/g
+    (mangio -> mangi, not "mangii").  Adjustments only apply before endings
+    starting with ``e`` or ``i``.
+    """
+    if ending[:1] not in ("e", "i"):
+        return stem
+    if is_car_gar:
+        return stem + "h"
+    if is_ci_gi and stem.endswith("i"):
+        return stem[:-1]
+    return stem
+
+
 def _derive_past_stem(verb_class: str, past_1s: str, infinitive: str) -> str:
     expected_ending = _IMPERFECT_ENDINGS[verb_class][0]
     if past_1s.endswith(expected_ending):
@@ -157,6 +174,12 @@ def conjugate(
         return None
 
     default_stem = infinitive_value[: -len(verb_class)]
+
+    # Orthographic adjustments only apply to -are verbs whose stem ends in a
+    # hard c/g (-care/-gare) or a softening i (-ciare/-giare).
+    is_car_gar = verb_class == "are" and infinitive_value.endswith(("care", "gare"))
+    is_ci_gi = verb_class == "are" and infinitive_value.endswith(("ciare", "giare"))
+
     present_stem = (
         present_1s.strip().lower()[: -len(_PRESENT_ENDINGS[verb_class][0])]
         if present_1s and present_1s.strip().lower().endswith(_PRESENT_ENDINGS[verb_class][0])
@@ -167,15 +190,22 @@ def conjugate(
         if past_1s
         else default_stem
     )
-    future_stem = (
-        _derive_future_stem(verb_class, future_1s.strip().lower(), infinitive_value)
-        if future_1s
-        else default_stem + ("er" if verb_class in {"are", "ere"} else "ir")
-    )
+    if future_1s:
+        future_stem = _derive_future_stem(verb_class, future_1s.strip().lower(), infinitive_value)
+    elif is_car_gar:
+        future_stem = default_stem + "her"  # cerc -> cercher(ò)
+    elif is_ci_gi:
+        future_stem = default_stem[:-1] + "er"  # mangi -> manger(ò)
+    else:
+        future_stem = default_stem + ("er" if verb_class in {"are", "ere"} else "ir")
 
     forms: Dict[str, str] = {}
     for index, person in enumerate(_PERSONS):
-        forms[f"{person}_present"] = present_stem + _PRESENT_ENDINGS[verb_class][index]
+        present_ending = _PRESENT_ENDINGS[verb_class][index]
+        forms[f"{person}_present"] = (
+            _adjust_are_stem(present_stem, present_ending, is_car_gar=is_car_gar, is_ci_gi=is_ci_gi)
+            + present_ending
+        )
         forms[f"{person}_past"] = past_stem + _IMPERFECT_ENDINGS[verb_class][index]
         forms[f"{person}_future"] = future_stem + _FUTURE_ENDINGS[index]
 

--- a/src/langtools/nl/conjugation.py
+++ b/src/langtools/nl/conjugation.py
@@ -79,13 +79,17 @@ def _normalize_stem(infinitive_value: str) -> Tuple[str, str]:
     """Return (display_stem, raw_stem) where raw_stem preserves v/z for 't kofschip."""
     raw_stem = infinitive_value[:-2]
     stem = raw_stem
-    # Double open-syllable vowels: CVC → CVVC (e.g. mak → maak)
-    if (
+    if len(stem) >= 2 and stem[-1] == stem[-2] and stem[-1] not in "aeiou":
+        # Doubled consonant marks a closed short syllable: degeminate and do
+        # NOT lengthen the vowel (pakken → pak, zetten → zet).
+        stem = stem[:-1]
+    elif (
         len(stem) >= 3
         and stem[-1] not in "aeiou"
         and stem[-2] in "aeiou"
         and stem[-3] not in "aeiou"
     ):
+        # Double open-syllable vowels: CVC → CVVC (e.g. mak → maak)
         stem = stem[:-2] + stem[-2] + stem[-2] + stem[-1]
     # Dutch stem-final devoicing: v→f, z→s
     # The raw_stem (before devoicing) is used for 't kofschip determination,
@@ -113,10 +117,13 @@ def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
     # Use the raw (pre-devoicing) stem for 't kofschip: lev → -de (not -te)
     past_suffix = "te" if _is_t_kofschip(raw_stem) else "de"
 
+    # A stem already ending in -t does not take another -t (praten → praat,
+    # zetten → zet).
+    t_ending = "" if stem.endswith("t") else "t"
     present = (
         stem,
-        stem + "t",
-        stem + "t",
+        stem + t_ending,
+        stem + t_ending,
         infinitive_value,
         infinitive_value,
         infinitive_value,

--- a/src/langtools/pt/conjugation.py
+++ b/src/langtools/pt/conjugation.py
@@ -108,6 +108,23 @@ _FUTURE_ENDINGS: Tuple[str, str, str, str, str, str] = ("ei", "ás", "á", "emos
 _PERSONS: Tuple[str, str, str, str, str, str] = ("1s", "2s", "3s", "1p", "2p", "3p")
 
 
+def _adjust_ar_preterite_1s_stem(stem: str) -> str:
+    """Spelling change for the 1s preterite of -ar verbs (ending -ei).
+
+    The hard c/g/ç sound must be preserved before the front vowel ``e``:
+      - c -> qu  (ficar -> fiquei)
+      - g -> gu  (chegar -> cheguei)
+      - ç -> c   (começar -> comecei)
+    """
+    if stem.endswith("c"):
+        return stem[:-1] + "qu"
+    if stem.endswith("g"):
+        return stem + "u"
+    if stem.endswith("ç"):
+        return stem[:-1] + "c"
+    return stem
+
+
 def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
     """Conjugate a regular Portuguese infinitive across present/past/future."""
     infinitive_value = infinitive.strip().lower()
@@ -130,8 +147,12 @@ def conjugate(infinitive: str) -> Optional[Dict[str, str]]:
     stem = infinitive_value[:-2]
     forms: Dict[str, str] = {}
     for index, person in enumerate(_PERSONS):
+        preterite_stem = stem
+        # 1s preterite of -ar verbs ends in -ei and needs a spelling change.
+        if index == 0 and verb_class == "ar":
+            preterite_stem = _adjust_ar_preterite_1s_stem(stem)
         forms[f"{person}_present"] = stem + _PRESENT_ENDINGS[verb_class][index]
-        forms[f"{person}_past"] = stem + _PRETERITE_ENDINGS[verb_class][index]
+        forms[f"{person}_past"] = preterite_stem + _PRETERITE_ENDINGS[verb_class][index]
         forms[f"{person}_future"] = infinitive_value + _FUTURE_ENDINGS[index]
 
     return forms

--- a/src/tests/langtools/test_de_conjugation.py
+++ b/src/tests/langtools/test_de_conjugation.py
@@ -91,6 +91,37 @@ class TestRegularLernen(unittest.TestCase):
         self.assertEqual(result["3s_present"], "lernt")
 
 
+class TestSibilantStems(unittest.TestCase):
+    """Stems ending in a sibilant take -t (not -st) in 2s present."""
+
+    def test_tanzen(self) -> None:
+        result = conjugate("tanzen")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "tanze")
+        self.assertEqual(result["2s_present"], "tanzt")
+        self.assertEqual(result["3s_present"], "tanzt")
+        self.assertEqual(result["2p_present"], "tanzt")
+
+    def test_reisen(self) -> None:
+        result = conjugate("reisen")
+        assert result is not None
+        self.assertEqual(result["2s_present"], "reist")
+        self.assertEqual(result["3s_present"], "reist")
+
+    def test_gruessen(self) -> None:
+        """grüßen: stem ends in ß → du grüßt."""
+        result = conjugate("grüßen")
+        assert result is not None
+        self.assertEqual(result["2s_present"], "grüßt")
+
+    def test_past_unaffected(self) -> None:
+        """The sibilant rule only touches 2s present, not the past tense."""
+        result = conjugate("tanzen")
+        assert result is not None
+        self.assertEqual(result["1s_past"], "tanzte")
+        self.assertEqual(result["2s_past"], "tanztest")
+
+
 class TestIrregularVerbsReturnNone(unittest.TestCase):
     """Irregular/strong/modal verbs must return None to trigger LLM fallback."""
 

--- a/src/tests/langtools/test_es_conjugation.py
+++ b/src/tests/langtools/test_es_conjugation.py
@@ -504,6 +504,56 @@ class TestConjugateSafe(unittest.TestCase):
         self.assertTrue(len(warnings) > 0)
 
 
+class TestUirVerbs(unittest.TestCase):
+    """-uir verbs insert a consonantal y (construir, huir)."""
+
+    def test_construir_present(self) -> None:
+        forms = conjugate("construir")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "construyo")
+        self.assertEqual(forms["2s_present"], "construyes")
+        self.assertEqual(forms["3s_present"], "construye")
+        self.assertEqual(forms["1p_present"], "construimos")
+        self.assertEqual(forms["2p_present"], "construís")
+        self.assertEqual(forms["3p_present"], "construyen")
+
+    def test_construir_preterite(self) -> None:
+        forms = conjugate("construir")
+        assert forms is not None
+        self.assertEqual(forms["1s_preterite"], "construí")
+        self.assertEqual(forms["3s_preterite"], "construyó")
+        self.assertEqual(forms["3p_preterite"], "construyeron")
+
+    def test_construir_subjunctive_and_nonfinite(self) -> None:
+        forms = conjugate("construir")
+        assert forms is not None
+        self.assertEqual(forms["1s_subjunctive_present"], "construya")
+        self.assertEqual(forms["1p_subjunctive_present"], "construyamos")
+        self.assertEqual(forms["gerund"], "construyendo")
+        self.assertEqual(forms["past_participle"], "construido")
+
+    def test_huir(self) -> None:
+        forms = conjugate("huir")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "huyo")
+        self.assertEqual(forms["3p_present"], "huyen")
+        self.assertEqual(forms["3s_preterite"], "huyó")
+
+    def test_guir_verbs_get_no_y(self) -> None:
+        """-guir verbs are NOT -uir y-verbs; the u is a silent digraph."""
+        forms = conjugate("seguir")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "sigo")
+        self.assertEqual(forms["2s_present"], "sigues")
+        self.assertEqual(forms["3p_present"], "siguen")
+
+    def test_distinguir_drops_u_before_o(self) -> None:
+        forms = conjugate("distinguir")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "distingo")
+        self.assertEqual(forms["2s_present"], "distingues")
+
+
 class TestUcirVerbs(unittest.TestCase):
     def test_conducir_present(self) -> None:
         forms = conjugate("conducir")

--- a/src/tests/langtools/test_fr_conjugation.py
+++ b/src/tests/langtools/test_fr_conjugation.py
@@ -142,6 +142,123 @@ class TestYerVerbs(_ConjugationTestBase):
         self.assertEqual(forms["pc_f"], "payée")
 
 
+class TestEGraveStemChange(_ConjugationTestBase):
+    """Test e -> è stem change (lever, mener, acheter)."""
+
+    def test_lever_present(self) -> None:
+        forms = self._forms("lever")
+        self.assertEqual(forms["1s_present"], "lève")
+        self.assertEqual(forms["2s_present"], "lèves")
+        self.assertEqual(forms["3s_present"], "lève")
+        self.assertEqual(forms["1p_present"], "levons")
+        self.assertEqual(forms["2p_present"], "levez")
+        self.assertEqual(forms["3p_present"], "lèvent")
+
+    def test_lever_future_uses_grave(self) -> None:
+        forms = self._forms("lever")
+        self.assertEqual(forms["1s_future"], "lèverai")
+        self.assertEqual(forms["3p_future"], "lèveront")
+
+    def test_lever_imperfect_keeps_e(self) -> None:
+        forms = self._forms("lever")
+        self.assertEqual(forms["1s_impf"], "levais")
+        self.assertEqual(forms["1p_impf"], "levions")
+
+    def test_mener(self) -> None:
+        forms = self._forms("mener")
+        self.assertEqual(forms["1s_present"], "mène")
+        self.assertEqual(forms["1p_present"], "menons")
+        self.assertEqual(forms["1s_future"], "mènerai")
+
+    def test_acheter_is_grave_not_doubled(self) -> None:
+        forms = self._forms("acheter")
+        self.assertEqual(forms["1s_present"], "achète")
+        self.assertEqual(forms["1p_present"], "achetons")
+        self.assertEqual(forms["3p_present"], "achètent")
+        self.assertEqual(forms["1s_future"], "achèterai")
+        self.assertEqual(forms["pc_m"], "acheté")
+
+    def test_geler_is_grave_not_doubled(self) -> None:
+        forms = self._forms("geler")
+        self.assertEqual(forms["3s_present"], "gèle")
+        self.assertEqual(forms["1p_present"], "gelons")
+        self.assertEqual(forms["1s_future"], "gèlerai")
+
+
+class TestEAcuteStemChange(_ConjugationTestBase):
+    """Test é -> è stem change (préférer, espérer): present only."""
+
+    def test_preferer_present(self) -> None:
+        forms = self._forms("préférer")
+        self.assertEqual(forms["1s_present"], "préfère")
+        self.assertEqual(forms["2s_present"], "préfères")
+        self.assertEqual(forms["3s_present"], "préfère")
+        self.assertEqual(forms["1p_present"], "préférons")
+        self.assertEqual(forms["2p_present"], "préférez")
+        self.assertEqual(forms["3p_present"], "préfèrent")
+
+    def test_preferer_future_keeps_acute(self) -> None:
+        forms = self._forms("préférer")
+        self.assertEqual(forms["1s_future"], "préférerai")
+        self.assertEqual(forms["3p_future"], "préféreront")
+
+    def test_esperer(self) -> None:
+        forms = self._forms("espérer")
+        self.assertEqual(forms["1s_present"], "espère")
+        self.assertEqual(forms["1p_present"], "espérons")
+        self.assertEqual(forms["1s_future"], "espérerai")
+        self.assertEqual(forms["pc_m"], "espéré")
+
+    def test_repeter(self) -> None:
+        forms = self._forms("répéter")
+        self.assertEqual(forms["3s_present"], "répète")
+        self.assertEqual(forms["1s_future"], "répéterai")
+
+
+class TestConsonantDoublingStemChange(_ConjugationTestBase):
+    """Test consonant doubling (appeler, jeter)."""
+
+    def test_appeler_present(self) -> None:
+        forms = self._forms("appeler")
+        self.assertEqual(forms["1s_present"], "appelle")
+        self.assertEqual(forms["2s_present"], "appelles")
+        self.assertEqual(forms["3s_present"], "appelle")
+        self.assertEqual(forms["1p_present"], "appelons")
+        self.assertEqual(forms["2p_present"], "appelez")
+        self.assertEqual(forms["3p_present"], "appellent")
+
+    def test_appeler_future_doubles(self) -> None:
+        forms = self._forms("appeler")
+        self.assertEqual(forms["1s_future"], "appellerai")
+        self.assertEqual(forms["3p_future"], "appelleront")
+
+    def test_appeler_imperfect_single(self) -> None:
+        forms = self._forms("appeler")
+        self.assertEqual(forms["1s_impf"], "appelais")
+        self.assertEqual(forms["pc_m"], "appelé")
+
+    def test_jeter(self) -> None:
+        forms = self._forms("jeter")
+        self.assertEqual(forms["1s_present"], "jette")
+        self.assertEqual(forms["1p_present"], "jetons")
+        self.assertEqual(forms["3p_present"], "jettent")
+        self.assertEqual(forms["1s_future"], "jetterai")
+        self.assertEqual(forms["pc_m"], "jeté")
+
+
+class TestProtegerCombined(_ConjugationTestBase):
+    """protéger combines é -> è and -ger softening."""
+
+    def test_proteger(self) -> None:
+        forms = self._forms("protéger")
+        self.assertEqual(forms["1s_present"], "protège")
+        self.assertEqual(forms["1p_present"], "protégeons")
+        self.assertEqual(forms["2p_present"], "protégez")
+        self.assertEqual(forms["3p_present"], "protègent")
+        self.assertEqual(forms["1s_impf"], "protégeais")
+        self.assertEqual(forms["1s_future"], "protégerai")
+
+
 class TestRegularIrVerbs(_ConjugationTestBase):
     """Test second-group (-ir with -iss-) regular conjugation."""
 

--- a/src/tests/langtools/test_it_conjugation.py
+++ b/src/tests/langtools/test_it_conjugation.py
@@ -90,6 +90,65 @@ class TestRegularIre(unittest.TestCase):
         self.assertEqual(self.forms["3s_future"], "partirà")
 
 
+class TestCareGareOrthography(unittest.TestCase):
+    """-care/-gare verbs insert h to keep the hard c/g sound."""
+
+    def test_cercare_present(self) -> None:
+        forms = conjugate("cercare")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "cerco")
+        self.assertEqual(forms["2s_present"], "cerchi")
+        self.assertEqual(forms["3s_present"], "cerca")
+        self.assertEqual(forms["1p_present"], "cerchiamo")
+        self.assertEqual(forms["2p_present"], "cercate")
+        self.assertEqual(forms["3p_present"], "cercano")
+
+    def test_cercare_future(self) -> None:
+        forms = conjugate("cercare")
+        assert forms is not None
+        self.assertEqual(forms["1s_future"], "cercherò")
+        self.assertEqual(forms["3p_future"], "cercheranno")
+
+    def test_pagare_present(self) -> None:
+        forms = conjugate("pagare")
+        assert forms is not None
+        self.assertEqual(forms["2s_present"], "paghi")
+        self.assertEqual(forms["1p_present"], "paghiamo")
+        self.assertEqual(forms["1s_future"], "pagherò")
+
+    def test_pagare_imperfect_unchanged(self) -> None:
+        forms = conjugate("pagare")
+        assert forms is not None
+        self.assertEqual(forms["1s_past"], "pagavo")
+
+
+class TestCiareGiareOrthography(unittest.TestCase):
+    """-ciare/-giare verbs drop the softening i before front vowels."""
+
+    def test_mangiare_present(self) -> None:
+        forms = conjugate("mangiare")
+        assert forms is not None
+        self.assertEqual(forms["1s_present"], "mangio")
+        self.assertEqual(forms["2s_present"], "mangi")
+        self.assertEqual(forms["3s_present"], "mangia")
+        self.assertEqual(forms["1p_present"], "mangiamo")
+        self.assertEqual(forms["2p_present"], "mangiate")
+        self.assertEqual(forms["3p_present"], "mangiano")
+
+    def test_mangiare_future(self) -> None:
+        forms = conjugate("mangiare")
+        assert forms is not None
+        self.assertEqual(forms["1s_future"], "mangerò")
+        self.assertEqual(forms["3s_future"], "mangerà")
+
+    def test_cominciare_present(self) -> None:
+        forms = conjugate("cominciare")
+        assert forms is not None
+        self.assertEqual(forms["2s_present"], "cominci")
+        self.assertEqual(forms["1p_present"], "cominciamo")
+        self.assertEqual(forms["1s_future"], "comincerò")
+
+
 class TestIrregularVerbsHandling(unittest.TestCase):
     """Common irregulars are hard-coded; other irregulars still fall back."""
 

--- a/src/tests/langtools/test_nl_conjugation.py
+++ b/src/tests/langtools/test_nl_conjugation.py
@@ -121,6 +121,55 @@ class TestRegularWithDeSuffix(unittest.TestCase):
         self.assertEqual(result["1p_past"], "speelden")
 
 
+class TestDoubledConsonantStems(unittest.TestCase):
+    """Verbs with a doubled consonant degeminate the stem (pakken → pak)."""
+
+    def test_pakken(self) -> None:
+        stem, raw = _normalize_stem("pakken")
+        self.assertEqual(stem, "pak")
+        self.assertEqual(raw, "pakk")
+        result = conjugate("pakken")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "pak")
+        self.assertEqual(result["2s_present"], "pakt")
+        self.assertEqual(result["1s_past"], "pakte")  # 't kofschip → -te
+
+    def test_stoppen(self) -> None:
+        result = conjugate("stoppen")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "stop")
+        self.assertEqual(result["3s_present"], "stopt")
+        self.assertEqual(result["1s_past"], "stopte")
+
+    def test_stellen_takes_de(self) -> None:
+        """stellen: degeminate to 'stel', ends in l → -de past."""
+        result = conjugate("stellen")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "stel")
+        self.assertEqual(result["1s_past"], "stelde")
+
+
+class TestStemEndingInT(unittest.TestCase):
+    """A stem ending in -t does not double the t in the present."""
+
+    def test_zetten(self) -> None:
+        """zetten: degeminate to 'zet'; 2s/3s stay 'zet'."""
+        result = conjugate("zetten")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "zet")
+        self.assertEqual(result["2s_present"], "zet")
+        self.assertEqual(result["3s_present"], "zet")
+        self.assertEqual(result["1s_past"], "zette")
+
+    def test_praten(self) -> None:
+        """praten: vowel-doubled to 'praat'; no extra t."""
+        result = conjugate("praten")
+        assert result is not None
+        self.assertEqual(result["1s_present"], "praat")
+        self.assertEqual(result["3s_present"], "praat")
+        self.assertEqual(result["1s_past"], "praatte")
+
+
 class TestIrregularVerbsReturnNone(unittest.TestCase):
     """Irregular/strong verbs must return None to trigger LLM fallback."""
 

--- a/src/tests/langtools/test_pt_conjugation.py
+++ b/src/tests/langtools/test_pt_conjugation.py
@@ -91,6 +91,30 @@ class TestRegularIr(unittest.TestCase):
         self.assertEqual(self.forms["3s_future"], "partirá")
 
 
+class TestArSpellingChangePreterite(unittest.TestCase):
+    """-car/-gar/-çar verbs keep their hard sound in the 1s preterite."""
+
+    def test_ficar(self) -> None:
+        forms = conjugate("ficar")
+        assert forms is not None
+        self.assertEqual(forms["1s_past"], "fiquei")
+        self.assertEqual(forms["3s_past"], "ficou")
+        self.assertEqual(forms["1s_present"], "fico")
+
+    def test_chegar(self) -> None:
+        forms = conjugate("chegar")
+        assert forms is not None
+        self.assertEqual(forms["1s_past"], "cheguei")
+        self.assertEqual(forms["3p_past"], "chegaram")
+
+    def test_comecar(self) -> None:
+        forms = conjugate("começar")
+        assert forms is not None
+        self.assertEqual(forms["1s_past"], "comecei")
+        self.assertEqual(forms["1s_present"], "começo")
+        self.assertEqual(forms["3s_past"], "começou")
+
+
 class TestHardcodedIrregularVerbs(unittest.TestCase):
     """Common irregular verbs should be hard-coded for deterministic output."""
 


### PR DESCRIPTION
## Summary
This PR extends the Romance and Germanic language conjugation modules with comprehensive support for orthographic and stem-change rules that were previously missing or incomplete. The changes enable accurate conjugation of verbs with vowel shifts, consonant doubling, and spelling adjustments across multiple languages.

## Key Changes

### French (`src/langtools/fr/conjugation.py`)
- **e → è stem change** (lever, mener, acheter): applies before silent present endings and throughout the future tense
- **é → è stem change** (préférer, espérer): applies only to silent present endings; future keeps the acute accent
- **Consonant doubling** (appeler, jeter): doubles the final consonant before silent endings and in the future, with exceptions for specific verbs (geler, acheter, etc.) that use grave accent instead
- Added helper function `_is_consonant()` and exception set `_ER_E_GRAVE_EXCEPTIONS` to distinguish doubling vs. grave-accent verbs
- Refactored `_conjugate_er()` to use a unified stem-change detection system

### Italian (`src/langtools/it/conjugation.py`)
- **-care/-gare orthography**: inserts 'h' before front vowels (e, i) to preserve hard c/g sound (cerco → cerchi, pagare → paghi)
- **-ciare/-giare orthography**: drops the stem-final 'i' before front vowels to avoid doubling (mangio → mangi, not "mangii")
- Added `_adjust_are_stem()` helper to apply these rules consistently in present and future tenses
- Updated future stem derivation to handle -care/-gare and -ciare/-giare patterns

### Spanish (`src/langtools/es/conjugation.py`)
- **-uir verbs** (construir, huir, incluir): insert consonantal 'y' in boot positions (present, subjunctive) and between vowels in preterite (construyó, construyeron)
- Distinguished -uir verbs from -guir/-quir verbs (where 'u' is a silent digraph marker)
- Added `_is_uir_verb()` helper and integrated y-insertion logic into present, preterite, and subjunctive conjugation
- **-guir verbs**: drop the silent 'u' before -o endings (sigo, distingo) but retain it before -e endings (sigues, sigue)

### Dutch (`src/langtools/nl/conjugation.py`)
- **Doubled consonant degemination** (pakken → pak, stoppen → stop): recognizes doubled consonants as markers of closed short syllables and removes one
- **Stem-final -t handling**: prevents doubling of -t in present tense (zetten → zet, not "zett")
- Refactored `_normalize_stem()` to prioritize degemination over vowel lengthening
- Updated past-tense suffix logic to account for degeminated stems

### German (`src/langtools/de/conjugation.py`)
- **Sibilant stem rule**: stems ending in s, ß, z, or x absorb the 's' of the 2s -st ending (tanzen → du tanzt, not "tanzst"; reisen → du reist)
- Added `sibilant_stem` flag to conditionally apply this rule in present tense conjugation

### Portuguese (`src/langtools/pt/conjugation.py`)
- **-car/-gar/-çar spelling changes** in 1s preterite: preserves hard sound before the front vowel 'e'
  - c → qu (ficar → fiquei)
  - g → gu (chegar → cheguei)
  - ç → c (começar → comecei)
- Added `_adjust_ar_preterite_1s_stem()` helper to apply these transformations

## Test Coverage
Comprehensive test suites added for all new features:
- French: `TestEGraveStemChange`, `TestEAcuteStemChange`, `TestConsonantDoublingStemChange`, `TestProtegerCombined`
- Italian

https://claude.ai/code/session_01CpYhtbXzmDkrXPGsyR9BjN