### PR TITLE
Add Latin/Sanskrit to translation LLM language config

### DIFF
--- a/src/storage/translation_helpers.py
+++ b/src/storage/translation_helpers.py
@@ -202,6 +202,12 @@ LANGUAGE_HIERARCHY = [
 ]
 
 # Language mappings
+# This is the storage-side source of truth for supported languages (code,
+# display name, table routing). The translation LLM path additionally needs
+# prompt data (description, instructions) kept in DEFAULT_TRANSLATION_LANGUAGES
+# in wordfreq/translation/constants.py. When adding/removing a language here,
+# make the matching change there (and in LLM_FIELD_TO_LANG_CODE below), or the
+# active query_translations path will skip it as "unknown".
 # Format: 'code': (field_name_or_code, display_name, use_lemma_translation_table)
 # If use_lemma_translation_table is True, field_name_or_code is the language_code for LemmaTranslation table
 # If False, field_name_or_code is the column name in Lemma table (only used for English)

--- a/src/wordfreq/translation/constants.py
+++ b/src/wordfreq/translation/constants.py
@@ -29,7 +29,12 @@ VALID_POS_TYPES = {
 # Define major parts of speech as a set for efficient lookup
 MAJOR_POS_TYPES = {"noun", "verb", "adjective", "adverb"}
 
-# Default languages and their configurations
+# Default languages and their configurations.
+# This carries prompt-specific data (description, instructions) needed by the
+# translation LLM path; the storage-side source of truth is LANGUAGE_FIELDS in
+# storage/translation_helpers.py. When adding/removing a language here, make the
+# matching change in LANGUAGE_FIELDS (and LLM_FIELD_TO_LANG_CODE) there, or the
+# active query_translations path will skip it as "unknown".
 DEFAULT_TRANSLATION_LANGUAGES = {
     "lithuanian": {
         "field": "lithuanian_translation",
@@ -72,6 +77,18 @@ DEFAULT_TRANSLATION_LANGUAGES = {
         "code": "ja",
         "description": "Japanese translation in lemma form",
         "instructions": "- Japanese: Provide standard Japanese in base form (dictionary form, singular for nouns)",
+    },
+    "latin": {
+        "field": "latin_translation",
+        "code": "la",
+        "description": "Latin translation in lemma form",
+        "instructions": "- Latin: Provide Classical Latin in base form (present active infinitive for verbs, nominative singular for nouns)\n  - Use Classical (not Ecclesiastical or Medieval) orthography and vocabulary\n  - For modern concepts with no Classical word, use the established Neo-Latin term",
+    },
+    "sanskrit": {
+        "field": "sanskrit_translation",
+        "code": "sa",
+        "description": "Sanskrit translation in lemma form (Devanagari script)",
+        "instructions": "- Sanskrit: Provide Sanskrit in Devanagari script in base form (root/stem form for verbs, nominative singular for nouns)\n  - Do not include IAST transliteration, just the Devanagari characters\n  - For modern concepts, use the established Sanskrit coinage where one exists",
     },
     "italian": {
         "field": "italian_translation",


### PR DESCRIPTION
DEFAULT_TRANSLATION_LANGUAGES lacked la/sa entries, so the active query_translations path skipped them as "unknown" and returned "No valid languages specified" when only la/sa were requested.

Add the entries and cross-reference comments between this file and LANGUAGE_FIELDS in storage/translation_helpers.py, since both locations exist for distinct reasons (prompt data vs. storage routing).