### PR TITLE
Add Punjabi (pa) language support

### DIFF
--- a/prompts/language_forms/pa/noun/context.txt
+++ b/prompts/language_forms/pa/noun/context.txt
@@ -1,0 +1,7 @@
+You are a Punjabi language expert helping generate accurate noun forms.
+
+Provide singular and plural forms in their nominative/dictionary (direct) case.
+
+Use Eastern (Indian) Punjabi in the Gurmukhi script. Do not use Shahmukhi/Perso-Arabic script, and do not include transliteration.
+
+Use empty string ("") for forms that don't exist.

--- a/prompts/language_forms/pa/noun/prompt.txt
+++ b/prompts/language_forms/pa/noun/prompt.txt
@@ -1,0 +1,6 @@
+Generate all Punjabi noun forms for the Punjabi noun "{noun}".
+
+English noun: {english_noun}
+Definition: {definition}{subtype_context}
+
+Please provide all 2 forms (singular and plural) in the Gurmukhi script, using empty strings for forms that don't exist.

--- a/prompts/language_forms/pa/verb/context.txt
+++ b/prompts/language_forms/pa/verb/context.txt
@@ -1,0 +1,8 @@
+You are a Punjabi language expert specializing in verb forms.
+
+Provide the present, past, and future tense forms of the verb.
+Give only the verb form without subject pronouns.
+
+Use Eastern (Indian) Punjabi in the Gurmukhi script. Do not use Shahmukhi/Perso-Arabic script, and do not include transliteration.
+
+Use empty string ("") for forms that don't exist.

--- a/prompts/language_forms/pa/verb/prompt.txt
+++ b/prompts/language_forms/pa/verb/prompt.txt
@@ -1,0 +1,7 @@
+Generate Punjabi verb forms for the Punjabi verb "{verb}".
+
+English verb: {english_verb}
+Definition: {definition}{subtype_context}
+
+Please provide present, past, and future tense forms in the Gurmukhi script.
+Provide only the verb form without any pronouns. Use empty strings for forms that don't exist.

--- a/src/langtools/family/brahmic/collation.py
+++ b/src/langtools/family/brahmic/collation.py
@@ -1,4 +1,4 @@
-"""Collation data for Brahmic-script languages (Devanagari, Bengali, Tamil, Kannada).
+"""Collation data for Brahmic-script languages (Devanagari, Bengali, Tamil, Kannada, Gurmukhi).
 
 Independent letters are in canonical varnamala order within each script's
 primary Unicode block, but we still remap to single-character ASCII so every
@@ -31,10 +31,17 @@ KN_LETTERS_LOWER: List[str] = list(
     "ಅಆಇಈಉಊಋಎಏಐಒಓಔ" "ಕಖಗಘಙ" "ಚಛಜಝಞ" "ಟಠಡಢಣ" "ತಥದಧನ" "ಪಫಬಭಮ" "ಯರಲವಶಷಸಹಳ"
 )
 
+# Punjabi (Gurmukhi): the three vowel-bearers (Ura, Aira, Iri) followed by the
+# 35 consonants of the painti in standard Gurmukhi alphabet order.  Independent
+# vowels are formed from the bearers plus matras, which are stripped as
+# combining marks before lookup, so word-initial vowels collate via their bearer.
+PA_LETTERS_LOWER: List[str] = list("ੳਅੲ" "ਸਹ" "ਕਖਗਘਙ" "ਚਛਜਝਞ" "ਟਠਡਢਣ" "ਤਥਦਧਨ" "ਪਫਬਭਮ" "ਯਰਲਵੜ")
+
 HI_REMAP: Dict[str, str] = build_position_codes(HI_LETTERS_LOWER)
 BN_REMAP: Dict[str, str] = build_position_codes(BN_LETTERS_LOWER)
 TA_REMAP: Dict[str, str] = build_position_codes(TA_LETTERS_LOWER)
 KN_REMAP: Dict[str, str] = build_position_codes(KN_LETTERS_LOWER)
+PA_REMAP: Dict[str, str] = build_position_codes(PA_LETTERS_LOWER)
 
 # Master table for Brahmic position-remapped languages.
 REMAP_LANGUAGES: Dict[str, Dict[str, str]] = {
@@ -42,6 +49,7 @@ REMAP_LANGUAGES: Dict[str, Dict[str, str]] = {
     "bn": BN_REMAP,
     "ta": TA_REMAP,
     "kn": KN_REMAP,
+    "pa": PA_REMAP,
 }
 
 

--- a/src/langtools/form_registry.py
+++ b/src/langtools/form_registry.py
@@ -219,7 +219,6 @@ _PATTERN_B_LANGS: List[Tuple[str, str]] = [
     ("mr", "Marathi"),
     ("ms", "Malay"),
     ("or", "Odia"),
-    ("pa", "Punjabi"),
     ("ps", "Pashto"),
     ("tl", "Filipino"),
     ("tr", "Turkish"),

--- a/src/langtools/pa/forms_config.py
+++ b/src/langtools/pa/forms_config.py
@@ -1,0 +1,26 @@
+"""Punjabi grammatical structure — single source of truth.
+
+Used by form_patterns.py to auto-generate enum members, form_registry entries,
+and task configurations.
+"""
+
+from typing import Any, Dict
+
+LANGUAGE_CODE = "pa"
+LANGUAGE_NAME = "Punjabi"
+
+NOUN_CONFIG: Dict[str, Any] = {
+    "type": "singular_plural",
+    "query_type": "punjabi_noun_forms",
+    "schema_name": "PunjabiNounForms",
+}
+
+# Punjabi verbs conjugate for person, number, gender, tense, and aspect.
+# Like Hindi, the periphrastic tense system uses auxiliary verbs, so we store
+# the three main tense constructions rather than person-inflected forms.
+VERB_CONFIG: Dict[str, Any] = {
+    "type": "tense_only",
+    "tenses": ["present", "past", "future"],
+    "query_type": "punjabi_verb_forms",
+    "schema_name": "PunjabiVerbForms",
+}

--- a/src/storage/translation_helpers.py
+++ b/src/storage/translation_helpers.py
@@ -58,6 +58,7 @@ TIER_3_LANGUAGES = [
     "bn",
     "sw",
     "hi",
+    "pa",
 ]
 
 # Tier 4: Additional experimental languages with minimal coverage
@@ -198,6 +199,7 @@ LANGUAGE_HIERARCHY = [
     "xh",  # Xhosa (experimental)
     "sn",  # Shona (experimental)
     "hi",  # Hindi (experimental)
+    "pa",  # Punjabi (experimental, Gurmukhi)
     "ps",  # Pashto (experimental)
     "fa",  # Persian (experimental)
     "ka",  # Georgian (experimental)
@@ -280,6 +282,7 @@ LANGUAGE_FIELDS = {
     "xh": ("xh", "Xhosa", True),
     "sn": ("sn", "Shona", True),
     "hi": ("hi", "Hindi", True),
+    "pa": ("pa", "Punjabi", True),
     "ps": ("ps", "Pashto", True),
     "fa": ("fa", "Persian", True),
     "ka": ("ka", "Georgian", True),
@@ -356,6 +359,7 @@ LLM_FIELD_TO_LANG_CODE = {
     "xhosa_translation": "xh",
     "shona_translation": "sn",
     "hindi_translation": "hi",
+    "punjabi_translation": "pa",
     "pashto_translation": "ps",
     "persian_translation": "fa",
     "georgian_translation": "ka",

--- a/src/tests/langtools/test_brahmic_collation.py
+++ b/src/tests/langtools/test_brahmic_collation.py
@@ -1,0 +1,41 @@
+"""Tests for Brahmic-script collation, including Gurmukhi (Punjabi)."""
+
+from langtools.collation import SORT_KEY_LANGUAGES, generate_sort_key
+from langtools.family.brahmic.collation import PA_LETTERS_LOWER, REMAP_LANGUAGES
+
+
+def test_punjabi_registered() -> None:
+    """Punjabi must be wired into both the Brahmic table and the public set."""
+    assert "pa" in REMAP_LANGUAGES
+    assert "pa" in SORT_KEY_LANGUAGES
+
+
+def test_punjabi_sort_keys_are_ascii() -> None:
+    """Every Gurmukhi sort key must be plain ASCII for binary collation."""
+    for word in ["ਪਾਣੀ", "ਕੁੱਤਾ", "ਅੱਗ", "ਗਾਂ", "ਸੇਬ", "ਮਾਂ"]:
+        key = generate_sort_key("pa", word)
+        assert key is not None
+        assert key.isascii(), f"non-ASCII sort key for {word!r}: {key!r}"
+
+
+def test_punjabi_alphabet_order() -> None:
+    """Words sort in Gurmukhi alphabet order (vowel-bearer, then painti)."""
+    # ਅ (vowel) < ਸ < ਕ < ਗ < ਪ < ਮ in standard Gurmukhi order.
+    words = ["ਮਾਂ", "ਪਾਣੀ", "ਗਾਂ", "ਕੁੱਤਾ", "ਸੇਬ", "ਅੱਗ"]
+    ordered = sorted(words, key=lambda w: generate_sort_key("pa", w) or "")
+    assert ordered == ["ਅੱਗ", "ਸੇਬ", "ਕੁੱਤਾ", "ਗਾਂ", "ਪਾਣੀ", "ਮਾਂ"]
+
+
+def test_punjabi_matras_stripped() -> None:
+    """Combining vowel signs (matras) must not perturb word-initial ordering."""
+    # ਕ and ਕੀ share the same initial consonant; the matra is stripped, so the
+    # first letter alone drives the leading sort position.
+    bare = generate_sort_key("pa", "ਕ")
+    with_matra = generate_sort_key("pa", "ਕੀ")
+    assert bare is not None and with_matra is not None
+    assert with_matra.startswith(bare)
+
+
+def test_painti_has_no_duplicate_letters() -> None:
+    """The Gurmukhi letter list must be unique so position codes are 1:1."""
+    assert len(PA_LETTERS_LOWER) == len(set(PA_LETTERS_LOWER))

--- a/src/wordfreq/translation/constants.py
+++ b/src/wordfreq/translation/constants.py
@@ -288,6 +288,12 @@ DEFAULT_TRANSLATION_LANGUAGES = {
         "description": "Hindi translation in lemma form (Devanagari script)",
         "instructions": "- Hindi: Provide standard Hindi in Devanagari script in base form (infinitive for verbs, singular for nouns)\n  - Use Modern Standard Hindi as spoken in India\n  - Do not include transliteration, just the Devanagari characters",
     },
+    "punjabi": {
+        "field": "punjabi_translation",
+        "code": "pa",
+        "description": "Punjabi translation in lemma form (Gurmukhi script)",
+        "instructions": "- Punjabi: Provide standard Punjabi in Gurmukhi script in base form (infinitive for verbs, singular for nouns)\n  - Use Eastern (Indian) Punjabi as spoken in Indian Punjab\n  - Use the Gurmukhi script, not Shahmukhi/Perso-Arabic\n  - Do not include transliteration, just the Gurmukhi characters",
+    },
     "bengali": {
         "field": "bengali_translation",
         "code": "bn",


### PR DESCRIPTION
Wire Punjabi into the translation/storage layer and morphology pipeline:

- Storage: add `pa` to Tier 3, LANGUAGE_HIERARCHY, LANGUAGE_FIELDS, and LLM_FIELD_TO_LANG_CODE in translation_helpers.py. Routes into the existing secondary.jsonl release files (no new grouped file).
- LLM prompt config: add the "punjabi" entry to DEFAULT_TRANSLATION_LANGUAGES (Gurmukhi script, Eastern/Indian Punjabi).
- Collation: add Gurmukhi sort-key support (vowel-bearers + 35-consonant painti) to the Brahmic collation table so translations get ASCII sort_keys.
- Morphology: add langtools/pa/forms_config.py (singular/plural nouns, present/past/future verbs) so GrammaticalForm enum members and FORM_SPECS auto-register; add Gurmukhi noun/verb prompt templates. Remove pa from the inert _PATTERN_B_LANGS not-yet-implemented list.
- Tests: add Gurmukhi collation tests.