### PR TITLE
Add lemma-creation API endpoint; thread model through translation worker

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -32,6 +32,7 @@ from api.batch_operations import (
     list_pos_subtypes,
 )
 from api.lemmas import (
+    add_lemmas,
     get_forms,
     get_grammar,
     get_lemma,
@@ -55,6 +56,7 @@ from api.sentences import get_sentence, get_sentence_metadata
 __all__ = [
     "BarsukasAPIError",
     "admin_restart",
+    "add_lemmas",
     "add_missing_translations",
     "check_definition",
     "check_disambiguation",

--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -194,6 +194,27 @@ def list_by_difficulty(
     )
 
 
+class AddLemmaInput(TypedDict, total=False):
+    lemma_text: str
+    definition_text: str
+    pos_type: str
+    pos_subtype: str
+    difficulty_level: Optional[int]
+    translations: Dict[str, str]
+
+
+@mirrored_route("/api/v1/lemmas/add", "POST")
+def add_lemmas(lemmas: List[AddLemmaInput]) -> Any:
+    """Create one or more lemmas, returning their generated GUIDs.
+
+    Each entry requires ``lemma_text``, ``definition_text``, ``pos_type`` and
+    ``pos_subtype``; ``difficulty_level`` and ``translations`` are optional.
+    An entry whose ``(lemma_text, pos_type)`` already exists is returned with
+    ``status`` ``"already_exists"`` and is not modified.
+    """
+    return post_json(f"{API_V1_PREFIX}/lemmas/add", {"lemmas": lemmas})
+
+
 @mirrored_route("/api/v1/lemma/<guid>", "GET")
 def get_lemma(guid: str) -> Any:
     """Basic lemma details."""

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -39,6 +39,12 @@ Base prefix: `/api`.
   - Update mutable lemma fields.
   - Body: `{"difficulty_level": <int|null>}`.
 
+- `POST /api/v1/lemmas/add`
+  - Create one or more lemmas, returning their generated GUIDs.
+  - Body: `{"lemmas": [{"lemma_text": ..., "definition_text": ..., "pos_type": ..., "pos_subtype": ..., "difficulty_level": <int|null>, "translations": {"<code>": "..."}}]}`.
+  - `lemma_text`/`definition_text`/`pos_type`/`pos_subtype` are required per entry; `difficulty_level` and `translations` are optional. Max 100 entries.
+  - GUIDs are assigned automatically from the `pos_type`/`pos_subtype` prefix. An entry whose `(lemma_text, pos_type)` already exists is returned with `status: "already_exists"` and its existing GUID, and is not modified; created entries return `status: "created"`.
+
 - `POST /api/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>`
   - Merge the synonym lemma into the main lemma. Requires the same `pos_type` and at least 3 matching non-empty translations after normalization.
   - Adds the synonym lemma text/translations as per-language `synonym` derivative forms on the main lemma, tombstones `synonym_guid`, repoints sentence/audio references, and deletes the synonym lemma row.

--- a/src/barsukas/routes/api/lemma_routes.py
+++ b/src/barsukas/routes/api/lemma_routes.py
@@ -31,6 +31,7 @@ from audioshoe.qwen.types import QwenVoice
 from storage.crud.grammar_fact import get_grammar_facts
 from storage.crud.guid_tombstone import create_tombstone, get_tombstone_by_guid
 from storage.crud.lemma import get_lemma_by_guid
+from storage.crud.operation_log import log_translation_change
 from storage.crud.sentence import add_sentence, find_sentence_by_text
 from storage.crud.sentence_translation import add_sentence_translation
 from storage.lexeme import get_lexeme
@@ -57,7 +58,9 @@ from storage.translation_helpers import (
     LANGUAGE_HIERARCHY,
     get_all_translations,
     get_translation_pronunciations,
+    set_translation,
 )
+from storage.utils.guid import generate_guid
 from workqueue.task_queue import TaskStatus, TaskType, enqueue_task
 from barsukas.routes.api import bp
 
@@ -790,6 +793,177 @@ def update_lemma_info(guid: str) -> ResponseReturnValue:
             "previous_difficulty_level": _serialize_value(old_difficulty_level),
             "updated": old_difficulty_level != lemma.difficulty_level,
         }
+    )
+
+
+_ADD_LEMMAS_MAX = 100
+
+
+@bp.route("/v1/lemmas/add", methods=["POST"])
+@mirrored_facade("/api/v1/lemmas/add", "POST")
+def add_lemmas() -> ResponseReturnValue:
+    """Create one or more lemmas, returning their generated GUIDs.
+
+    JSON body:
+      - ``lemmas``: non-empty list (max 100) of objects, each requiring
+        ``lemma_text``, ``definition_text``, ``pos_type`` and ``pos_subtype``.
+        Optional per-lemma fields: ``difficulty_level`` (int in the configured
+        range, ``-1`` to exclude, or ``null``/omitted to leave unset) and
+        ``translations`` (mapping of language code to translation text used to
+        seed initial translations).
+
+    A lemma whose ``(lemma_text, pos_type)`` pair already exists is reported
+    with ``status: "already_exists"`` and its existing GUID; it is not
+    modified. The GUID for created lemmas is assigned automatically from the
+    ``pos_type``/``pos_subtype`` prefix.
+    """
+    payload = request.get_json(silent=True) or {}
+    lemmas_raw = payload.get("lemmas")
+    if not isinstance(lemmas_raw, list) or not lemmas_raw:
+        return _build_error_response("lemmas must be a non-empty list")
+    if len(lemmas_raw) > _ADD_LEMMAS_MAX:
+        return _build_error_response(f"lemmas may contain at most {_ADD_LEMMAS_MAX} items")
+
+    results: List[Dict[str, Any]] = []
+    created_count = 0
+    already_exists_count = 0
+
+    for index, item in enumerate(lemmas_raw):
+        if not isinstance(item, dict):
+            return _build_error_response(f"lemmas[{index}] must be an object")
+
+        required_fields: Dict[str, str] = {}
+        for field_name in ("lemma_text", "definition_text", "pos_type", "pos_subtype"):
+            field_value = item.get(field_name)
+            if not isinstance(field_value, str) or not field_value.strip():
+                return _build_error_response(
+                    f"lemmas[{index}].{field_name} is required and must be a non-empty string"
+                )
+            required_fields[field_name] = field_value.strip()
+        lemma_text = required_fields["lemma_text"]
+        definition_text = required_fields["definition_text"]
+        pos_type = required_fields["pos_type"]
+        pos_subtype = required_fields["pos_subtype"]
+
+        difficulty_value = item.get("difficulty_level")
+        if difficulty_value is None:
+            difficulty_level: Optional[int] = None
+        else:
+            try:
+                difficulty_level = int(difficulty_value)
+            except (TypeError, ValueError):
+                return _build_error_response(
+                    f"lemmas[{index}].difficulty_level must be an integer or null"
+                )
+            if difficulty_level != Config.EXCLUDE_DIFFICULTY_LEVEL and (
+                difficulty_level < Config.MIN_DIFFICULTY_LEVEL
+                or difficulty_level > Config.MAX_DIFFICULTY_LEVEL
+            ):
+                return _build_error_response(
+                    f"lemmas[{index}].difficulty_level must be between "
+                    f"{Config.MIN_DIFFICULTY_LEVEL} and {Config.MAX_DIFFICULTY_LEVEL}, "
+                    f"or {Config.EXCLUDE_DIFFICULTY_LEVEL}"
+                )
+
+        translations_raw = item.get("translations")
+        translations: Dict[str, str] = {}
+        if translations_raw is not None:
+            if not isinstance(translations_raw, dict):
+                return _build_error_response(
+                    f"lemmas[{index}].translations must be an object mapping language to text"
+                )
+            for lang_code, translation_text in translations_raw.items():
+                if not isinstance(lang_code, str) or not lang_code.strip():
+                    return _build_error_response(
+                        f"lemmas[{index}].translations has an invalid language code"
+                    )
+                if not isinstance(translation_text, str) or not translation_text.strip():
+                    return _build_error_response(
+                        f"lemmas[{index}].translations[{lang_code}] must be a non-empty string"
+                    )
+                translations[lang_code.strip().lower()] = translation_text.strip()
+
+        existing = (
+            g.db.query(Lemma)
+            .filter(Lemma.lemma_text == lemma_text, Lemma.pos_type == pos_type)
+            .first()
+        )
+        if existing is not None:
+            results.append(
+                {
+                    "lemma_text": lemma_text,
+                    "pos_type": pos_type,
+                    "guid": existing.guid,
+                    "status": "already_exists",
+                }
+            )
+            already_exists_count += 1
+            continue
+
+        try:
+            guid = generate_guid(g.db, pos_type, pos_subtype)
+        except ValueError as exc:
+            return _build_error_response(f"lemmas[{index}]: {exc}")
+
+        new_lemma = Lemma(
+            lemma_text=lemma_text,
+            definition_text=definition_text,
+            pos_type=pos_type,
+            pos_subtype=pos_subtype,
+            guid=guid,
+            difficulty_level=difficulty_level,
+            confidence=0.0,
+            verified=False,
+        )
+        g.db.add(new_lemma)
+        g.db.flush()
+
+        log_translation_change(
+            session=g.db,
+            source=Config.OPERATION_LOG_SOURCE,
+            operation_type="lemma_create",
+            lemma_id=new_lemma.id,
+            field_name="created",
+            old_value=None,
+            new_value=f"{lemma_text} ({pos_type})",
+        )
+
+        seeded_languages: List[str] = []
+        for lang_code, translation_text in translations.items():
+            set_translation(g.db, new_lemma, lang_code, translation_text)
+            log_translation_change(
+                session=g.db,
+                source=Config.OPERATION_LOG_SOURCE,
+                operation_type="translation_add",
+                lemma_id=new_lemma.id,
+                field_name=f"{lang_code}_translation",
+                old_value=None,
+                new_value=translation_text,
+            )
+            seeded_languages.append(lang_code)
+
+        results.append(
+            {
+                "lemma_text": lemma_text,
+                "pos_type": pos_type,
+                "pos_subtype": pos_subtype,
+                "guid": guid,
+                "difficulty_level": _serialize_value(difficulty_level),
+                "translations": sorted(seeded_languages),
+                "status": "created",
+            }
+        )
+        created_count += 1
+
+    g.db.commit()
+
+    return _build_success_response(
+        results,
+        {
+            "total": len(lemmas_raw),
+            "created": created_count,
+            "already_exists": already_exists_count,
+        },
     )
 
 

--- a/src/workqueue/handlers/words/translations.py
+++ b/src/workqueue/handlers/words/translations.py
@@ -21,11 +21,11 @@ from wordfreq.translation.client import LinguisticClient
 from workqueue.tools import workqueue_payload_handler
 
 
-def _build_config() -> DataSourceConfig:
+def _build_config(model: Optional[str] = None) -> DataSourceConfig:
     return DataSourceConfig(
         backend_type=BackendType.SQLITE,
         sqlite_path=Config.DB_PATH,
-        model=constants.DEFAULT_MODEL,
+        model=model or constants.DEFAULT_MODEL,
         debug=Config.DEBUG,
     )
 
@@ -34,6 +34,7 @@ def do_generate_missing_translations(
     session: Any,
     lemma_id: int,
     languages: Optional[List[str]] = None,
+    model: Optional[str] = None,
     **_: Any,
 ) -> str:
     """Generate missing translations for a lemma, optionally constrained to languages."""
@@ -44,8 +45,6 @@ def do_generate_missing_translations(
     requested_languages = languages or list(LANGUAGE_FIELDS.keys())
     missing_languages: List[str] = []
     for language_code in requested_languages:
-        if language_code == "lt":
-            continue
         translation = get_translation(session, lemma, language_code)
         if not translation or not translation.strip():
             missing_languages.append(language_code)
@@ -60,7 +59,7 @@ def do_generate_missing_translations(
         reference_lang_code = "en"
         reference_translation = lemma.lemma_text
 
-    config = _build_config()
+    config = _build_config(model)
     agent = VorasAgent(config=config)
     client = LinguisticClient(
         model=config.model or "",
@@ -200,6 +199,8 @@ def handle_words_translations(
     lemma_id: Optional[int] = None,
     lemma_ids: Optional[List[int]] = None,
     languages: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    **_: Any,
 ) -> str:
     """Workqueue wrapper for missing translation generation."""
     if lemma_ids:
@@ -208,13 +209,16 @@ def handle_words_translations(
                 session=session,
                 lemma_id=queued_lemma_id,
                 languages=languages,
+                model=model,
             )
             for queued_lemma_id in lemma_ids
         ]
         return f"Batch completed for {len(lemma_ids)} lemmas: " + "; ".join(results)
     if lemma_id is None:
         raise ValueError("lemma_id or lemma_ids is required")
-    return do_generate_missing_translations(session=session, lemma_id=lemma_id, languages=languages)
+    return do_generate_missing_translations(
+        session=session, lemma_id=lemma_id, languages=languages, model=model
+    )
 
 
 @workqueue_payload_handler()


### PR DESCRIPTION
Add POST /api/v1/lemmas/add (batch, idempotent) with its api/ facade add_lemmas() so external tools can create lemmas over HTTP; GUIDs are assigned automatically from the pos_type/pos_subtype prefix and an existing (lemma_text, pos_type) is returned as already_exists.

Fix the add-missing-translations worker: handle_words_translations now accepts the model payload key and threads it into the LinguisticClient (previously it crashed with an unexpected 'model' kwarg), and stop skipping Lithuanian so lt can be generated like any other language.