### PR TITLE
Add Barsukas "scholar" persona (golden + API keys + Postgres concepts)

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -100,6 +100,7 @@ class BarsukasFlask(Flask):
     backend_config: DataSourceConfig
     db_session_factory: Callable[[], Session]
     bench_db_session_factory: Optional[Callable[[], Session]]
+    concepts_db_session_factory: Optional[Callable[[], Session]]
 
 
 def create_app(
@@ -189,6 +190,30 @@ def create_app(
         return cast(Session, create_session(backend_config))
 
     app.db_session_factory = session_factory
+    app.concepts_db_session_factory = None
+
+    if os.environ.get("BARSUKAS_CONCEPTS_BACKEND") == "postgres":
+        try:
+            concepts_postgres_url = DataSourceConfig.build_postgres_url()
+        except Exception as concepts_exc:
+            print(f"Error building PostgreSQL URL for concepts: {concepts_exc}", file=sys.stderr)
+            sys.exit(1)
+
+        concepts_backend_config = DataSourceConfig(
+            backend_type=BackendType.POSTGRES,
+            postgres_url=concepts_postgres_url,
+            use_word2vec=use_word2vec,
+        )
+
+        def concepts_session_factory() -> Session:
+            return cast(Session, create_session(concepts_backend_config))
+
+        app.concepts_db_session_factory = concepts_session_factory
+        app.config["CONCEPTS_BACKEND"] = "postgres"
+        app.config["CONCEPTS_WRITABLE"] = True
+    else:
+        app.config["CONCEPTS_BACKEND"] = backend_config.backend_type.value
+        app.config["CONCEPTS_WRITABLE"] = False
     try:
         from sqlalchemy.engine import Engine
 
@@ -381,10 +406,20 @@ def create_app(
             return
 
         g.db = app.db_session_factory()
+        if endpoint_name.startswith("concepts.") and app.concepts_db_session_factory is not None:
+            g.concepts_db = app.concepts_db_session_factory()
 
     @app.teardown_appcontext
     def shutdown_session(exception: Optional[BaseException]) -> None:
         """Clean up database session after request."""
+        concepts_db = g.pop("concepts_db", None)
+        if concepts_db is not None:
+            if exception:
+                concepts_db.rollback()
+            else:
+                concepts_db.commit()
+            concepts_db.close()
+
         db = g.pop("db", None)
         if db is not None:
             if exception:

--- a/src/barsukas/launch.sh
+++ b/src/barsukas/launch.sh
@@ -54,6 +54,7 @@ while [[ $# -gt 0 ]]; do
             echo "  prod   - Production mode: PostgreSQL backend, no local API keys, LLM calls only"
             echo "  golden - Golden mode: Read-only JSONL from data/release"
             echo "  hosted - Hosted mode: Like golden but hardened (no restart, no exports)"
+            echo "  scholar - Scholar mode: Golden JSONL with API keys and PostgreSQL concepts"
             echo "  local  - Local development: SQLite database with full access (default)"
             exit 0
             ;;
@@ -81,6 +82,10 @@ if [[ -n "$PERSONA" ]]; then
             STORAGE_FORMAT="jsonl"
             PERSONA_ARGS="--persona hosted --readonly --no-worker"
             ;;
+        scholar)
+            STORAGE_FORMAT="jsonl"
+            PERSONA_ARGS="--persona scholar --readonly --no-worker"
+            ;;
         local)
             STORAGE_FORMAT="sqlite"
             PERSONA_ARGS="--persona local"
@@ -96,7 +101,7 @@ fi
 # Validate storage format (only if not using postgres and no persona set)
 if [[ -z "$PERSONA" && -z "$USE_POSTGRES" && "$STORAGE_FORMAT" != "jsonl" && "$STORAGE_FORMAT" != "sqlite" ]]; then
     echo "Error: Invalid storage format '$STORAGE_FORMAT'"
-    echo "Usage: $0 [--persona prod|golden|local] [-f|--format jsonl|sqlite] [--postgres] [-a|--all-interfaces] [-p|--port PORT] [--db-path PATH] [--venv PATH]"
+    echo "Usage: $0 [--persona prod|golden|hosted|scholar|local] [-f|--format jsonl|sqlite] [--postgres] [-a|--all-interfaces] [-p|--port PORT] [--db-path PATH] [--venv PATH]"
     exit 1
 fi
 

--- a/src/barsukas/personas.py
+++ b/src/barsukas/personas.py
@@ -22,6 +22,7 @@ class PersonaName(Enum):
     GOLDEN = "golden"
     HOSTED = "hosted"
     LOCAL = "local"
+    SCHOLAR = "scholar"
 
 
 @dataclass
@@ -35,6 +36,7 @@ class PersonaConfig:
     use_postgres: bool = False
     use_jsonl: bool = False
     jsonl_data_dir: Optional[str] = None  # Relative to repo root
+    use_postgres_concepts: bool = False
 
     # Access control
     readonly: bool = False
@@ -82,6 +84,19 @@ PERSONAS: dict[PersonaName, PersonaConfig] = {
         enable_worker=False,
         allow_restart=False,
         allow_exports=False,
+    ),
+    PersonaName.SCHOLAR: PersonaConfig(
+        name=PersonaName.SCHOLAR,
+        description=(
+            "Scholar mode: Golden JSONL data with API keys and writable PostgreSQL concepts"
+        ),
+        use_jsonl=True,
+        jsonl_data_dir="data/release",
+        use_postgres_concepts=True,
+        readonly=True,
+        allow_api_keys=True,
+        allow_outbound_calls=True,
+        enable_worker=False,
     ),
     PersonaName.LOCAL: PersonaConfig(
         name=PersonaName.LOCAL,

--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -10,7 +10,7 @@ may contain ``[[wiki links]]`` to other concepts.
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, cast
 
 import constants
 from flask import (
@@ -38,6 +38,7 @@ from storage.queries.concept import count_concepts, get_backlinks, list_concepts
 
 if TYPE_CHECKING:
     from barsukas.app import BarsukasFlask
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +52,15 @@ def _get_config() -> DataSourceConfig:
 
 
 def _is_readonly() -> bool:
-    """Return True if the server is in read-only mode."""
+    """Return True if concept editing should be disabled."""
+    if bool(current_app.config.get("CONCEPTS_WRITABLE", False)):
+        return False
     return bool(current_app.config.get("READONLY", False))
+
+
+def _concept_session() -> "Session":
+    """Return the session that owns concept reads and writes."""
+    return cast("Session", getattr(g, "concepts_db", g.db))
 
 
 def _outbound_allowed() -> bool:
@@ -94,11 +102,11 @@ def list_concepts_view() -> ResponseReturnValue:
     """List concepts with optional search and verified filter."""
     search = request.args.get("q", "").strip()
     verified_only = request.args.get("verified") == "1"
-    concepts = list_concepts(g.db, search=search, verified_only=verified_only)
+    concepts = list_concepts(_concept_session(), search=search, verified_only=verified_only)
     return render_template(
         "concepts/list.html",
         concepts=concepts,
-        total=count_concepts(g.db),
+        total=count_concepts(_concept_session()),
         search=search,
         verified_only=verified_only,
         readonly=_is_readonly(),
@@ -136,7 +144,7 @@ def create() -> ResponseReturnValue:
         flash("A title is required.", "error")
         return redirect(url_for("concepts.new_concept"))
 
-    if get_concept_by_slug(g.db, title) is not None:
+    if get_concept_by_slug(_concept_session(), title) is not None:
         flash(f"A concept titled {title!r} already exists.", "error")
         return redirect(url_for("concepts.new_concept"))
 
@@ -153,7 +161,7 @@ def create() -> ResponseReturnValue:
         flash("Outbound calls are disabled; saved without a generated body.", "warning")
 
     concept = create_concept(
-        g.db,
+        _concept_session(),
         title=title,
         summary=summary,
         body=body,
@@ -171,15 +179,15 @@ def create() -> ResponseReturnValue:
 @bp.route("/<path:slug>")
 def detail(slug: str) -> ResponseReturnValue:
     """Show a single concept with its rendered body and backlinks."""
-    concept = get_concept_by_slug(g.db, slug)
+    concept = get_concept_by_slug(_concept_session(), slug)
     if concept is None:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
 
-    existing = get_existing_link_targets(g.db, concept.body or "")
+    existing = get_existing_link_targets(_concept_session(), concept.body or "")
     rendered_body = render_concept_body(concept.body or "", existing)
     sources = json.loads(concept.sources) if concept.sources else []
-    backlinks = get_backlinks(g.db, concept.slug)
+    backlinks = get_backlinks(_concept_session(), concept.slug)
 
     return render_template(
         "concepts/detail.html",
@@ -198,7 +206,7 @@ def edit(slug: str) -> ResponseReturnValue:
         flash("Cannot edit concepts in read-only mode", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    concept = get_concept_by_slug(g.db, slug)
+    concept = get_concept_by_slug(_concept_session(), slug)
     if concept is None:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
@@ -221,7 +229,7 @@ def update(slug: str) -> ResponseReturnValue:
         flash("Cannot edit concepts in read-only mode", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    concept = get_concept_by_slug(g.db, slug)
+    concept = get_concept_by_slug(_concept_session(), slug)
     if concept is None:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
@@ -233,12 +241,12 @@ def update(slug: str) -> ResponseReturnValue:
 
     # Guard against renaming onto another existing concept's slug.
     new_slug = normalize_concept_slug(title)
-    if new_slug != concept.slug and get_concept_by_slug(g.db, new_slug) is not None:
+    if new_slug != concept.slug and get_concept_by_slug(_concept_session(), new_slug) is not None:
         flash(f"A concept titled {title!r} already exists.", "error")
         return redirect(url_for("concepts.edit", slug=slug))
 
     updated = update_concept(
-        g.db,
+        _concept_session(),
         concept,
         title=title,
         summary=request.form.get("summary", "").strip(),
@@ -264,7 +272,7 @@ def regenerate(slug: str) -> ResponseReturnValue:
         flash("Outbound calls are disabled; cannot regenerate.", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    concept = get_concept_by_slug(g.db, slug)
+    concept = get_concept_by_slug(_concept_session(), slug)
     if concept is None:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
@@ -278,7 +286,7 @@ def regenerate(slug: str) -> ResponseReturnValue:
         flash(f"Regeneration failed: {exc}", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    update_concept(g.db, concept, body=body, source_model=model)
+    update_concept(_concept_session(), concept, body=body, source_model=model)
     flash("Regenerated concept body.", "success")
     return redirect(url_for("concepts.detail", slug=concept.slug))
 
@@ -290,12 +298,12 @@ def delete(slug: str) -> ResponseReturnValue:
         flash("Cannot delete in read-only mode", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    concept = get_concept_by_slug(g.db, slug)
+    concept = get_concept_by_slug(_concept_session(), slug)
     if concept is None:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
 
     title = concept.title
-    delete_concept(g.db, concept)
+    delete_concept(_concept_session(), concept)
     flash(f"Deleted concept {title!r}.", "success")
     return redirect(url_for("concepts.list_concepts_view"))

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -83,6 +83,7 @@ def run_flask_server(
         app.config["ENABLE_WORKER"] = persona.enable_worker
         app.config["ALLOW_RESTART"] = persona.allow_restart
         app.config["ALLOW_EXPORTS"] = persona.allow_exports
+        app.config["CONCEPTS_WRITABLE"] = persona.use_postgres_concepts
     else:
         # Defaults when no persona specified
         app.config["ALLOW_OUTBOUND_CALLS"] = True
@@ -90,6 +91,7 @@ def run_flask_server(
         app.config["ENABLE_WORKER"] = True
         app.config["ALLOW_RESTART"] = True
         app.config["ALLOW_EXPORTS"] = True
+        app.config["CONCEPTS_WRITABLE"] = False
 
     logger.info(f"Starting Barsukas Flask server on http://{host}:{port}")
     logger.info(f"Database: {app.config['DB_PATH']}")
@@ -139,8 +141,8 @@ def main() -> None:
     parser.add_argument(
         "--persona",
         type=str,
-        choices=["prod", "golden", "hosted", "local"],
-        help="Launch persona (prod, golden, hosted, local) - overrides other backend settings",
+        choices=["prod", "golden", "hosted", "scholar", "local"],
+        help="Launch persona (prod, golden, hosted, scholar, local) - overrides other backend settings",
     )
     parser.add_argument(
         "--list-personas",
@@ -174,6 +176,8 @@ def main() -> None:
             args.no_worker = True
         if persona.use_postgres:
             args.postgres = True
+        if persona.use_postgres_concepts:
+            os.environ["BARSUKAS_CONCEPTS_BACKEND"] = "postgres"
 
     # Safety rule: read-only mode never starts the background worker.
     if args.readonly and not args.no_worker:
@@ -237,6 +241,8 @@ def main() -> None:
         logger.info(f"Task worker will poll every {args.poll_interval}s")
     else:
         logger.info("Task worker DISABLED")
+    if persona and persona.use_postgres_concepts:
+        logger.info("Concepts database: PostgreSQL (writable)")
     if persona and not persona.allow_api_keys:
         logger.info("API keys: DISABLED (no local keys)")
     if persona and not persona.allow_outbound_calls:


### PR DESCRIPTION
### Motivation
- Provide a hybrid Barsukas mode that serves golden JSONL data for most content while allowing API-key-enabled LLM access and writable concept pages backed by PostgreSQL. 
- Avoid switching the entire app to Postgres when only the `concepts` table needs to be writable, keeping the main app on the golden JSONL backend. 
- Make it easy to launch this mode from existing launchers and show UI affordances for API keys and writable concepts. 

### Description
- Add a new persona `scholar` and a `use_postgres_concepts` flag in `PersonaConfig`, and advertise the new persona in `src/barsukas/launch.sh` and the unified launcher choices. 
- Wire persona semantics into `unified_app.py` so selecting `scholar` sets `BARSUKAS_CONCEPTS_BACKEND=postgres` and logs that concepts are writable. 
- Extend the Flask app (`src/barsukas/app.py`) with `concepts_db_session_factory` that builds a separate `DataSourceConfig` for a Postgres concepts backend and expose `CONCEPTS_WRITABLE`/`CONCEPTS_BACKEND` app config values. 
- Open/close a dedicated concepts DB session only for `concepts.*` endpoints and update `src/barsukas/routes/concepts.py` to use `_concept_session()` for all concept reads/writes and to respect `CONCEPTS_WRITABLE` (allowing editing even when the rest of the app is read-only). 

### Testing
- Ran formatting: `PYTHONPATH=src black src/barsukas/personas.py src/barsukas/unified_app.py src/barsukas/app.py src/barsukas/routes/concepts.py`, which completed successfully. 
- Ran static typing: `PYTHONPATH=src mypy src/barsukas/personas.py src/barsukas/unified_app.py src/barsukas/app.py src/barsukas/routes/concepts.py`, which reported no issues. 
- Verified persona listing with the unified launcher: `PYTHONPATH=src python src/barsukas/unified_app.py --list-personas`, which shows `scholar`. 
- Verified shell launcher listing: `bash src/barsukas/launch.sh --list-personas`, which shows `scholar` in the usage/help output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a380a74ba9c832798b573345e272cbf)