### PR TITLE
Fix Wikidata concept seeding workflow

### DIFF
--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -145,7 +145,15 @@ def wikidata_preview() -> ResponseReturnValue:
     seed = fetch_wikidata_concept_seed(qid)
     if seed is None:
         return jsonify({"found": False, "qid": qid})
-    return jsonify({"found": True, "qid": seed.qid, "title": seed.title, "summary": seed.summary})
+    return jsonify(
+        {
+            "found": True,
+            "qid": seed.qid,
+            "title": seed.title,
+            "summary": seed.summary,
+            "sources": seed.sources,
+        }
+    )
 
 
 @bp.route("/create", methods=["POST"])

--- a/src/barsukas/static/js/concept_form.js
+++ b/src/barsukas/static/js/concept_form.js
@@ -1,7 +1,11 @@
 (function () {
+    const form = document.getElementById('concept-form');
     const qidInput = document.getElementById('wikidata_qid');
+    const titleInput = document.getElementById('title');
+    const summaryInput = document.getElementById('summary');
+    const sourcesInput = document.getElementById('sources');
     const preview = document.getElementById('wikidata-preview');
-    if (!qidInput || !preview) {
+    if (!form || !qidInput || !titleInput || !summaryInput || !sourcesInput || !preview) {
         return;
     }
 
@@ -14,6 +18,51 @@
         preview.textContent = message;
         preview.className = className;
     }
+
+    function sourceUrls(sources) {
+        if (!Array.isArray(sources)) {
+            return [];
+        }
+        return sources.map(function (source) {
+            return source.url || '';
+        }).filter(function (url) {
+            return url.length > 0;
+        });
+    }
+
+    function mergeSourceUrls(existingText, sources) {
+        const existingUrls = existingText.split('\n').map(function (line) {
+            return line.trim();
+        }).filter(function (line) {
+            return line.length > 0;
+        });
+        const seenUrls = new Set(existingUrls);
+        sourceUrls(sources).forEach(function (url) {
+            if (!seenUrls.has(url)) {
+                existingUrls.push(url);
+                seenUrls.add(url);
+            }
+        });
+        return existingUrls.join('\n');
+    }
+
+    function hydrateFields(data) {
+        if (!titleInput.value.trim()) {
+            titleInput.value = data.title || '';
+        }
+        if (!summaryInput.value.trim()) {
+            summaryInput.value = data.summary || '';
+        }
+        sourcesInput.value = mergeSourceUrls(sourcesInput.value, data.sources || []);
+    }
+
+    qidInput.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            qidInput.dispatchEvent(new Event('input'));
+            setPreview('Looking up this Q-id; review the populated fields, then click Create & generate.', 'form-text text-muted');
+        }
+    });
 
     qidInput.addEventListener('input', function () {
         const qid = qidInput.value.trim().toUpperCase();
@@ -51,8 +100,9 @@
                         return;
                     }
                     if (data.found) {
+                        hydrateFields(data);
                         setPreview(
-                            'Wikidata match: ' + data.title + (data.summary ? ' — ' + data.summary : ''),
+                            'Wikidata match: ' + data.title + (data.summary ? ' — ' + data.summary : '') + '. Review the fields, then click Create & generate.',
                             'form-text text-success'
                         );
                     } else {
@@ -61,7 +111,7 @@
                 })
                 .catch(function () {
                     if (qidInput.value.trim().toUpperCase() === qid) {
-                        setPreview('Could not preview ' + qid + '; creation can still try resolving it.', 'form-text text-warning');
+                        setPreview('Could not preview ' + qid + '; creation can still try resolving it after you click Create & generate.', 'form-text text-warning');
                     }
                 });
         }, 600);

--- a/src/barsukas/templates/concepts/form.html
+++ b/src/barsukas/templates/concepts/form.html
@@ -28,7 +28,7 @@
 </div>
 {% endif %}
 
-<form method="post"
+<form id="concept-form" method="post"
       action="{{ url_for('concepts.update', slug=concept.slug) if concept else url_for('concepts.create') }}">
     <div class="row">
         <div class="col-lg-8">
@@ -38,7 +38,7 @@
                 <input type="text" class="form-control" id="wikidata_qid" name="wikidata_qid"
                        placeholder="e.g. Q42"
                        data-preview-url="{{ url_for('concepts.wikidata_preview') }}">
-                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title, summary, and default sources are filled from Wikidata/Wikipedia.</div>
+                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title, summary, and default sources are previewed and filled from Wikidata/Wikipedia. Pressing Return in this field previews data but does not create the page.</div>
             </div>
             {% endif %}
 

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import requests
 
@@ -21,6 +21,61 @@ WIKISOURCE_SEARCH_URL = "https://en.wikisource.org/w/api.php"
 DEFAULT_TIMEOUT_SECONDS = 10
 MAX_SOURCE_TEXT_CHARS = 12000
 WIKIPEDIA_LEAD_THRESHOLD_CHARS = 10_000
+EB1911_MAX_PARAGRAPHS = 10
+EB1911_MAX_WORDS = 1200
+
+
+def _word_count(text: str) -> int:
+    """Return a simple whitespace-delimited word count."""
+    return len(text.split())
+
+
+def _limit_eb1911_extract(extract: str) -> tuple[str, bool]:
+    """Return an EB1911 extract limited to an intro-sized excerpt when needed."""
+    paragraphs = [
+        paragraph.strip() for paragraph in re.split(r"\n\s*\n", extract) if paragraph.strip()
+    ]
+    if len(paragraphs) <= EB1911_MAX_PARAGRAPHS and _word_count(extract) <= EB1911_MAX_WORDS:
+        return extract, False
+
+    selected_paragraphs: List[str] = []
+    selected_words = 0
+    for paragraph in paragraphs:
+        paragraph_words = _word_count(paragraph)
+        if selected_paragraphs and (
+            len(selected_paragraphs) >= EB1911_MAX_PARAGRAPHS
+            or selected_words + paragraph_words > EB1911_MAX_WORDS
+        ):
+            break
+        selected_paragraphs.append(paragraph)
+        selected_words += paragraph_words
+        if len(selected_paragraphs) >= EB1911_MAX_PARAGRAPHS or selected_words >= EB1911_MAX_WORDS:
+            break
+
+    if not selected_paragraphs:
+        return " ".join(extract.split()[:EB1911_MAX_WORDS]), True
+    return "\n\n".join(selected_paragraphs), True
+
+
+def _eb1911_search_titles(title: str, label: str = "") -> List[str]:
+    """Return likely EB1911 page-title candidates for a Wikidata concept."""
+    candidates: List[str] = []
+    for raw_title in (title, label):
+        clean_title = raw_title.strip()
+        if not clean_title:
+            continue
+        candidates.append(clean_title)
+        parts = clean_title.split()
+        if len(parts) == 2:
+            candidates.append(f"{parts[1]}, {parts[0]}")
+    deduped: List[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        normalized = candidate.casefold()
+        if normalized not in seen:
+            deduped.append(candidate)
+            seen.add(normalized)
+    return deduped
 
 
 @dataclass(frozen=True)
@@ -120,22 +175,44 @@ def _fetch_wikipedia_source(page_title: str) -> Optional[Dict[str, Any]]:
     }
 
 
-def _fetch_eb1911_source(title: str) -> Optional[Dict[str, Any]]:
+def _search_eb1911_page_title(candidates: Sequence[str]) -> Optional[str]:
+    """Return the first Wikisource EB1911 page title matching any candidate."""
+    for candidate in candidates:
+        search_title = f"1911 Encyclopædia Britannica/{candidate}"
+        params = {
+            "action": "query",
+            "list": "search",
+            "srsearch": f'intitle:"{search_title}"',
+            "srlimit": "1",
+            "format": "json",
+        }
+        search_payload = _get_json(WIKISOURCE_SEARCH_URL, params=params)
+        results = (search_payload or {}).get("query", {}).get("search", [])
+        if results:
+            page_title = str(results[0].get("title", "")).strip()
+            if page_title:
+                return page_title
+
+        params = {
+            "action": "query",
+            "list": "search",
+            "srsearch": f'"1911 Encyclopædia Britannica/{candidate}"',
+            "srlimit": "1",
+            "format": "json",
+        }
+        search_payload = _get_json(WIKISOURCE_SEARCH_URL, params=params)
+        results = (search_payload or {}).get("query", {}).get("search", [])
+        if results:
+            page_title = str(results[0].get("title", "")).strip()
+            if page_title:
+                return page_title
+    return None
+
+
+def _fetch_eb1911_source(title: str, label: str = "") -> Optional[Dict[str, Any]]:
     """Try to find an EB1911 Wikisource page for the topic and return its extract."""
-    search_title = f"1911 Encyclopædia Britannica/{title}"
-    params = {
-        "action": "query",
-        "list": "search",
-        "srsearch": f'intitle:"{search_title}"',
-        "srlimit": "1",
-        "format": "json",
-    }
-    search_payload = _get_json(WIKISOURCE_SEARCH_URL, params=params)
-    results = (search_payload or {}).get("query", {}).get("search", [])
-    if not results:
-        return None
-    page_title = str(results[0].get("title", "")).strip()
-    if not page_title:
+    page_title = _search_eb1911_page_title(_eb1911_search_titles(title, label))
+    if page_title is None:
         return None
     params = {
         "action": "query",
@@ -153,10 +230,14 @@ def _fetch_eb1911_source(title: str) -> Optional[Dict[str, Any]]:
     extract = str(pages[0].get("extract", "")).strip()
     if not extract:
         return None
+    extract, intro_only = _limit_eb1911_extract(extract)
+    note = "1911 Encyclopædia Britannica text from Wikisource."
+    if intro_only:
+        note = "1911 Encyclopædia Britannica intro excerpt from Wikisource; full page exceeded the concept-generation size limit."
     return {
         "url": f"https://en.wikisource.org/wiki/{page_title.replace(' ', '_')}",
         "title": f"EB1911: {title}",
-        "note": "1911 Encyclopædia Britannica text from Wikisource, truncated for concept generation.",
+        "note": note,
         "text": extract[:MAX_SOURCE_TEXT_CHARS],
     }
 
@@ -199,7 +280,7 @@ def fetch_wikidata_concept_seed(raw_qid: str) -> Optional[WikidataConceptSeed]:
         wikipedia_source = _fetch_wikipedia_source(enwiki_title)
         if wikipedia_source is not None:
             sources.append(wikipedia_source)
-    eb1911_source = _fetch_eb1911_source(title)
+    eb1911_source = _fetch_eb1911_source(title, label)
     if eb1911_source is not None:
         sources.append(eb1911_source)
 

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -23,6 +23,7 @@ MAX_SOURCE_TEXT_CHARS = 12000
 WIKIPEDIA_LEAD_THRESHOLD_CHARS = 10_000
 EB1911_MAX_PARAGRAPHS = 10
 EB1911_MAX_WORDS = 1200
+EB1911_WIKIDATA_QID = "Q867541"
 
 
 def _word_count(text: str) -> int:
@@ -115,6 +116,30 @@ def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[
     return None
 
 
+def _extract_entity_qid(snak: Dict[str, Any]) -> Optional[str]:
+    """Extract a Wikidata entity Q-id from a claim snak."""
+    data_value = snak.get("datavalue", {})
+    value = data_value.get("value", {})
+    if not isinstance(value, dict):
+        return None
+    raw_id = value.get("id")
+    if isinstance(raw_id, str):
+        return normalize_qid(raw_id)
+    numeric_id = value.get("numeric-id")
+    if isinstance(numeric_id, int):
+        return normalize_qid(f"Q{numeric_id}")
+    return None
+
+
+def _fetch_wikidata_entity(qid: str) -> Optional[Dict[str, Any]]:
+    """Fetch a single Wikidata entity JSON object."""
+    payload = _get_json(WIKIDATA_ENTITY_URL.format(qid=qid))
+    entity = (payload or {}).get("entities", {}).get(qid)
+    if isinstance(entity, dict):
+        return entity
+    return None
+
+
 def _extract_english_value(values: Dict[str, Dict[str, str]]) -> str:
     """Extract an English Wikidata label/description value."""
     english = values.get("en", {})
@@ -175,6 +200,39 @@ def _fetch_wikipedia_source(page_title: str) -> Optional[Dict[str, Any]]:
     }
 
 
+def _extract_eb1911_page_qids(entity: Dict[str, Any]) -> List[str]:
+    """Extract EB1911 article item Q-ids from Wikidata P1343/P805 claims."""
+    page_qids: List[str] = []
+    seen_qids: set[str] = set()
+    for claim in entity.get("claims", {}).get("P1343", []):
+        if not isinstance(claim, dict):
+            continue
+        mainsnak = claim.get("mainsnak", {})
+        if not isinstance(mainsnak, dict):
+            continue
+        if _extract_entity_qid(mainsnak) != EB1911_WIKIDATA_QID:
+            continue
+        qualifiers = claim.get("qualifiers", {})
+        if not isinstance(qualifiers, dict):
+            continue
+        for qualifier in qualifiers.get("P805", []):
+            if not isinstance(qualifier, dict):
+                continue
+            page_qid = _extract_entity_qid(qualifier)
+            if page_qid is not None and page_qid not in seen_qids:
+                page_qids.append(page_qid)
+                seen_qids.add(page_qid)
+    return page_qids
+
+
+def _extract_wikisource_title(entity: Dict[str, Any]) -> str:
+    """Extract an English Wikisource title from a Wikidata entity."""
+    sitelinks = entity.get("sitelinks", {})
+    if not isinstance(sitelinks, dict):
+        return ""
+    return str(sitelinks.get("enwikisource", {}).get("title", "")).strip()
+
+
 def _search_eb1911_page_title(candidates: Sequence[str]) -> Optional[str]:
     """Return the first Wikisource EB1911 page title matching any candidate."""
     for candidate in candidates:
@@ -209,9 +267,21 @@ def _search_eb1911_page_title(candidates: Sequence[str]) -> Optional[str]:
     return None
 
 
-def _fetch_eb1911_source(title: str, label: str = "") -> Optional[Dict[str, Any]]:
+def _fetch_eb1911_source(
+    title: str, label: str = "", entity: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
     """Try to find an EB1911 Wikisource page for the topic and return its extract."""
-    page_title = _search_eb1911_page_title(_eb1911_search_titles(title, label))
+    page_title = None
+    if entity is not None:
+        for page_qid in _extract_eb1911_page_qids(entity):
+            page_entity = _fetch_wikidata_entity(page_qid)
+            if page_entity is None:
+                continue
+            page_title = _extract_wikisource_title(page_entity)
+            if page_title:
+                break
+    if page_title is None or not page_title:
+        page_title = _search_eb1911_page_title(_eb1911_search_titles(title, label))
     if page_title is None:
         return None
     params = {
@@ -248,9 +318,8 @@ def fetch_wikidata_concept_seed(raw_qid: str) -> Optional[WikidataConceptSeed]:
     if qid is None:
         return None
 
-    payload = _get_json(WIKIDATA_ENTITY_URL.format(qid=qid))
-    entity = (payload or {}).get("entities", {}).get(qid)
-    if not isinstance(entity, dict):
+    entity = _fetch_wikidata_entity(qid)
+    if entity is None:
         return None
 
     label = _extract_english_value(entity.get("labels", {}))
@@ -280,7 +349,7 @@ def fetch_wikidata_concept_seed(raw_qid: str) -> Optional[WikidataConceptSeed]:
         wikipedia_source = _fetch_wikipedia_source(enwiki_title)
         if wikipedia_source is not None:
             sources.append(wikipedia_source)
-    eb1911_source = _fetch_eb1911_source(title, label)
+    eb1911_source = _fetch_eb1911_source(title, label, entity)
     if eb1911_source is not None:
         sources.append(eb1911_source)
 

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -7,7 +7,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from storage.crud.concept import create_concept, get_wikidata_index, link_wikidata_concept
 from storage.models.concept import Base
-from storage.wikidata import _fetch_wikipedia_source, fetch_wikidata_concept_seed, normalize_qid
+from storage.wikidata import (
+    _eb1911_search_titles,
+    _fetch_wikipedia_source,
+    _limit_eb1911_extract,
+    fetch_wikidata_concept_seed,
+    normalize_qid,
+)
 
 
 def test_normalize_qid_accepts_canonical_ids() -> None:
@@ -49,6 +55,19 @@ def test_wikipedia_source_uses_lead_for_long_articles(monkeypatch) -> None:  # t
     assert source["text"] == "Lead section only"
     assert "lead section" in source["note"]
     assert calls == [False, True]
+
+
+def test_eb1911_search_titles_include_last_first_variant() -> None:
+    assert _eb1911_search_titles("Abraham Lincoln") == ["Abraham Lincoln", "Lincoln, Abraham"]
+
+
+def test_eb1911_extract_uses_intro_for_long_pages() -> None:
+    paragraphs = [f"Paragraph {index} text." for index in range(12)]
+
+    extract, intro_only = _limit_eb1911_extract("\n\n".join(paragraphs))
+
+    assert intro_only is True
+    assert extract == "\n\n".join(paragraphs[:10])
 
 
 def test_fetch_wikidata_seed_builds_sources_from_mocked_apis(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -9,6 +9,8 @@ from storage.crud.concept import create_concept, get_wikidata_index, link_wikida
 from storage.models.concept import Base
 from storage.wikidata import (
     _eb1911_search_titles,
+    _extract_eb1911_page_qids,
+    _fetch_eb1911_source,
     _fetch_wikipedia_source,
     _limit_eb1911_extract,
     fetch_wikidata_concept_seed,
@@ -68,6 +70,77 @@ def test_eb1911_extract_uses_intro_for_long_pages() -> None:
 
     assert intro_only is True
     assert extract == "\n\n".join(paragraphs[:10])
+
+
+def test_eb1911_page_qids_use_p1343_p805_claims() -> None:
+    entity = {
+        "claims": {
+            "P1343": [
+                {
+                    "mainsnak": {
+                        "datavalue": {"value": {"id": "Q867541"}},
+                    },
+                    "qualifiers": {
+                        "P805": [
+                            {"datavalue": {"value": {"id": "Q64437865"}}},
+                        ]
+                    },
+                },
+                {
+                    "mainsnak": {
+                        "datavalue": {"value": {"id": "Q123"}},
+                    },
+                    "qualifiers": {
+                        "P805": [
+                            {"datavalue": {"value": {"id": "Q999"}}},
+                        ]
+                    },
+                },
+            ]
+        }
+    }
+
+    assert _extract_eb1911_page_qids(entity) == ["Q64437865"]
+
+
+def test_eb1911_source_prefers_wikidata_p805_wikisource_page(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    entity = {
+        "claims": {
+            "P1343": [
+                {
+                    "mainsnak": {"datavalue": {"value": {"id": "Q867541"}}},
+                    "qualifiers": {"P805": [{"datavalue": {"value": {"id": "Q64437865"}}}]},
+                }
+            ]
+        }
+    }
+
+    def fake_fetch_entity(qid: str) -> Optional[Dict[str, Any]]:
+        assert qid == "Q64437865"
+        return {
+            "sitelinks": {
+                "enwikisource": {"title": "1911 Encyclopædia Britannica/Lincoln, Abraham"}
+            }
+        }
+
+    def fake_get_json(
+        url: str, *, params: Optional[Dict[str, str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        assert params is not None
+        assert params.get("titles") == "1911 Encyclopædia Britannica/Lincoln, Abraham"
+        return {"query": {"pages": [{"extract": "Lincoln EB1911 text"}]}}
+
+    monkeypatch.setattr("storage.wikidata._fetch_wikidata_entity", fake_fetch_entity)
+    monkeypatch.setattr("storage.wikidata._get_json", fake_get_json)
+
+    source = _fetch_eb1911_source("Abraham Lincoln", entity=entity)
+
+    assert source is not None
+    assert (
+        source["url"]
+        == "https://en.wikisource.org/wiki/1911_Encyclopædia_Britannica/Lincoln,_Abraham"
+    )
+    assert source["text"] == "Lincoln EB1911 text"
 
 
 def test_fetch_wikidata_seed_builds_sources_from_mocked_apis(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
### Motivation
- Prevent accidental form submission when users press Return in the Wikidata Q-id field so the Q-id can be previewed and the user can confirm populated fields before creating a page. 
- Populate more form fields (title, summary, sources) from the Wikidata preview so concept creation requires less manual copying. 
- Ensure EB1911 (1911 Encyclopædia Britannica) content is discovered more reliably and limited to an intro excerpt when long pages would flood the concept generator.

### Description
- Add an `id="concept-form"` to the create form and update the preview help text to clarify that Return previews data rather than submitting the form in `src/barsukas/templates/concepts/form.html`.
- Extend the preview route to return seed `sources` in `src/barsukas/routes/concepts.py` so the client can hydrate more fields from the Q-id lookup.
- Replace `src/barsukas/static/js/concept_form.js` with logic to prevent Enter from submitting, debounce lookups, populate `title`, `summary`, and merge source URLs into the `sources` textarea, and update preview messages to guide the user to click `Create & generate` after review.
- Improve EB1911 lookup in `src/storage/wikidata.py` by generating candidate titles (including last-name-first variants), searching those candidates, and truncating long EB1911 extracts to an intro-sized excerpt (defaults: 10 paragraphs or ~1200 words) with a note explaining truncation.
- Add regression tests for EB1911 candidate generation and intro-size limiting in `src/tests/storage/test_wikidata_concepts.py`.

### Testing
- Ran `PYTHONPATH=src pytest src/tests/storage/test_wikidata_concepts.py` and all tests passed (`7 passed`).
- Ran `PYTHONPATH=src mypy src/storage/wikidata.py src/barsukas/routes/concepts.py src/tests/storage/test_wikidata_concepts.py` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3811032d7c832794ec44f95558cde4)