### PR TITLE
Use BeautifulSoup for HTML extraction; enhance Wikidata seeding, sources handling, and regenerate UX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "prometheus_client>=0.19.0",
     "psutil>=5.9.0",
     "markdown>=3.3.0",
+    "beautifulsoup4>=4.12.0",
     "simplejson>=3.17.0",
     "pypinyin>=0.53.0",
     "jieba>=0.42.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ psutil>=5.9.0
 
 # For HTML/report generation
 markdown>=3.3.0
+beautifulsoup4>=4.12.0
 
 # For JSON processing
 simplejson>=3.17.0

--- a/src/agents/vovere.py
+++ b/src/agents/vovere.py
@@ -27,7 +27,6 @@ import logging
 import sys
 import urllib.error
 import urllib.request
-from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -56,42 +55,36 @@ FETCH_TIMEOUT_SECONDS: int = 20
 DEFAULT_USER_AGENT: str = "Greenland-Vovere/1.0 (concept entry generator)"
 
 
-class _TextExtractor(HTMLParser):
-    """Minimal HTML-to-text extractor that skips script/style content."""
-
-    _SKIP_TAGS = {"script", "style", "noscript", "head"}
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._chunks: List[str] = []
-        self._skip_depth = 0
-
-    def handle_starttag(self, tag: str, attrs: List[Any]) -> None:
-        if tag in self._SKIP_TAGS:
-            self._skip_depth += 1
-
-    def handle_endtag(self, tag: str) -> None:
-        if tag in self._SKIP_TAGS and self._skip_depth > 0:
-            self._skip_depth -= 1
-
-    def handle_data(self, data: str) -> None:
-        if self._skip_depth == 0:
-            text = data.strip()
-            if text:
-                self._chunks.append(text)
-
-    def get_text(self) -> str:
-        return " ".join(self._chunks)
-
-
 def html_to_text(html: str) -> str:
-    """Strip HTML to readable text, dropping script/style content."""
-    parser = _TextExtractor()
-    try:
-        parser.feed(html)
-    except Exception as error:  # malformed HTML should not crash generation
-        logger.warning(f"HTML parse error, using partial text: {error}")
-    return parser.get_text()
+    """Strip HTML to readable text, dropping navigation and other page chrome."""
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(html, "html.parser")
+    for selector in (
+        "script",
+        "style",
+        "noscript",
+        "head",
+        "nav",
+        "header",
+        "footer",
+        "aside",
+        "form",
+        "button",
+        "menu",
+        "[role='navigation']",
+        "[aria-hidden='true']",
+        ".mw-editsection",
+        ".navbox",
+        ".metadata",
+        ".reference",
+        ".reflist",
+        ".sidebar",
+        ".toc",
+    ):
+        for element in soup.select(selector):
+            element.decompose()
+    return cast(str, soup.get_text(" ", strip=True))
 
 
 class VovereAgent:

--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -76,6 +76,27 @@ def _outbound_allowed() -> bool:
     return bool(current_app.config.get("ALLOW_OUTBOUND_CALLS", True))
 
 
+def _source_key(source: Dict[str, Any]) -> str:
+    """Return a stable de-duplication key for a source dict."""
+    return str(source.get("url", "")).strip().rstrip("/").casefold()
+
+
+def _merge_sources(*source_lists: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge source lists by URL, preserving first occurrence order."""
+    merged_sources: List[Dict[str, Any]] = []
+    seen_sources: set[str] = set()
+    for source_list in source_lists:
+        for source in source_list:
+            source_key = _source_key(source)
+            if not source_key or source_key in seen_sources:
+                continue
+            merged_sources.append(source)
+            seen_sources.add(source_key)
+            if len(merged_sources) >= MAX_CONCEPT_SOURCES:
+                return merged_sources
+    return merged_sources
+
+
 def _parse_sources_form(raw: str) -> List[Dict[str, Any]]:
     """Parse the sources textarea (one URL per line) into source dicts.
 
@@ -90,7 +111,22 @@ def _parse_sources_form(raw: str) -> List[Dict[str, Any]]:
         url = line.strip()
         if url:
             sources.append({"url": url})
-    return sources[:MAX_CONCEPT_SOURCES]
+    return _merge_sources(sources)
+
+
+def _concept_sources(concept: Any) -> List[Dict[str, Any]]:
+    """Return parsed concept sources."""
+    if not concept.sources:
+        return []
+    parsed_sources = json.loads(concept.sources)
+    if isinstance(parsed_sources, list):
+        return [source for source in parsed_sources if isinstance(source, dict)]
+    return []
+
+
+def _source_urls_text(sources: List[Dict[str, Any]]) -> str:
+    """Render source URLs for the textarea editor."""
+    return "\n".join(str(source.get("url", "")) for source in sources)
 
 
 def _generate_body(title: str, summary: str, sources: List[Dict[str, Any]], model: str) -> str:
@@ -142,7 +178,8 @@ def wikidata_preview() -> ResponseReturnValue:
     qid = normalize_qid(request.args.get("qid", ""))
     if qid is None:
         return jsonify({"found": False, "error": "invalid_qid"}), 400
-    seed = fetch_wikidata_concept_seed(qid)
+    include_regional_wikis = request.args.get("include_regional_wikis") == "1"
+    seed = fetch_wikidata_concept_seed(qid, include_regional_wikis=include_regional_wikis)
     if seed is None:
         return jsonify({"found": False, "qid": qid})
     return jsonify(
@@ -182,13 +219,16 @@ def create() -> ResponseReturnValue:
                 "error",
             )
             return redirect(url_for("concepts.detail", slug=existing_index.concept.slug))
-        seed = fetch_wikidata_concept_seed(wikidata_qid)
+        include_regional_wikis = request.form.get("include_regional_wikis") == "1"
+        seed = fetch_wikidata_concept_seed(
+            wikidata_qid, include_regional_wikis=include_regional_wikis
+        )
         if seed is None:
             flash(f"Could not resolve Wikidata ID {wikidata_qid}.", "error")
             return redirect(url_for("concepts.new_concept"))
         title = title or seed.title
         summary = summary or seed.summary
-        sources = (sources + seed.sources)[:MAX_CONCEPT_SOURCES]
+        sources = _merge_sources(sources, seed.sources)
 
     if not title:
         flash("A title or Wikidata Q-id is required.", "error")
@@ -239,7 +279,7 @@ def detail(slug: str) -> ResponseReturnValue:
 
     existing = get_existing_link_targets(_concept_session(), concept.body or "")
     rendered_body = render_concept_body(concept.body or "", existing)
-    sources = json.loads(concept.sources) if concept.sources else []
+    sources = _concept_sources(concept)
     backlinks = get_backlinks(_concept_session(), concept.slug)
     wikidata_links = (
         _concept_session()
@@ -271,11 +311,11 @@ def edit(slug: str) -> ResponseReturnValue:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
 
-    sources = json.loads(concept.sources) if concept.sources else []
+    sources = _concept_sources(concept)
     return render_template(
         "concepts/form.html",
         concept=concept,
-        sources_text="\n".join(str(s.get("url", "")) for s in sources),
+        sources_text=_source_urls_text(sources),
         default_model=constants.DEFAULT_MODEL,
         max_sources=MAX_CONCEPT_SOURCES,
         outbound_allowed=_outbound_allowed(),
@@ -322,9 +362,9 @@ def update(slug: str) -> ResponseReturnValue:
     return redirect(url_for("concepts.detail", slug=updated.slug))
 
 
-@bp.route("/<path:slug>/regenerate", methods=["POST"])
+@bp.route("/<path:slug>/regenerate", methods=["GET", "POST"])
 def regenerate(slug: str) -> ResponseReturnValue:
-    """Regenerate the body from the stored sources and one-sentence summary."""
+    """Review sources, then regenerate the body after explicit confirmation."""
     if _is_readonly():
         flash("Cannot regenerate in read-only mode", "error")
         return redirect(url_for("concepts.detail", slug=slug))
@@ -337,8 +377,29 @@ def regenerate(slug: str) -> ResponseReturnValue:
         flash(f"No concept found for {slug!r}.", "error")
         return redirect(url_for("concepts.list_concepts_view"))
 
+    sources = _concept_sources(concept)
+    sources_text = _source_urls_text(sources)
+    if request.method == "GET":
+        return render_template(
+            "concepts/regenerate.html",
+            concept=concept,
+            sources_text=sources_text,
+            default_model=constants.DEFAULT_MODEL,
+            max_sources=MAX_CONCEPT_SOURCES,
+        )
+
+    if request.form.get("confirm_regenerate") != "1":
+        flash("Please confirm the LLM cost before regenerating.", "error")
+        return render_template(
+            "concepts/regenerate.html",
+            concept=concept,
+            sources_text=request.form.get("sources", sources_text),
+            default_model=request.form.get("model", "").strip() or constants.DEFAULT_MODEL,
+            max_sources=MAX_CONCEPT_SOURCES,
+        )
+
     model = request.form.get("model", "").strip() or constants.DEFAULT_MODEL
-    sources = json.loads(concept.sources) if concept.sources else []
+    sources = _parse_sources_form(request.form.get("sources", ""))
     try:
         body = _generate_body(concept.title, concept.summary or "", sources, model)
     except Exception as exc:
@@ -346,7 +407,7 @@ def regenerate(slug: str) -> ResponseReturnValue:
         flash(f"Regeneration failed: {exc}", "error")
         return redirect(url_for("concepts.detail", slug=slug))
 
-    update_concept(_concept_session(), concept, body=body, source_model=model)
+    update_concept(_concept_session(), concept, body=body, sources=sources, source_model=model)
     flash("Regenerated concept body.", "success")
     return redirect(url_for("concepts.detail", slug=concept.slug))
 

--- a/src/barsukas/static/js/concept_form.js
+++ b/src/barsukas/static/js/concept_form.js
@@ -5,6 +5,7 @@
     const summaryInput = document.getElementById('summary');
     const sourcesInput = document.getElementById('sources');
     const preview = document.getElementById('wikidata-preview');
+    const includeRegionalWikisInput = document.getElementById('include_regional_wikis');
     if (!form || !qidInput || !titleInput || !summaryInput || !sourcesInput || !preview) {
         return;
     }
@@ -64,6 +65,13 @@
         }
     });
 
+    if (includeRegionalWikisInput) {
+        includeRegionalWikisInput.addEventListener('change', function () {
+            lastRequestedQid = '';
+            qidInput.dispatchEvent(new Event('input'));
+        });
+    }
+
     qidInput.addEventListener('input', function () {
         const qid = qidInput.value.trim().toUpperCase();
         window.clearTimeout(debounceHandle);
@@ -86,7 +94,8 @@
             lastRequestedQid = qid;
             setPreview('Looking up ' + qid + '…', 'form-text text-muted');
 
-            fetch(previewUrl + '?qid=' + encodeURIComponent(qid), {
+            const regionalParam = includeRegionalWikisInput && includeRegionalWikisInput.checked ? '&include_regional_wikis=1' : '';
+            fetch(previewUrl + '?qid=' + encodeURIComponent(qid) + regionalParam, {
                 headers: {Accept: 'application/json'},
             })
                 .then(function (response) {

--- a/src/barsukas/templates/concepts/detail.html
+++ b/src/barsukas/templates/concepts/detail.html
@@ -78,12 +78,11 @@
         {% if not readonly %}
         <div class="card">
             <div class="card-body">
-                <form method="post" action="{{ url_for('concepts.regenerate', slug=concept.slug) }}" class="mb-2">
-                    <button type="submit" class="btn btn-outline-secondary w-100"
-                            {{ 'disabled' if not sources }}>
-                        <i class="bi bi-arrow-clockwise"></i> Regenerate from sources
-                    </button>
-                </form>
+                <a class="btn btn-outline-secondary w-100 mb-2 {{ 'disabled' if not sources }}"
+                   href="{{ url_for('concepts.regenerate', slug=concept.slug) }}"
+                   {% if not sources %}aria-disabled="true" tabindex="-1"{% endif %}>
+                    <i class="bi bi-arrow-clockwise"></i> Regenerate from references
+                </a>
                 <form method="post" action="{{ url_for('concepts.delete', slug=concept.slug) }}"
                       onsubmit="return confirm('Delete this concept?');">
                     <button type="submit" class="btn btn-outline-danger w-100">

--- a/src/barsukas/templates/concepts/form.html
+++ b/src/barsukas/templates/concepts/form.html
@@ -15,7 +15,7 @@
         <h1><i class="bi bi-plus-lg"></i> Create Page</h1>
         <p class="text-muted">
             Provide either a Wikidata Q-id or a title, then add any optional description and sources.
-            If a Q-id is provided, Wikipedia and EB1911 sources are added automatically when available.
+            If a Q-id is provided, the title/description are resolved from Wikidata and Wikipedia/EB1911 text sources are added automatically when available.
         </p>
         {% endif %}
     </div>
@@ -38,7 +38,7 @@
                 <input type="text" class="form-control" id="wikidata_qid" name="wikidata_qid"
                        placeholder="e.g. Q42"
                        data-preview-url="{{ url_for('concepts.wikidata_preview') }}">
-                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title, summary, and default sources are previewed and filled from Wikidata/Wikipedia. Pressing Return in this field previews data but does not create the page.</div>
+                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title and summary are previewed from Wikidata, while source URLs are filled only from text sources such as Wikipedia and EB1911. Pressing Return in this field previews data but does not create the page.</div>
             </div>
             {% endif %}
 
@@ -69,10 +69,16 @@
                 <label for="sources" class="form-label">Sources (one URL per line)</label>
                 <textarea class="form-control" id="sources" name="sources" rows="6"
                           placeholder="https://example.com/topic">{{ sources_text if concept else '' }}</textarea>
-                <div class="form-text">Up to {{ max_sources }}. Q-id creation adds Wikipedia and EB1911 defaults when available.</div>
+                <div class="form-text">Up to {{ max_sources }}. Q-id creation adds Wikipedia and EB1911 text sources when available; Wikidata itself is not added as a generation source.</div>
             </div>
 
             {% if not concept %}
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="include_regional_wikis" name="include_regional_wikis" value="1">
+                <label class="form-check-label" for="include_regional_wikis">Include de/fr Wikipedia sources</label>
+                <div class="form-text">Optional supplementary sources with regional-bias notes. English Wikipedia remains the default Wikipedia source.</div>
+            </div>
+
             <div class="mb-3">
                 <label for="model" class="form-label">Generation model</label>
                 <input type="text" class="form-control" id="model" name="model"

--- a/src/barsukas/templates/concepts/regenerate.html
+++ b/src/barsukas/templates/concepts/regenerate.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+
+{% block title %}Regenerate {{ concept.title }}{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/concepts.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="row mb-3">
+    <div class="col">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a href="{{ url_for('concepts.list_concepts_view') }}">Concepts</a></li>
+                <li class="breadcrumb-item"><a href="{{ url_for('concepts.detail', slug=concept.slug) }}">{{ concept.title }}</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Regenerate</li>
+            </ol>
+        </nav>
+        <h1><i class="bi bi-arrow-clockwise"></i> Regenerate: {{ concept.title }}</h1>
+        <p class="text-muted">
+            Review and edit the references before making a new LLM call.
+        </p>
+    </div>
+</div>
+
+<div class="alert alert-warning">
+    Regeneration sends the references and current summary to the configured LLM and may incur API cost.
+    Confirm only after the references below are correct.
+</div>
+
+<form method="post" action="{{ url_for('concepts.regenerate', slug=concept.slug) }}">
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="mb-3">
+                <label for="sources" class="form-label">References (one URL per line)</label>
+                <textarea class="form-control" id="sources" name="sources" rows="10">{{ sources_text }}</textarea>
+                <div class="form-text">Up to {{ max_sources }} references. These replace the stored references when regeneration succeeds.</div>
+            </div>
+
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" id="confirm_regenerate" name="confirm_regenerate" value="1">
+                <label class="form-check-label" for="confirm_regenerate">
+                    I reviewed the references and understand this will make an LLM generation call.
+                </label>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="mb-3">
+                <label for="model" class="form-label">Generation model</label>
+                <input type="text" class="form-control" id="model" name="model" value="{{ default_model }}">
+            </div>
+
+            <button type="submit" class="btn btn-primary w-100" {{ 'disabled' if not sources_text }}>
+                <i class="bi bi-arrow-clockwise"></i> Confirm and regenerate
+            </button>
+            <a class="btn btn-link w-100 mt-2" href="{{ url_for('concepts.detail', slug=concept.slug) }}">
+                Cancel
+            </a>
+        </div>
+    </div>
+</form>
+{% endblock %}

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 QID_RE = re.compile(r"^Q[1-9][0-9]*$", re.IGNORECASE)
 WIKIDATA_ENTITY_URL = "https://www.wikidata.org/wiki/Special:EntityData/{qid}.json"
 WIKIPEDIA_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
-WIKIPEDIA_EXTRACT_URL = "https://en.wikipedia.org/w/api.php"
+WIKIPEDIA_EXTRACT_URL = "https://{language_code}.wikipedia.org/w/api.php"
 WIKISOURCE_SEARCH_URL = "https://en.wikisource.org/w/api.php"
 DEFAULT_TIMEOUT_SECONDS = 10
 MAX_SOURCE_TEXT_CHARS = 12000
@@ -24,6 +24,7 @@ WIKIPEDIA_LEAD_THRESHOLD_CHARS = 10_000
 EB1911_MAX_PARAGRAPHS = 10
 EB1911_MAX_WORDS = 1200
 EB1911_WIKIDATA_QID = "Q867541"
+REGIONAL_WIKIPEDIA_LANGUAGE_CODES = ("de", "fr")
 
 
 def _word_count(text: str) -> int:
@@ -147,7 +148,7 @@ def _extract_english_value(values: Dict[str, Dict[str, str]]) -> str:
 
 
 def _fetch_wikipedia_extract(
-    page_title: str, *, lead_only: bool = False
+    page_title: str, *, language_code: str = "en", lead_only: bool = False
 ) -> Optional[Dict[str, str]]:
     """Fetch a Wikipedia plain-text extract for a page."""
     # TODO: Switch source hydration to a local Wikipedia dump so concept creation
@@ -164,7 +165,7 @@ def _fetch_wikipedia_extract(
     }
     if lead_only:
         params["exintro"] = "1"
-    payload = _get_json(WIKIPEDIA_EXTRACT_URL, params=params)
+    payload = _get_json(WIKIPEDIA_EXTRACT_URL.format(language_code=language_code), params=params)
     pages = (payload or {}).get("query", {}).get("pages", [])
     if not pages:
         return None
@@ -176,25 +177,33 @@ def _fetch_wikipedia_extract(
     return {"title": title, "extract": extract}
 
 
-def _fetch_wikipedia_source(page_title: str) -> Optional[Dict[str, Any]]:
+def _fetch_wikipedia_source(
+    page_title: str, *, language_code: str = "en", regional_note: bool = False
+) -> Optional[Dict[str, Any]]:
     """Return a Wikipedia source dict with full short articles or lead-only long articles."""
-    page_extract = _fetch_wikipedia_extract(page_title)
+    page_extract = _fetch_wikipedia_extract(page_title, language_code=language_code)
     if page_extract is None:
         return None
     extract = page_extract["extract"]
     title = page_extract["title"]
     note = "Plain-text Wikipedia article extract for concept generation."
     if len(extract) > WIKIPEDIA_LEAD_THRESHOLD_CHARS:
-        lead_extract = _fetch_wikipedia_extract(title, lead_only=True)
+        lead_extract = _fetch_wikipedia_extract(title, language_code=language_code, lead_only=True)
         if lead_extract is not None:
             extract = lead_extract["extract"]
             title = lead_extract["title"]
         note = (
             "Plain-text Wikipedia lead section for concept generation; full article exceeded 10 KB."
         )
+    if regional_note:
+        note = (
+            f"{note} Regional Wikipedia source ({language_code}); use as a supplementary "
+            "perspective because coverage and framing may reflect local editorial bias."
+        )
+    source_label = "Wikipedia" if language_code == "en" else f"Wikipedia ({language_code})"
     return {
-        "url": f"https://en.wikipedia.org/wiki/{title.replace(' ', '_')}",
-        "title": f"Wikipedia: {title}",
+        "url": f"https://{language_code}.wikipedia.org/wiki/{title.replace(' ', '_')}",
+        "title": f"{source_label}: {title}",
         "note": note,
         "text": extract[:MAX_SOURCE_TEXT_CHARS],
     }
@@ -312,7 +321,9 @@ def _fetch_eb1911_source(
     }
 
 
-def fetch_wikidata_concept_seed(raw_qid: str) -> Optional[WikidataConceptSeed]:
+def fetch_wikidata_concept_seed(
+    raw_qid: str, *, include_regional_wikis: bool = False
+) -> Optional[WikidataConceptSeed]:
     """Resolve a Wikidata Q-id into a concept title, summary, and default sources."""
     qid = normalize_qid(raw_qid)
     if qid is None:
@@ -338,17 +349,21 @@ def fetch_wikidata_concept_seed(raw_qid: str) -> Optional[WikidataConceptSeed]:
         extract = str((summary_payload or {}).get("extract", "")).strip()
         summary = extract.split(".")[0].strip() + "." if extract and not description else summary
 
-    sources: List[Dict[str, Any]] = [
-        {
-            "url": f"https://www.wikidata.org/wiki/{qid}",
-            "title": f"Wikidata: {qid}",
-            "note": "Wikidata entity used to seed the concept title and summary.",
-        }
-    ]
+    sources: List[Dict[str, Any]] = []
     if enwiki_title:
         wikipedia_source = _fetch_wikipedia_source(enwiki_title)
         if wikipedia_source is not None:
             sources.append(wikipedia_source)
+    if include_regional_wikis:
+        for language_code in REGIONAL_WIKIPEDIA_LANGUAGE_CODES:
+            regional_title = str(sitelinks.get(f"{language_code}wiki", {}).get("title", "")).strip()
+            if not regional_title:
+                continue
+            regional_source = _fetch_wikipedia_source(
+                regional_title, language_code=language_code, regional_note=True
+            )
+            if regional_source is not None:
+                sources.append(regional_source)
     eb1911_source = _fetch_eb1911_source(title, label, entity)
     if eb1911_source is not None:
         sources.append(eb1911_source)

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-from agents.vovere import VovereAgent
+import pytest
+from agents.vovere import VovereAgent, html_to_text
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from storage.crud.concept import create_concept, get_wikidata_index, link_wikidata_concept
@@ -43,7 +44,9 @@ def test_link_wikidata_concept_creates_reverse_index() -> None:
 def test_wikipedia_source_uses_lead_for_long_articles(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     calls: list[bool] = []
 
-    def fake_fetch(page_title: str, *, lead_only: bool = False) -> Optional[Dict[str, str]]:
+    def fake_fetch(
+        page_title: str, *, language_code: str = "en", lead_only: bool = False
+    ) -> Optional[Dict[str, str]]:
         calls.append(lead_only)
         if lead_only:
             return {"title": page_title, "extract": "Lead section only"}
@@ -174,10 +177,75 @@ def test_fetch_wikidata_seed_builds_sources_from_mocked_apis(monkeypatch) -> Non
     assert seed.title == "Douglas Adams"
     assert seed.summary == "English writer and humorist"
     assert [source["title"] for source in seed.sources] == [
-        "Wikidata: Q42",
         "Wikipedia: Douglas Adams",
         "EB1911: Douglas Adams",
     ]
+    assert all(not source["title"].startswith("Wikidata:") for source in seed.sources)
+
+
+def test_fetch_wikidata_seed_can_include_regional_wikipedia_sources(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fake_get_json(
+        url: str, *, params: Optional[Dict[str, str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        if "Special:EntityData" in url:
+            return {
+                "entities": {
+                    "Q1204": {
+                        "labels": {"en": {"value": "Illinois"}},
+                        "descriptions": {"en": {"value": "state of the United States"}},
+                        "sitelinks": {
+                            "enwiki": {"title": "Illinois"},
+                            "dewiki": {"title": "Illinois"},
+                            "frwiki": {"title": "Illinois"},
+                        },
+                    }
+                }
+            }
+        if "rest_v1/page/summary" in url:
+            return {"extract": "Illinois is a state. More text."}
+        if "en.wikipedia.org/w/api.php" in url:
+            return {"query": {"pages": [{"title": "Illinois", "extract": "English text"}]}}
+        if "de.wikipedia.org/w/api.php" in url:
+            return {"query": {"pages": [{"title": "Illinois", "extract": "German text"}]}}
+        if "fr.wikipedia.org/w/api.php" in url:
+            return {"query": {"pages": [{"title": "Illinois", "extract": "French text"}]}}
+        if params and params.get("list") == "search":
+            return {"query": {"search": []}}
+        return {"query": {"pages": []}}
+
+    monkeypatch.setattr("storage.wikidata._get_json", fake_get_json)
+
+    seed = fetch_wikidata_concept_seed("Q1204", include_regional_wikis=True)
+
+    assert seed is not None
+    assert [source["title"] for source in seed.sources] == [
+        "Wikipedia: Illinois",
+        "Wikipedia (de): Illinois",
+        "Wikipedia (fr): Illinois",
+    ]
+    assert "regional" in seed.sources[1]["note"].lower()
+    assert all(not source["title"].startswith("Wikidata:") for source in seed.sources)
+
+
+def test_vovere_html_to_text_removes_navigation_chrome() -> None:
+    pytest.importorskip("bs4")
+    html = """
+    <html>
+      <body>
+        <nav>Main menu should disappear</nav>
+        <header>Header should disappear</header>
+        <main><p>Useful article text remains.</p></main>
+        <footer>Footer should disappear</footer>
+      </body>
+    </html>
+    """
+
+    text = html_to_text(html)
+
+    assert "Useful article text remains." in text
+    assert "Main menu should disappear" not in text
+    assert "Header should disappear" not in text
+    assert "Footer should disappear" not in text
 
 
 def test_vovere_uses_provided_source_text(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
### Motivation
- Improve HTML-to-text extraction for source pages to remove navigation and page chrome more robustly than the minimal HTMLParser implementation.
- Make Wikidata-based seeding richer and safer by preferring text sources (Wikipedia, EB1911), supporting regional Wikipedia supplements, and bounding EB1911 extracts.
- Prevent duplicate source URLs, surface source lists in the editor, and add an explicit review/confirmation step before making LLM regeneration calls.
- Add a required dependency for improved HTML parsing and update the UI/JS to hydrate fields from Wikidata previews and merge source lists.

### Description
- Add `beautifulsoup4` to `pyproject.toml` and `requirements.txt` and replace the custom `_TextExtractor` with `html_to_text` powered by `bs4` that strips script/style/nav/header/footer/aside/toc and other chrome. 
- Extend `storage.wikidata` with helper functions and features including `_fetch_wikidata_entity`, regional `WIKIPEDIA_EXTRACT_URL` templating, EB1911 page discovery and excerpt limiting, `include_regional_wikis` support in `fetch_wikidata_concept_seed`, and removal of Wikidata entity links as generation sources. 
- Add source de-duplication and merging helpers in `barsukas/routes/concepts.py` (`_source_key`, `_merge_sources`, `_concept_sources`, `_source_urls_text`) and change flows to use merged sources when creating/updating/regenerating concepts; make `/regenerate` a GET/POST flow with a confirmation form and replace the detail-page regenerate POST with a link to the confirmation page. 
- Update frontend behavior in `concept_form.js` to hydrate title/summary/sources from Wikidata previews, merge incoming source URLs, support `include_regional_wikis` checkbox, and update wording; add `regenerate.html` template and tweak `form.html`/`detail.html` copy and controls. 
- Expand and update unit tests in `src/tests/storage/test_wikidata_concepts.py` to cover Q-id normalization, Wikipedia lead extraction behavior, EB1911 heuristics and selection, regional wiki inclusion, the new `html_to_text` behavior, and Vovere source-message building.

### Testing
- Ran unit tests with `pytest` for the modified storage and agent tests (notably `test_wikidata_concepts.py`), and all new and existing assertions passed. 
- Exercised the Wikidata seeding helpers with mocked `_get_json` and related network calls via `monkeypatch` to validate regional Wikipedia and EB1911 behaviors, all checks succeeded. 
- Verified the `html_to_text` behavior in tests using `pytest.importorskip('bs4')` to ensure graceful skip when `bs4` is unavailable, and the test passed when `bs4` is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3811032d7c832794ec44f95558cde4)