### PR TITLE
Exclude Wikidata from generation sources, show Q-id generated sources, and add Wikimedia fetch retries

### DIFF
--- a/src/agents/vovere.py
+++ b/src/agents/vovere.py
@@ -27,6 +27,7 @@ import logging
 import sys
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
@@ -53,6 +54,14 @@ PER_SOURCE_CHAR_LIMIT: int = 12000
 TOTAL_SOURCE_CHAR_LIMIT: int = 40000
 FETCH_TIMEOUT_SECONDS: int = 20
 DEFAULT_USER_AGENT: str = "Greenland-Vovere/1.0 (concept entry generator)"
+BLOCKED_SOURCE_HOSTS: frozenset[str] = frozenset({"wikidata.org", "www.wikidata.org"})
+
+
+def is_allowed_generation_source_url(url: str) -> bool:
+    """Return False for source URLs that are unsuitable as generation text."""
+    parsed_url = urlparse(url)
+    host = parsed_url.netloc.casefold()
+    return host not in BLOCKED_SOURCE_HOSTS
 
 
 def html_to_text(html: str) -> str:
@@ -139,7 +148,7 @@ class VovereAgent:
         budget = TOTAL_SOURCE_CHAR_LIMIT
         for index, source in enumerate(sources[:MAX_CONCEPT_SOURCES], start=1):
             url = str(source.get("url", "")).strip()
-            if not url:
+            if not url or not is_allowed_generation_source_url(url):
                 continue
             provided_text = str(source.get("text", "")).strip()
             text = (

--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -11,6 +11,7 @@ may contain ``[[wiki links]]`` to other concepts.
 import json
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, cast
+from urllib.parse import urlparse
 
 import constants
 from flask import (
@@ -43,6 +44,8 @@ from storage.models.concept import (
 )
 from storage.queries.concept import count_concepts, get_backlinks, list_concepts
 from storage.wikidata import fetch_wikidata_concept_seed, normalize_qid
+
+BLOCKED_SOURCE_HOSTS: frozenset[str] = frozenset({"wikidata.org", "www.wikidata.org"})
 
 if TYPE_CHECKING:
     from barsukas.app import BarsukasFlask
@@ -97,6 +100,13 @@ def _merge_sources(*source_lists: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return merged_sources
 
 
+def _is_allowed_generation_source_url(url: str) -> bool:
+    """Return False for source URLs that produce unusable generation text."""
+    parsed_url = urlparse(url)
+    host = parsed_url.netloc.casefold()
+    return host not in BLOCKED_SOURCE_HOSTS
+
+
 def _parse_sources_form(raw: str) -> List[Dict[str, Any]]:
     """Parse the sources textarea (one URL per line) into source dicts.
 
@@ -109,7 +119,7 @@ def _parse_sources_form(raw: str) -> List[Dict[str, Any]]:
     sources: List[Dict[str, Any]] = []
     for line in raw.splitlines():
         url = line.strip()
-        if url:
+        if url and _is_allowed_generation_source_url(url):
             sources.append({"url": url})
     return _merge_sources(sources)
 

--- a/src/barsukas/static/js/concept_form.js
+++ b/src/barsukas/static/js/concept_form.js
@@ -6,6 +6,7 @@
     const sourcesInput = document.getElementById('sources');
     const preview = document.getElementById('wikidata-preview');
     const includeRegionalWikisInput = document.getElementById('include_regional_wikis');
+    const generatedSources = document.getElementById('wikidata-generated-sources');
     if (!form || !qidInput || !titleInput || !summaryInput || !sourcesInput || !preview) {
         return;
     }
@@ -20,31 +21,37 @@
         preview.className = className;
     }
 
-    function sourceUrls(sources) {
+    function sourceLabels(sources) {
         if (!Array.isArray(sources)) {
             return [];
         }
         return sources.map(function (source) {
-            return source.url || '';
-        }).filter(function (url) {
-            return url.length > 0;
+            return source.title || source.url || '';
+        }).filter(function (label) {
+            return label.length > 0;
         });
     }
 
-    function mergeSourceUrls(existingText, sources) {
-        const existingUrls = existingText.split('\n').map(function (line) {
-            return line.trim();
-        }).filter(function (line) {
-            return line.length > 0;
+    function renderGeneratedSources(sources) {
+        if (!generatedSources) {
+            return;
+        }
+        const labels = sourceLabels(sources);
+        generatedSources.textContent = '';
+        if (labels.length === 0) {
+            return;
+        }
+        const heading = document.createElement('div');
+        heading.textContent = 'Q-id generated sources that will be included automatically:';
+        generatedSources.appendChild(heading);
+        const list = document.createElement('ul');
+        list.className = 'mb-0';
+        labels.forEach(function (label) {
+            const item = document.createElement('li');
+            item.textContent = label;
+            list.appendChild(item);
         });
-        const seenUrls = new Set(existingUrls);
-        sourceUrls(sources).forEach(function (url) {
-            if (!seenUrls.has(url)) {
-                existingUrls.push(url);
-                seenUrls.add(url);
-            }
-        });
-        return existingUrls.join('\n');
+        generatedSources.appendChild(list);
     }
 
     function hydrateFields(data) {
@@ -54,7 +61,7 @@
         if (!summaryInput.value.trim()) {
             summaryInput.value = data.summary || '';
         }
-        sourcesInput.value = mergeSourceUrls(sourcesInput.value, data.sources || []);
+        renderGeneratedSources(data.sources || []);
     }
 
     qidInput.addEventListener('keydown', function (event) {
@@ -79,11 +86,13 @@
         if (!qid) {
             lastRequestedQid = '';
             setPreview('', 'form-text');
+            renderGeneratedSources([]);
             return;
         }
 
         if (!qidPattern.test(qid)) {
             setPreview('Enter a complete Wikidata Q-id such as Q42.', 'form-text text-muted');
+            renderGeneratedSources([]);
             return;
         }
 
@@ -116,11 +125,13 @@
                         );
                     } else {
                         setPreview('No Wikidata match found for ' + qid + '.', 'form-text text-warning');
+                        renderGeneratedSources([]);
                     }
                 })
                 .catch(function () {
                     if (qidInput.value.trim().toUpperCase() === qid) {
                         setPreview('Could not preview ' + qid + '; creation can still try resolving it after you click Create & generate.', 'form-text text-warning');
+                        renderGeneratedSources([]);
                     }
                 });
         }, 600);

--- a/src/barsukas/templates/concepts/form.html
+++ b/src/barsukas/templates/concepts/form.html
@@ -38,7 +38,8 @@
                 <input type="text" class="form-control" id="wikidata_qid" name="wikidata_qid"
                        placeholder="e.g. Q42"
                        data-preview-url="{{ url_for('concepts.wikidata_preview') }}">
-                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title and summary are previewed from Wikidata, while source URLs are filled only from text sources such as Wikipedia and EB1911. Pressing Return in this field previews data but does not create the page.</div>
+                <div id="wikidata-preview" class="form-text">Optional. If supplied, the title and summary are previewed from Wikidata, and generated text sources are listed below without adding them to the editable source URL field. Pressing Return in this field previews data but does not create the page.</div>
+                <div id="wikidata-generated-sources" class="form-text mt-2"></div>
             </div>
             {% endif %}
 
@@ -69,7 +70,7 @@
                 <label for="sources" class="form-label">Sources (one URL per line)</label>
                 <textarea class="form-control" id="sources" name="sources" rows="6"
                           placeholder="https://example.com/topic">{{ sources_text if concept else '' }}</textarea>
-                <div class="form-text">Up to {{ max_sources }}. Q-id creation adds Wikipedia and EB1911 text sources when available; Wikidata itself is not added as a generation source.</div>
+                <div class="form-text">Up to {{ max_sources }} additional URLs. Q-id creation adds generated Wikipedia and EB1911 text sources automatically, but does not copy those URLs here. Wikidata itself is not added as a generation source. TODO: add checkboxes to disable individual Q-id generated sources.</div>
             </div>
 
             {% if not concept %}

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence
+from urllib.parse import quote
 
 import requests
 
@@ -19,6 +22,11 @@ WIKIPEDIA_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/{titl
 WIKIPEDIA_EXTRACT_URL = "https://{language_code}.wikipedia.org/w/api.php"
 WIKISOURCE_SEARCH_URL = "https://en.wikisource.org/w/api.php"
 DEFAULT_TIMEOUT_SECONDS = 10
+MAX_HTTP_ATTEMPTS = 3
+DEFAULT_USER_AGENT = os.environ.get(
+    "GREENLAND_HTTP_USER_AGENT",
+    "Greenland-Barsukas/1.0 (concept seeding; set GREENLAND_HTTP_USER_AGENT with contact)",
+)
 MAX_SOURCE_TEXT_CHARS = 12000
 WIKIPEDIA_LEAD_THRESHOLD_CHARS = 10_000
 EB1911_MAX_PARAGRAPHS = 10
@@ -98,22 +106,52 @@ def normalize_qid(raw_qid: str) -> Optional[str]:
     return None
 
 
+def _retry_delay_seconds(response: requests.Response, attempt_index: int) -> float:
+    """Return a short retry delay for rate-limited Wikimedia responses."""
+    retry_after = response.headers.get("Retry-After", "").strip()
+    if retry_after.isdigit():
+        return min(float(retry_after), 5.0)
+    fallback_delay: float = 0.5 * float(2**attempt_index)
+    return min(fallback_delay, 5.0)
+
+
 def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Any]]:
-    """Fetch JSON with a short timeout, returning None on HTTP/network errors."""
-    try:
-        response = requests.get(
-            url,
-            params=params,
-            timeout=DEFAULT_TIMEOUT_SECONDS,
-            headers={"User-Agent": "Greenland-Barsukas/1.0 (Wikidata concept seeding)"},
-        )
-        response.raise_for_status()
-        payload = response.json()
-    except (requests.RequestException, ValueError) as error:
-        logger.warning("Failed to fetch JSON from %s: %s", url, error)
+    """Fetch JSON with Wikimedia-friendly headers and limited 429 retries."""
+    request_params = dict(params or {})
+    if "/w/api.php" in url:
+        request_params.setdefault("maxlag", "5")
+        request_params.setdefault("format", "json")
+
+    last_error: Optional[Exception] = None
+    for attempt_index in range(MAX_HTTP_ATTEMPTS):
+        try:
+            response = requests.get(
+                url,
+                params=request_params or None,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+                headers={
+                    "User-Agent": DEFAULT_USER_AGENT,
+                    "Api-User-Agent": DEFAULT_USER_AGENT,
+                },
+            )
+            if response.status_code in {429, 503} and attempt_index < MAX_HTTP_ATTEMPTS - 1:
+                time.sleep(_retry_delay_seconds(response, attempt_index))
+                continue
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError) as error:
+            last_error = error
+            if attempt_index < MAX_HTTP_ATTEMPTS - 1 and isinstance(error, requests.HTTPError):
+                error_response = error.response
+                if error_response is not None and error_response.status_code in {429, 503}:
+                    time.sleep(_retry_delay_seconds(error_response, attempt_index))
+                    continue
+            break
+        if isinstance(payload, dict):
+            return payload
         return None
-    if isinstance(payload, dict):
-        return payload
+
+    logger.warning("Failed to fetch JSON from %s: %s", url, last_error)
     return None
 
 
@@ -344,7 +382,7 @@ def fetch_wikidata_concept_seed(
     summary = description
     if enwiki_title:
         summary_payload = _get_json(
-            WIKIPEDIA_SUMMARY_URL.format(title=enwiki_title.replace(" ", "%20"))
+            WIKIPEDIA_SUMMARY_URL.format(title=quote(enwiki_title, safe=""))
         )
         extract = str((summary_payload or {}).get("extract", "")).strip()
         summary = extract.split(".")[0].strip() + "." if extract and not description else summary

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -227,6 +227,54 @@ def test_fetch_wikidata_seed_can_include_regional_wikipedia_sources(monkeypatch)
     assert all(not source["title"].startswith("Wikidata:") for source in seed.sources)
 
 
+def test_get_json_retries_429_with_wikimedia_headers(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+            self.headers: dict[str, str] = {"Retry-After": "0"}
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError("unexpected status")
+
+        def json(self) -> dict[str, str]:
+            return {"ok": "yes"}
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        calls.append(kwargs)
+        return FakeResponse(429 if len(calls) == 1 else 200)
+
+    monkeypatch.setattr("storage.wikidata.requests.get", fake_get)
+    monkeypatch.setattr("storage.wikidata.time.sleep", lambda delay: None)
+
+    from storage.wikidata import _get_json
+
+    assert _get_json("https://en.wikisource.org/w/api.php", params={"action": "query"}) == {
+        "ok": "yes"
+    }
+    assert len(calls) == 2
+    assert calls[0]["headers"]["Api-User-Agent"]
+    assert calls[0]["params"]["maxlag"] == "5"
+
+
+def test_vovere_skips_wikidata_generation_sources() -> None:
+    agent = VovereAgent.__new__(VovereAgent)
+
+    messages = agent._build_source_messages(
+        [
+            {
+                "url": "https://www.wikidata.org/wiki/Q12439",
+                "title": "Wikidata: Detroit",
+                "text": "Jump to content From Wikidata junk",
+            }
+        ]
+    )
+
+    assert messages == []
+
+
 def test_vovere_html_to_text_removes_navigation_chrome() -> None:
     pytest.importorskip("bs4")
     html = """


### PR DESCRIPTION
### Motivation
- Prevent Wikidata entity pages from being used as raw generation text because their content is noisy or unusable for LLM input.
- Surface which text sources are generated from a supplied Wikidata Q-id so users can review them without copying those URLs into editable source fields.
- Make Wikidata/Wikipedia/Wikisource HTTP requests more robust to transient 429/503 responses and follow Wikimedia-friendly request patterns.

### Description
- Add host-based blocking for generation sources by introducing `BLOCKED_SOURCE_HOSTS` and `is_allowed_generation_source_url` in `agents/vovere.py` and similar `_is_allowed_generation_source_url` in `barsukas/routes/concepts.py`, and skip blocked URLs when building source messages and parsing form input.
- Update the concept creation UI: display a non-editable list of generated Q-id text sources in the form by adding `wikidata-generated-sources` to `templates/concepts/form.html` and rendering them in `static/js/concept_form.js` (new `renderGeneratedSources` and `sourceLabels` helpers), and adjust copy text to clarify generated sources are not copied into the editable URL field.
- Improve Wikimedia fetch helper in `storage/wikidata.py` by adding `DEFAULT_USER_AGENT`, `MAX_HTTP_ATTEMPTS`, `time`-backoff handling, `Api-User-Agent` headers, `maxlag` and `format` params for MediaWiki API calls, and retry logic on `429`/`503` responses in `_get_json`; also use `quote` for safe URL encoding when fetching summaries.

### Testing
- Ran unit tests for Wikidata helpers and Vovere behavior including `test_get_json_retries_429_with_wikimedia_headers` and `test_vovere_skips_wikidata_generation_sources`, and the existing `test_vovere_html_to_text_removes_navigation_chrome`; all ran successfully.
- Exercised the concept form preview flow locally to verify generated Q-id sources are displayed and not copied into the editable `sources` textarea; UI behavior observed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381a4283908327b33b246948450e44)