### PR TITLE
Clean concept source summaries

### DIFF
--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -64,7 +64,18 @@ class _WikiLinkHTMLTextParser(HTMLParser):
             self.skip_depth += 1
             return
         if tag in {"script", "style", "table"} or classes.intersection(
-            {"navbox", "vertical-navbox", "metadata", "ambox", "infobox", "sidebar"}
+            {
+                "ambox",
+                "infobox",
+                "metadata",
+                "mw-references-wrap",
+                "navbox",
+                "reference",
+                "references",
+                "reflist",
+                "sidebar",
+                "vertical-navbox",
+            }
         ):
             self.skip_depth += 1
             return
@@ -107,11 +118,26 @@ class _WikiLinkHTMLTextParser(HTMLParser):
         return text.strip()
 
 
+def _strip_wikipedia_trailing_reference_sections(text: str) -> str:
+    """Remove trailing Wikipedia maintenance/reference sections from parsed article text."""
+    section_heading_re = re.compile(
+        r"^(references|notes|citations|sources|further reading|external links|bibliography)$",
+        re.IGNORECASE,
+    )
+    kept_lines: List[str] = []
+    for line in text.splitlines():
+        clean_line = line.strip().strip("=").strip()
+        if section_heading_re.match(clean_line):
+            break
+        kept_lines.append(line)
+    return "\n".join(kept_lines).strip()
+
+
 def _html_to_text_with_wikilinks(html: str) -> str:
     """Convert parsed Wikimedia HTML to text while preserving internal link targets."""
     parser = _WikiLinkHTMLTextParser()
     parser.feed(html)
-    return parser.get_text()
+    return _strip_wikipedia_trailing_reference_sections(parser.get_text())
 
 
 def _fetch_wikipedia_parsed_text(
@@ -146,13 +172,38 @@ def _word_count(text: str) -> int:
     return len(text.split())
 
 
-def _limit_eb1911_extract(extract: str) -> tuple[str, bool]:
-    """Return an EB1911 extract limited to an intro-sized excerpt when needed."""
+def _looks_like_eb1911_sections_index(paragraph: str) -> bool:
+    """Return whether a paragraph is an EB1911 table-of-sections index."""
+    clean_paragraph = " ".join(paragraph.split())
+    if not clean_paragraph.lower().startswith("sections"):
+        return False
+    section_markers = re.findall(r"\b[IVXLCDM]+\.—", clean_paragraph)
+    return len(section_markers) >= 3
+
+
+def _strip_eb1911_sections_index(extract: str) -> str:
+    """Remove EB1911 front-matter section indexes from Wikisource extracts."""
     paragraphs = [
         paragraph.strip() for paragraph in re.split(r"\n\s*\n", extract) if paragraph.strip()
     ]
-    if len(paragraphs) <= EB1911_MAX_PARAGRAPHS and _word_count(extract) <= EB1911_MAX_WORDS:
-        return extract, False
+    while paragraphs and _looks_like_eb1911_sections_index(paragraphs[0]):
+        paragraphs.pop(0)
+    return "\n\n".join(paragraphs)
+
+
+def _limit_eb1911_extract(extract: str) -> tuple[str, bool]:
+    """Return an EB1911 extract limited to an intro-sized excerpt when needed."""
+    cleaned_extract = _strip_eb1911_sections_index(extract)
+    paragraphs = [
+        paragraph.strip()
+        for paragraph in re.split(r"\n\s*\n", cleaned_extract)
+        if paragraph.strip()
+    ]
+    if (
+        len(paragraphs) <= EB1911_MAX_PARAGRAPHS
+        and _word_count(cleaned_extract) <= EB1911_MAX_WORDS
+    ):
+        return cleaned_extract, cleaned_extract != extract
 
     selected_paragraphs: List[str] = []
     selected_words = 0
@@ -169,7 +220,7 @@ def _limit_eb1911_extract(extract: str) -> tuple[str, bool]:
             break
 
     if not selected_paragraphs:
-        return " ".join(extract.split()[:EB1911_MAX_WORDS]), True
+        return " ".join(cleaned_extract.split()[:EB1911_MAX_WORDS]), True
     return "\n\n".join(selected_paragraphs), True
 
 

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -15,6 +15,7 @@ from storage.wikidata import (
     _fetch_wikipedia_source,
     _html_to_text_with_wikilinks,
     _limit_eb1911_extract,
+    _strip_eb1911_sections_index,
     fetch_wikidata_concept_seed,
     normalize_qid,
 )
@@ -56,6 +57,25 @@ def test_wikipedia_html_to_text_preserves_wikilink_targets() -> None:
     assert "[[Lake Michigan|the lake]]" in text
     assert "[[Illinois]]" in text
     assert "[[Help:Contents" not in text
+
+
+def test_wikipedia_html_to_text_removes_trailing_references() -> None:
+    html = """
+    <div class="mw-parser-output">
+      <p>Useful article lead with <a href="/wiki/Chicago">Chicago</a>.</p>
+      <h2>References</h2>
+      <ol class="references"><li>Reference text should disappear.</li></ol>
+      <h2>External links</h2>
+      <p>External link text should disappear.</p>
+    </div>
+    """
+
+    text = _html_to_text_with_wikilinks(html)
+
+    assert "Useful article lead with [[Chicago]]." in text
+    assert "References" not in text
+    assert "Reference text should disappear" not in text
+    assert "External link text should disappear" not in text
 
 
 def test_wikipedia_source_uses_parsed_html_with_wikilinks(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -112,6 +132,29 @@ def test_eb1911_extract_uses_intro_for_long_pages() -> None:
 
     assert intro_only is True
     assert extract == "\n\n".join(paragraphs[:10])
+
+
+def test_eb1911_sections_index_is_removed_before_limiting() -> None:
+    extract = """Sections
+I.—Physical Geography
+II.—Geology
+III.—Climate
+IV.—Fauna and Flora
+V.—Population and Social Conditions
+
+UNITED STATES, a federal republic of North America.
+
+Second paragraph.
+"""
+
+    assert _strip_eb1911_sections_index(extract).startswith("UNITED STATES")
+    limited_extract, intro_only = _limit_eb1911_extract(extract)
+
+    assert (
+        limited_extract
+        == "UNITED STATES, a federal republic of North America.\n\nSecond paragraph."
+    )
+    assert intro_only is True
 
 
 def test_eb1911_page_qids_use_p1343_p805_claims() -> None:


### PR DESCRIPTION
### Motivation
- Wikipedia article extracts were including trailing reference/maintenance sections and reference DOM elements, causing those lines to appear in generated concept text and summaries. 
- EB1911 Wikisource extracts sometimes begin with a front-matter "Sections" index (Roman‑numeral list) which was being included in intro excerpts and summary selection. 

### Description
- Extend the HTML parser skip list to ignore typical Wikipedia reference/maintenance classes and add `_strip_wikipedia_trailing_reference_sections` to trim trailing headings like `References`, `External links`, and `Bibliography` from parsed text, and call it from `_html_to_text_with_wikilinks`. 
- Add `_looks_like_eb1911_sections_index` and `_strip_eb1911_sections_index` to remove EB1911 front-matter section indexes before excerpting, and update `_limit_eb1911_extract` to operate on the cleaned extract while preserving the intro/word-limit semantics. 
- Adjust behavior to return the cleaned excerpt when the original extract was modified by stripping, and fall back to a word-limited slice of the cleaned text when needed. 
- Modify `src/tests/storage/test_wikidata_concepts.py` to add regression tests for removing trailing Wikipedia references and for removing EB1911 section indexes prior to limiting. 

### Testing
- Ran unit tests with `PYTHONPATH=src pytest src/tests/storage/test_wikidata_concepts.py`, which completed with `17 passed, 1 skipped`. 
- Ran static type checks with `PYTHONPATH=src mypy src/storage/wikidata.py src/tests/storage/test_wikidata_concepts.py`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382226bf008327984f5c7a1d9144fa)