### PR TITLE
Add Wikisource parse fallback for EB1911 sources

### DIFF
--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -467,7 +467,21 @@ def _fetch_eb1911_page_extract(page_title: str) -> Optional[str]:
         return None
     extract = str(page.get("extract", "")).strip()
     if not extract:
-        return None
+        parse_params = {
+            "action": "parse",
+            "page": page_title,
+            "prop": "text",
+            "redirects": "1",
+            "format": "json",
+            "formatversion": "2",
+        }
+        parse_payload = _get_json(WIKISOURCE_SEARCH_URL, params=parse_params)
+        html = str((parse_payload or {}).get("parse", {}).get("text", "")).strip()
+        if not html:
+            return None
+        extract = _html_to_text_with_wikilinks(html)
+        if not extract:
+            return None
     return extract
 
 

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -218,6 +218,46 @@ def test_eb1911_source_uses_direct_existing_page_before_search(monkeypatch) -> N
     assert calls == ["query", "query"]
 
 
+def test_eb1911_source_uses_wikisource_parse_when_extract_is_empty(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fake_get_json(
+        url: str, *, params: Optional[Dict[str, str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        assert params is not None
+        if params.get("prop") == "extracts":
+            return {
+                "query": {
+                    "pages": [
+                        {
+                            "title": "1911 Encyclopædia Britannica/Atlantic Ocean",
+                            "extract": "",
+                        }
+                    ]
+                }
+            }
+        if params.get("action") == "parse":
+            assert params.get("page") == "1911 Encyclopædia Britannica/Atlantic Ocean"
+            return {
+                "parse": {
+                    "text": (
+                        '<div class="mw-parser-output"><p><b>ATLANTIC OCEAN</b>, '
+                        "a belt of water between Europe, Africa, and the Americas.</p></div>"
+                    )
+                }
+            }
+        raise AssertionError(f"Unexpected params: {params}")
+
+    monkeypatch.setattr("storage.wikidata._get_json", fake_get_json)
+
+    source = _fetch_eb1911_source("Atlantic Ocean")
+
+    assert source is not None
+    assert (
+        source["url"]
+        == "https://en.wikisource.org/wiki/1911_Encyclopædia_Britannica/Atlantic_Ocean"
+    )
+    assert "ATLANTIC OCEAN" in source["text"]
+
+
 def test_eb1911_source_prefers_wikidata_p805_wikisource_page(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     entity = {
         "claims": {


### PR DESCRIPTION
### Motivation

- Some EB1911 Wikisource pages return an empty `extracts` response (observed for topics like "Atlantic Ocean"), causing the EB1911 source lookup to miss usable text. 
- Provide a robust fallback to retrieve article content by parsing the Wikisource HTML when the extracts API yields no extract.

### Description

- Update `_fetch_eb1911_page_extract` to call the Wikisource `action=parse` endpoint when the `extracts` result is empty and convert the returned HTML to text via `_html_to_text_with_wikilinks`.
- Add `test_eb1911_source_uses_wikisource_parse_when_extract_is_empty` to `src/tests/storage/test_wikidata_concepts.py` to cover the Atlantic-Ocean-style empty-extract case.
- Changes are limited to `src/storage/wikidata.py` and the related test file and preserve existing behavior for non-empty extracts.

### Testing

- Formatted and static-checked the modified files with `PYTHONPATH=src black src/storage/wikidata.py src/tests/storage/test_wikidata_concepts.py` and `PYTHONPATH=src mypy src/storage/wikidata.py src/tests/storage/test_wikidata_concepts.py`, both reporting no issues. 
- Ran the focused unit tests with `PYTHONPATH=src pytest -q src/tests/storage/test_wikidata_concepts.py`, which completed with `18 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38251e82448327a419e4a29cf89089)