### PR TITLE
Cache Wikidata Q-id seed lookups

### DIFF
--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -8,6 +8,7 @@ import os
 import re
 import time
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Sequence
 from urllib.parse import quote, unquote
 
@@ -566,6 +567,16 @@ def _fetch_eb1911_source(
     }
 
 
+def _clone_wikidata_concept_seed(seed: WikidataConceptSeed) -> WikidataConceptSeed:
+    """Return a copy of cached seed data with fresh mutable source dictionaries."""
+    return WikidataConceptSeed(
+        qid=seed.qid,
+        title=seed.title,
+        summary=seed.summary,
+        sources=[dict(source) for source in seed.sources],
+    )
+
+
 def fetch_wikidata_concept_seed(
     raw_qid: str, *, include_regional_wikis: bool = False
 ) -> Optional[WikidataConceptSeed]:
@@ -574,6 +585,17 @@ def fetch_wikidata_concept_seed(
     if qid is None:
         return None
 
+    seed = _fetch_wikidata_concept_seed_cached(qid, include_regional_wikis)
+    if seed is None:
+        return None
+    return _clone_wikidata_concept_seed(seed)
+
+
+@lru_cache(maxsize=256)
+def _fetch_wikidata_concept_seed_cached(
+    qid: str, include_regional_wikis: bool
+) -> Optional[WikidataConceptSeed]:
+    """Resolve a normalized Q-id, caching repeated lookups in this process."""
     entity = _fetch_wikidata_entity(qid)
     if entity is None:
         return None

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -12,6 +12,7 @@ from storage.wikidata import (
     _eb1911_search_titles,
     _extract_eb1911_page_qids,
     _fetch_eb1911_source,
+    _fetch_wikidata_concept_seed_cached,
     _fetch_wikipedia_source,
     _html_to_text_with_wikilinks,
     _limit_eb1911_extract,
@@ -333,6 +334,46 @@ def test_fetch_wikidata_seed_builds_sources_from_mocked_apis(monkeypatch) -> Non
         "EB1911: Douglas Adams",
     ]
     assert all(not source["title"].startswith("Wikidata:") for source in seed.sources)
+
+
+def test_fetch_wikidata_seed_caches_repeated_qid_lookups(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    _fetch_wikidata_concept_seed_cached.cache_clear()
+    calls: list[str] = []
+
+    def fake_get_json(
+        url: str, *, params: Optional[Dict[str, str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        calls.append(url)
+        if "Special:EntityData" in url:
+            return {
+                "entities": {
+                    "Q555": {
+                        "labels": {"en": {"value": "Cached concept"}},
+                        "descriptions": {"en": {"value": "cached description"}},
+                        "sitelinks": {"enwiki": {"title": "Cached concept"}},
+                    }
+                }
+            }
+        if "rest_v1/page/summary" in url:
+            return {"extract": "Cached concept summary."}
+        if "en.wikipedia.org/w/api.php" in url:
+            return {"query": {"pages": [{"title": "Cached concept", "extract": "Article text"}]}}
+        if params and params.get("list") == "search":
+            return {"query": {"search": []}}
+        return {"query": {"pages": []}}
+
+    monkeypatch.setattr("storage.wikidata._get_json", fake_get_json)
+
+    first_seed = fetch_wikidata_concept_seed("q555")
+    assert first_seed is not None
+    first_seed.sources.append({"title": "mutated"})
+    second_seed = fetch_wikidata_concept_seed("Q555")
+
+    assert second_seed is not None
+    assert second_seed.title == "Cached concept"
+    assert [source["title"] for source in second_seed.sources] == ["Wikipedia: Cached concept"]
+    assert sum("Special:EntityData" in url for url in calls) == 1
+    _fetch_wikidata_concept_seed_cached.cache_clear()
 
 
 def test_fetch_wikidata_seed_can_include_regional_wikipedia_sources(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
### Motivation
- Reduce repeated network/API work when resolving the same Wikidata Q-id multiple times during a single flow by caching resolved concept seeds in-memory.

### Description
- Add an LRU in-process cache around normalized lookups with `@lru_cache(maxsize=256)` in a new function `_fetch_wikidata_concept_seed_cached(qid, include_regional_wikis)` and route `fetch_wikidata_concept_seed` to use it via normalized Q-id.
- Add `_clone_wikidata_concept_seed(seed)` which returns a fresh `WikidataConceptSeed` with copied `sources` dictionaries so callers cannot mutate shared cached data.
- Import `lru_cache` from `functools` and update `src/storage/wikidata.py`; add a regression test `test_fetch_wikidata_seed_caches_repeated_qid_lookups` in `src/tests/storage/test_wikidata_concepts.py` to verify caching and mutation-safety.

### Testing
- Ran `PYTHONPATH=src python -m pytest src/tests/storage/test_wikidata_concepts.py -q` and all tests passed (19 passed, 1 skipped). 
- Ran `python -m black` on the modified files which reformatted the test file as expected. 
- Ran `PYTHONPATH=src python -m mypy` on the modified files and no type issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382673064c8327a01dd831e0adc48a)