### PR TITLE
Voverukas: concept-crawl ranker + shared Q-id concept service

### DIFF
--- a/src/agents/STYLE.md
+++ b/src/agents/STYLE.md
@@ -289,6 +289,7 @@ if __name__ == '__main__':
 | **Žvirblis** | Sparrow | Example sentence generator with automatic difficulty calculation |
 | **Povas** | Peacock | HTML report generator (POS subtype pages with comprehensive data) |
 | **Vovere** | Squirrel | Concept entry generator (fetches source pages, writes encyclopedia bodies) |
+| **Voverukas** | Little squirrel | Concept crawl ranker (read-only): ranks wanted "red-link" topics by importance over the concept link-graph to prioritise what to create next |
 
 ### Export & Integration
 

--- a/src/agents/voverukas.py
+++ b/src/agents/voverukas.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Voverukas - Concept crawl ranker ("powering the crawl").
+
+"Voverukas" means "little squirrel" in Lithuanian: it scampers across the
+concept link-graph and decides which acorns to bury next. It complements
+**Vovere** (the concept *generator*): Voverukas only ranks and reports, it
+never creates or modifies concepts.
+
+The agent runs the Voverukas ranking algorithm (a typed port of slmt's
+"Powerrank") over every existing concept body, then surfaces the highest-ranked
+"red links" -- ``[[wiki links]]`` whose target has no concept yet. That ranked
+list is the worklist for which missing topics to create next: a red link cited
+by many high-importance concepts ranks above one cited by a single obscure
+concept.
+
+This agent is READ-ONLY. It computes the ranking on the fly each run; nothing is
+persisted.
+
+Usage:
+    PYTHONPATH=src python src/agents/voverukas.py --limit 30
+    PYTHONPATH=src python src/agents/voverukas.py --limit 50 --iterations 6 --debug
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Add src directory to path
+GREENLAND_SRC_PATH = str(Path(__file__).parent.parent)
+if GREENLAND_SRC_PATH not in sys.path:
+    sys.path.insert(0, GREENLAND_SRC_PATH)
+
+from agents.common.common_args import (
+    add_backend_args,
+    add_common_args,
+    add_llm_args,
+    get_data_source_config,
+)
+from storage.backend import create_session as create_backend_session
+from storage.backend.config import DataSourceConfig
+from storage.concept_service import create_concept_from_qid
+from storage.crud.concept import cache_wikidata_title
+from storage.models.concept import Concept, concept_slug_to_title
+from storage.wikidata import resolve_titles_to_qids
+from wordfreq.voverukas import (
+    DEFAULT_DAMPING,
+    DEFAULT_ITERATIONS,
+    build_link_graph,
+    compute_ranks,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class VoverukasAgent:
+    """Read-only agent that ranks wanted (red-link) concept topics."""
+
+    def __init__(self, config: DataSourceConfig) -> None:
+        """Initialize the agent.
+
+        Args:
+            config: DataSourceConfig with backend and debug settings.
+        """
+        self.config = config
+        self.debug = config.debug
+        if self.debug:
+            logger.setLevel(logging.DEBUG)
+
+    def rank_wanted(
+        self,
+        *,
+        limit: int = 50,
+        iterations: int = DEFAULT_ITERATIONS,
+        damping: float = DEFAULT_DAMPING,
+    ) -> List[Dict[str, object]]:
+        """Rank red-link targets by importance over the concept link-graph.
+
+        Args:
+            limit: Maximum number of wanted slugs to return.
+            iterations: Number of ranking dispersion passes.
+            damping: Fraction of a node's rank dispersed across its out-links.
+
+        Returns:
+            A list of ``{"slug", "title", "score", "inbound"}`` dicts for the
+            top wanted (missing) topics, ordered by descending score.
+        """
+        session = create_backend_session(self.config)
+        try:
+            bodies_by_slug: Dict[str, str] = {}
+            existing_slugs = set()
+            for slug, body in session.query(Concept.slug, Concept.body).all():
+                existing_slugs.add(slug)
+                bodies_by_slug[slug] = body or ""
+
+            logger.info("Loaded %d concepts", len(existing_slugs))
+
+            link_graph, inbound_counts = build_link_graph(bodies_by_slug)
+            ranks = compute_ranks(
+                link_graph,
+                existing_slugs,
+                iterations=iterations,
+                damping=damping,
+            )
+
+            # Keep only targets that are linked-to but have no concept yet.
+            wanted: List[Dict[str, object]] = []
+            for slug, score in ranks.top(n=len(ranks.scores)):
+                if slug in existing_slugs:
+                    continue
+                wanted.append(
+                    {
+                        "slug": slug,
+                        "title": concept_slug_to_title(slug),
+                        "score": round(score, 4),
+                        "inbound": inbound_counts.get(slug, 0),
+                    }
+                )
+                if len(wanted) >= limit:
+                    break
+            return wanted
+        finally:
+            session.close()
+
+    def _make_body_generator(self) -> Any:
+        """Return a (title, summary, sources) -> body callable backed by Vovere.
+
+        Imported lazily so ranking-only runs do not require the LLM client.
+        """
+        from agents.vovere import VovereAgent
+
+        agent = VovereAgent(self.config)
+
+        def generate(title: str, summary: str, sources: List[Dict[str, Any]]) -> str:
+            return agent.generate_body(title, summary, sources)
+
+        return generate
+
+    def resolve_and_create(
+        self,
+        wanted: List[Dict[str, object]],
+        *,
+        create: bool,
+        generate_body: bool,
+    ) -> List[Dict[str, object]]:
+        """Resolve ranked red-link titles to Q-ids (cached) and optionally create.
+
+        Resolution uses a single batched Wikipedia API request for all titles.
+        Every resolved Q-id is cached in ``concept_wikidata_index`` (title only,
+        no concept yet). When ``create`` is set, each resolved Q-id is run
+        through the shared concept-creation service.
+
+        Args:
+            wanted: Ranked wanted items from :meth:`rank_wanted`.
+            create: If True, create a concept for each resolved Q-id.
+            generate_body: If True (and creating), generate a Markdown body via
+                Vovere; otherwise concepts are saved with sources but no body.
+
+        Returns:
+            ``wanted`` augmented in place with ``qid`` and (when creating)
+            ``status``/``detail`` fields.
+        """
+        titles = [str(item["title"]) for item in wanted]
+        qid_map = resolve_titles_to_qids(titles)
+
+        body_generator = None
+        if create and generate_body:
+            body_generator = self._make_body_generator()
+
+        session = create_backend_session(self.config)
+        try:
+            for item in wanted:
+                qid = qid_map.get(str(item["title"]))
+                item["qid"] = qid or ""
+                if not qid:
+                    if create:
+                        item["status"] = "unresolved"
+                    continue
+                # Cache the qid<->title mapping regardless of creation.
+                cache_wikidata_title(session, qid, str(item["title"]))
+                if not create:
+                    continue
+                result = create_concept_from_qid(
+                    session,
+                    qid,
+                    body_generator=body_generator,
+                    source_model=self.config.model if body_generator else None,
+                )
+                item["status"] = result.status
+                item["detail"] = result.detail
+                logger.info(
+                    "%s [%s] %s%s",
+                    result.status.upper(),
+                    qid,
+                    item["title"],
+                    f" - {result.detail}" if result.detail else "",
+                )
+            return wanted
+        finally:
+            session.close()
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Voverukas - rank wanted (red-link) concept topics (read-only)"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of ranked wanted topics to show (default: 50)",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=DEFAULT_ITERATIONS,
+        help=f"Number of ranking dispersion passes (default: {DEFAULT_ITERATIONS})",
+    )
+    parser.add_argument(
+        "--damping",
+        type=float,
+        default=DEFAULT_DAMPING,
+        help=f"Rank dispersed across out-links per pass (default: {DEFAULT_DAMPING})",
+    )
+    parser.add_argument(
+        "--resolve-qids",
+        action="store_true",
+        help="Batch-resolve ranked titles to Wikidata Q-ids and cache them (read-only).",
+    )
+    parser.add_argument(
+        "--create",
+        action="store_true",
+        help="Create a concept for each resolved Q-id (implies --resolve-qids).",
+    )
+    parser.add_argument(
+        "--no-body",
+        action="store_true",
+        help="With --create, save concepts without generating an LLM body.",
+    )
+    add_common_args(parser)
+    add_backend_args(parser)
+    add_llm_args(parser)
+
+    args = parser.parse_args()
+    config = get_data_source_config(args)
+
+    agent = VoverukasAgent(config)
+    wanted = agent.rank_wanted(
+        limit=args.limit,
+        iterations=args.iterations,
+        damping=args.damping,
+    )
+
+    if not wanted:
+        logger.info("No wanted (red-link) topics found.")
+        return 0
+
+    if args.resolve_qids or args.create:
+        if args.create and not args.yes:
+            generate_note = "without bodies" if args.no_body else "with generated bodies"
+            confirm = input(f"Create up to {len(wanted)} concepts {generate_note}? [y/N]: ")
+            if confirm.strip().lower() != "y":
+                logger.info("Aborted.")
+                return 0
+        wanted = agent.resolve_and_create(
+            wanted,
+            create=args.create,
+            generate_body=not args.no_body,
+        )
+
+    show_qid = "qid" in wanted[0]
+    show_status = "status" in wanted[0]
+    header = f"{'#':>4}  {'score':>10}  {'inbound':>7}"
+    if show_qid:
+        header += f"  {'Q-id':>9}"
+    if show_status:
+        header += f"  {'status':>10}"
+    header += "  topic"
+    print(f"\nTop {len(wanted)} wanted concept topics (by Voverukas rank):\n")
+    print(header)
+    for index, item in enumerate(wanted, 1):
+        row = f"{index:>4}  {item['score']:>10}  {item['inbound']:>7}"
+        if show_qid:
+            row += f"  {str(item.get('qid') or '—'):>9}"
+        if show_status:
+            row += f"  {str(item.get('status') or '—'):>10}"
+        row += f"  {item['title']}"
+        print(row)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -10,7 +10,7 @@ may contain ``[[wiki links]]`` to other concepts.
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, cast
 from urllib.parse import urlparse
 
 import constants
@@ -29,12 +29,11 @@ from flask.typing import ResponseReturnValue
 
 from barsukas.helpers.wikilinks import get_existing_link_targets, render_concept_body
 from storage.backend.config import DataSourceConfig
+from storage.concept_service import create_concept_from_qid
 from storage.crud.concept import (
     create_concept,
     delete_concept,
     get_concept_by_slug,
-    get_wikidata_index,
-    link_wikidata_concept,
     update_concept,
 )
 from storage.models.concept import (
@@ -144,11 +143,20 @@ def _generate_body(title: str, summary: str, sources: List[Dict[str, Any]], mode
 
     Imported lazily so the route module stays importable without LLM clients.
     """
+    return _body_generator_for_model(model)(title, summary, sources)
+
+
+def _body_generator_for_model(model: str) -> Callable[[str, str, List[Dict[str, Any]]], str]:
+    """Return a (title, summary, sources) -> body callable backed by Vovere."""
     from agents.vovere import VovereAgent
 
     config = _get_config().with_model(model)
     agent = VovereAgent(config)
-    return agent.generate_body(title, summary, sources)
+
+    def generate(title: str, summary: str, sources: List[Dict[str, Any]]) -> str:
+        return agent.generate_body(title, summary, sources)
+
+    return generate
 
 
 @bp.route("/")
@@ -215,35 +223,49 @@ def create() -> ResponseReturnValue:
     summary = request.form.get("summary", "").strip()
     sources = _parse_sources_form(request.form.get("sources", ""))
     model = request.form.get("model", "").strip() or constants.DEFAULT_MODEL
+    include_regional_wikis = request.form.get("include_regional_wikis") == "1"
 
-    if wikidata_qid is None:
-        flash(
-            "Creating a concept without a Wikidata Q-id; please add one later if a good match exists.",
-            "warning",
+    # Q-id-seeded creation goes through the shared concept-creation service so
+    # Barsukas and bulk agents (voverukas) use one implementation.
+    if wikidata_qid is not None:
+        body_generator = None
+        if _outbound_allowed():
+            body_generator = _body_generator_for_model(model)
+        else:
+            flash("Outbound calls are disabled; saved without a generated body.", "warning")
+
+        result = create_concept_from_qid(
+            _concept_session(),
+            wikidata_qid,
+            body_generator=body_generator,
+            source_model=model if body_generator else None,
+            include_regional_wikis=include_regional_wikis,
         )
-    else:
-        existing_index = get_wikidata_index(_concept_session(), wikidata_qid)
-        if existing_index is not None and existing_index.concept is not None:
+        if result.status == "exists" and result.concept is not None:
             flash(
-                f"Wikidata ID {wikidata_qid} is already linked to {existing_index.concept.title!r}.",
+                f"Wikidata ID {wikidata_qid} is already linked to {result.concept.title!r}.",
                 "error",
             )
-            return redirect(url_for("concepts.detail", slug=existing_index.concept.slug))
-        include_regional_wikis = request.form.get("include_regional_wikis") == "1"
-        seed = fetch_wikidata_concept_seed(
-            wikidata_qid, include_regional_wikis=include_regional_wikis
-        )
-        if seed is None:
+            return redirect(url_for("concepts.detail", slug=result.concept.slug))
+        if result.status == "unresolved":
             flash(f"Could not resolve Wikidata ID {wikidata_qid}.", "error")
             return redirect(url_for("concepts.new_concept"))
-        title = title or seed.title
-        summary = summary or seed.summary
-        sources = _merge_sources(sources, seed.sources)
+        if result.concept is None:
+            flash("Failed to create the concept.", "error")
+            return redirect(url_for("concepts.new_concept"))
+        if result.detail.startswith("saved without body"):
+            flash(f"Saved the page, but body generation failed: {result.detail}", "warning")
+        flash(f"Created concept {result.concept.title!r}.", "success")
+        return redirect(url_for("concepts.detail", slug=result.concept.slug))
 
+    # Manual (no Q-id) creation: keep the inline path.
+    flash(
+        "Creating a concept without a Wikidata Q-id; please add one later if a good match exists.",
+        "warning",
+    )
     if not title:
         flash("A title or Wikidata Q-id is required.", "error")
         return redirect(url_for("concepts.new_concept"))
-
     if get_concept_by_slug(_concept_session(), title) is not None:
         flash(f"A concept titled {title!r} already exists.", "error")
         return redirect(url_for("concepts.new_concept"))
@@ -271,9 +293,6 @@ def create() -> ResponseReturnValue:
     if concept is None:
         flash("Failed to create the concept.", "error")
         return redirect(url_for("concepts.new_concept"))
-
-    if wikidata_qid is not None:
-        link_wikidata_concept(_concept_session(), wikidata_qid, concept)
 
     flash(f"Created concept {concept.title!r}.", "success")
     return redirect(url_for("concepts.detail", slug=concept.slug))

--- a/src/storage/concept_service.py
+++ b/src/storage/concept_service.py
@@ -1,0 +1,155 @@
+"""Service helpers that orchestrate concept creation across storage + Wikidata.
+
+This sits above the thin CRUD layer (:mod:`storage.crud.concept`) and the
+Wikidata client (:mod:`storage.wikidata`). It owns the multi-step "create a
+concept from a Wikidata Q-id" flow so both the Barsukas route and bulk agents
+(e.g. ``voverukas``) share one implementation instead of duplicating it.
+
+Body generation is injected as a callable so this module stays decoupled from
+the LLM/agents layer: callers that can generate a body pass a ``body_generator``;
+callers that cannot (or run with outbound calls disabled) omit it and the
+concept is saved with an empty body.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from storage.crud.concept import (
+    create_concept,
+    get_concept_by_slug,
+    get_wikidata_index,
+    link_wikidata_concept,
+)
+from storage.models.concept import Concept
+from storage.wikidata import fetch_wikidata_concept_seed, normalize_qid
+
+logger = logging.getLogger(__name__)
+
+# A body generator takes (title, summary, sources) and returns Markdown.
+BodyGenerator = Callable[[str, str, List[Dict[str, Any]]], str]
+
+
+@dataclass(frozen=True)
+class ConceptCreationResult:
+    """Outcome of a single create-from-Q-id attempt."""
+
+    qid: str
+    title: str
+    concept: Optional[Concept]
+    status: str  # "created" | "exists" | "unresolved" | "failed"
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """True when a concept was newly created."""
+        return self.status == "created"
+
+
+def create_concept_from_qid(
+    session: Session,
+    qid: str,
+    *,
+    body_generator: Optional[BodyGenerator] = None,
+    source_model: Optional[str] = None,
+    include_regional_wikis: bool = False,
+) -> ConceptCreationResult:
+    """Create a concept from a Wikidata Q-id (seed -> body -> create -> link).
+
+    Idempotent: if the Q-id is already linked to a concept, or a concept with
+    the seeded title already exists, no new concept is created.
+
+    Args:
+        session: Database session.
+        qid: A Wikidata Q-id (any case; normalized).
+        body_generator: Optional callable that turns (title, summary, sources)
+            into a Markdown body. If omitted, the concept is saved with an empty
+            body (sources are still stored for later generation).
+        source_model: Name of the model used by ``body_generator``, recorded on
+            the concept when a body is successfully generated.
+        include_regional_wikis: Pass through to the Wikidata seed fetch.
+
+    Returns:
+        A :class:`ConceptCreationResult` describing the outcome.
+    """
+    normalized_qid = normalize_qid(qid)
+    if normalized_qid is None:
+        return ConceptCreationResult(
+            qid=qid, title="", concept=None, status="failed", detail="invalid Q-id"
+        )
+
+    existing_index = get_wikidata_index(session, normalized_qid)
+    if existing_index is not None and existing_index.concept is not None:
+        concept = existing_index.concept
+        return ConceptCreationResult(
+            qid=normalized_qid,
+            title=concept.title,
+            concept=concept,
+            status="exists",
+            detail=f"already linked to {concept.slug!r}",
+        )
+
+    seed = fetch_wikidata_concept_seed(
+        normalized_qid, include_regional_wikis=include_regional_wikis
+    )
+    if seed is None:
+        return ConceptCreationResult(
+            qid=normalized_qid,
+            title="",
+            concept=None,
+            status="unresolved",
+            detail="Wikidata seed could not be resolved",
+        )
+
+    if get_concept_by_slug(session, seed.title) is not None:
+        return ConceptCreationResult(
+            qid=normalized_qid,
+            title=seed.title,
+            concept=None,
+            status="exists",
+            detail=f"a concept titled {seed.title!r} already exists",
+        )
+
+    body = ""
+    body_model: Optional[str] = None
+    return_detail = ""
+    if body_generator is not None:
+        try:
+            body = body_generator(seed.title, seed.summary, list(seed.sources))
+            body_model = source_model
+        except Exception as exc:  # generation failure must not lose the entry
+            logger.exception("Concept body generation failed for %s", normalized_qid)
+            body = ""
+            return_detail = f"saved without body: {exc}"
+    else:
+        return_detail = "no body generator supplied"
+
+    created = create_concept(
+        session,
+        title=seed.title,
+        summary=seed.summary,
+        body=body,
+        sources=list(seed.sources),
+        source_model=body_model,
+    )
+    if created is None:
+        return ConceptCreationResult(
+            qid=normalized_qid,
+            title=seed.title,
+            concept=None,
+            status="failed",
+            detail="create_concept returned None",
+        )
+
+    link_wikidata_concept(session, normalized_qid, created)
+    return ConceptCreationResult(
+        qid=normalized_qid,
+        title=created.title,
+        concept=created,
+        status="created",
+        detail=return_detail,
+    )

--- a/src/storage/crud/concept.py
+++ b/src/storage/crud/concept.py
@@ -76,6 +76,45 @@ def link_wikidata_concept(
         return None
 
 
+def cache_wikidata_title(session: Session, qid: str, title: str) -> Optional[ConceptWikidataIndex]:
+    """Cache a Q-id and its remote Wikipedia title in the reverse index.
+
+    Used for Q-ids that are known but have no concept yet (``concept_id`` stays
+    NULL), e.g. ranked "wanted" red links resolved from titles. Existing rows
+    keep their ``concept_id``/``rejected`` state; only the ``title`` is filled
+    in (refreshed if a different title is supplied).
+
+    Args:
+        session: Database session.
+        qid: A Wikidata Q-id (any case; normalized).
+        title: The remote Wikipedia article title to cache.
+
+    Returns:
+        The cached/updated row, or None if the Q-id was invalid / the write
+        failed.
+    """
+    from storage.wikidata import normalize_qid
+
+    normalized_qid = normalize_qid(qid)
+    if normalized_qid is None:
+        return None
+    clean_title = title.strip()
+    if not clean_title:
+        return None
+    row = get_wikidata_index(session, normalized_qid)
+    if row is None:
+        row = ConceptWikidataIndex(qid=normalized_qid)
+        session.add(row)
+    row.title = clean_title
+    try:
+        session.commit()
+        return row
+    except IntegrityError as error:
+        session.rollback()
+        logger.warning("Failed to cache Wikidata title for %s: %s", normalized_qid, error)
+        return None
+
+
 def get_concept_by_slug(session: Session, slug: str) -> Optional[Concept]:
     """Look up a concept by slug, normalizing space/underscore equivalence.
 

--- a/src/storage/migrations/add_concept_wikidata_index_title.py
+++ b/src/storage/migrations/add_concept_wikidata_index_title.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Migration: Add a ``title`` column to ``concept_wikidata_index``.
+
+The Wikidata reverse index originally tracked only ``qid -> concept_id``. We now
+also cache the remote Wikipedia article title for Q-ids that have no concept yet
+(e.g. ranked "wanted" red links resolved from titles). This migration adds a
+nullable ``title`` column. It is idempotent and backend-agnostic.
+
+Usage:
+    PYTHONPATH=src python src/storage/migrations/add_concept_wikidata_index_title.py
+    PYTHONPATH=src python src/storage/migrations/add_concept_wikidata_index_title.py --postgres
+    PYTHONPATH=src python src/storage/migrations/add_concept_wikidata_index_title.py --dry-run
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Add src to path
+if str(Path(__file__).parent.parent.parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from sqlalchemy import inspect, text
+
+from constants import WORDFREQ_DB_PATH
+from storage.backend import create_session
+from storage.backend.config import BackendType, DataSourceConfig
+from storage.models.concept import ConceptWikidataIndex
+
+
+def build_data_source_config(db_path: str, use_postgres: bool) -> DataSourceConfig:
+    """Build the storage config for this migration."""
+    if use_postgres:
+        return DataSourceConfig(
+            backend_type=BackendType.POSTGRES,
+            postgres_url=DataSourceConfig.build_postgres_url(),
+        )
+    return DataSourceConfig(
+        backend_type=BackendType.SQLITE,
+        sqlite_path=db_path,
+    )
+
+
+def add_title_column(config: DataSourceConfig, *, dry_run: bool = False) -> bool:
+    """Add the ``title`` column to concept_wikidata_index if it is missing.
+
+    Args:
+        config: Storage configuration selecting the backend.
+        dry_run: If True, report what would happen without altering the table.
+
+    Returns:
+        True if the column was added (or would be), False if it already existed
+        or the table does not exist.
+    """
+    table_name = ConceptWikidataIndex.__tablename__
+    session = create_session(config)
+    try:
+        bind = session.get_bind()
+        inspector = inspect(bind)
+        if not inspector.has_table(table_name):
+            print(f"Table '{table_name}' does not exist; nothing to do.")
+            return False
+
+        columns = {col["name"] for col in inspector.get_columns(table_name)}
+        if "title" in columns:
+            print(f"Column '{table_name}.title' already exists; nothing to do.")
+            return False
+
+        if dry_run:
+            print(f"Would add column '{table_name}.title' (VARCHAR, nullable).")
+            return True
+
+        print(f"Adding column '{table_name}.title'...")
+        session.execute(text(f"ALTER TABLE {table_name} ADD COLUMN title VARCHAR"))
+        session.commit()
+        print("Column added successfully.")
+        return True
+    finally:
+        session.close()
+
+
+def main() -> int:
+    """Run the migration."""
+    parser = argparse.ArgumentParser(description="Add a title column to concept_wikidata_index")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=WORDFREQ_DB_PATH,
+        help=f"Path to SQLite database (default: {WORDFREQ_DB_PATH})",
+    )
+    parser.add_argument(
+        "--postgres",
+        action="store_true",
+        help="Use PostgreSQL instead of SQLite",
+    )
+    args = parser.parse_args()
+
+    config = build_data_source_config(args.db_path, args.postgres)
+    database_label = config.postgres_url if args.postgres else config.sqlite_path
+
+    print(f"Database: {database_label}")
+    print(f"Backend: {config.backend_type.value}")
+    print(f"Dry run: {args.dry_run}")
+    print()
+
+    add_title_column(config, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/storage/models/concept.py
+++ b/src/storage/models/concept.py
@@ -176,6 +176,11 @@ class ConceptWikidataIndex(Base):
     concept_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("concepts.id"), nullable=True, index=True
     )
+    # Remote Wikipedia article title for this Q-id. Cached when a Q-id is known
+    # but no concept exists yet (concept_id NULL), e.g. ranked "wanted" red links
+    # resolved by storage.wikidata.resolve_titles_to_qids. Just the title string,
+    # not the full Wikidata entity payload.
+    title: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     rejected: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     added_at: Mapped[datetime.datetime] = mapped_column(TIMESTAMP, server_default=func.now())

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -264,6 +264,95 @@ def normalize_qid(raw_qid: str) -> Optional[str]:
     return None
 
 
+# Wikipedia's query API accepts up to 50 titles per request for non-bot clients.
+MAX_TITLES_PER_QUERY = 50
+
+
+def resolve_titles_to_qids(
+    titles: Sequence[str], *, language_code: str = "en"
+) -> Dict[str, Optional[str]]:
+    """Resolve many Wikipedia article titles to Q-ids in batched API requests.
+
+    Uses the Wikipedia ``pageprops`` API (``wikibase_item``), which follows
+    redirects and accepts up to 50 titles per request, so a whole ranked
+    worklist resolves in one or two calls rather than one call per title. This
+    is the Text -> Q-id step that bridges plain topic titles (e.g.
+    ``"Lake Huron"``) into the Q-id-based concept-seeding flow
+    (:func:`fetch_wikidata_concept_seed`).
+
+    Args:
+        titles: Wikipedia article titles (spaces or underscores both work).
+        language_code: Wikipedia language edition to resolve against.
+
+    Returns:
+        A mapping from each input title (as given) to its canonical Q-id, or
+        None when the title has no article / no linked Wikidata item.
+    """
+    # Map the API's normalized/redirected title back to the caller's input.
+    clean_to_input: Dict[str, str] = {}
+    for title in titles:
+        clean_title = " ".join(title.replace("_", " ").split())
+        if clean_title:
+            clean_to_input.setdefault(clean_title, title)
+
+    results: Dict[str, Optional[str]] = {title: None for title in titles}
+    clean_titles = list(clean_to_input.keys())
+    for start in range(0, len(clean_titles), MAX_TITLES_PER_QUERY):
+        batch = clean_titles[start : start + MAX_TITLES_PER_QUERY]
+        params = {
+            "action": "query",
+            "prop": "pageprops",
+            "ppprop": "wikibase_item",
+            "redirects": "1",
+            "titles": "|".join(batch),
+            "format": "json",
+            "formatversion": "2",
+        }
+        payload = _get_json(
+            WIKIPEDIA_EXTRACT_URL.format(language_code=language_code), params=params
+        )
+        query = payload or {}
+        query = query.get("query", {}) if isinstance(query, dict) else {}
+
+        # Build a lookup from any title the API mentions (normalized + redirected
+        # forms both map back to a requested title) to the resolved page title.
+        alias_to_requested: Dict[str, str] = {clean: clean for clean in batch}
+        for entry in query.get("normalized", []):
+            if entry.get("from") in alias_to_requested or entry.get("from") in batch:
+                alias_to_requested[entry.get("to", "")] = alias_to_requested.get(
+                    entry.get("from", ""), entry.get("from", "")
+                )
+        for entry in query.get("redirects", []):
+            source = entry.get("from", "")
+            target = entry.get("to", "")
+            if source in alias_to_requested:
+                alias_to_requested[target] = alias_to_requested[source]
+
+        for page in query.get("pages", []):
+            if page.get("missing"):
+                continue
+            raw_qid = str(page.get("pageprops", {}).get("wikibase_item", "")).strip()
+            if not raw_qid:
+                continue
+            qid = normalize_qid(raw_qid)
+            requested_clean = alias_to_requested.get(str(page.get("title", "")))
+            if requested_clean is None:
+                continue
+            input_title = clean_to_input.get(requested_clean)
+            if input_title is not None:
+                results[input_title] = qid
+    return results
+
+
+def resolve_title_to_qid(title: str, *, language_code: str = "en") -> Optional[str]:
+    """Resolve a single Wikipedia article title to its Wikidata Q-id.
+
+    Thin wrapper over :func:`resolve_titles_to_qids` for one-off lookups; prefer
+    the batched form when resolving more than one title.
+    """
+    return resolve_titles_to_qids([title], language_code=language_code).get(title)
+
+
 def _retry_delay_seconds(response: requests.Response, attempt_index: int) -> float:
     """Return a short retry delay for rate-limited Wikimedia responses."""
     retry_after = response.headers.get("Retry-After", "").strip()

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -24,7 +24,11 @@ WIKIPEDIA_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/{titl
 WIKIPEDIA_EXTRACT_URL = "https://{language_code}.wikipedia.org/w/api.php"
 WIKISOURCE_SEARCH_URL = "https://en.wikisource.org/w/api.php"
 DEFAULT_TIMEOUT_SECONDS = 10
-MAX_HTTP_ATTEMPTS = 3
+# 429 (rate limit) and 503-with-maxlag are transient Wikimedia conditions worth
+# waiting out, so allow several attempts with a longer backoff cap than a normal
+# request would use.
+MAX_HTTP_ATTEMPTS = 5
+MAX_RETRY_DELAY_SECONDS = 30.0
 DEFAULT_USER_AGENT = os.environ.get(
     "GREENLAND_HTTP_USER_AGENT",
     "Greenland-Barsukas/1.0 (concept seeding; set GREENLAND_HTTP_USER_AGENT with contact)",
@@ -311,8 +315,17 @@ def resolve_titles_to_qids(
         payload = _get_json(
             WIKIPEDIA_EXTRACT_URL.format(language_code=language_code), params=params
         )
-        query = payload or {}
-        query = query.get("query", {}) if isinstance(query, dict) else {}
+        if payload is None:
+            # A None payload means the request failed (e.g. rate-limited after
+            # retries), not that the titles have no Q-id. Surface it so callers
+            # don't silently treat a transient failure as "unresolved".
+            logger.warning(
+                "Title->Q-id batch request failed for %d titles (left unresolved): %s",
+                len(batch),
+                ", ".join(batch[:5]) + ("..." if len(batch) > 5 else ""),
+            )
+            continue
+        query = payload.get("query", {}) if isinstance(payload, dict) else {}
 
         # Build a lookup from any title the API mentions (normalized + redirected
         # forms both map back to a requested title) to the resolved page title.
@@ -354,12 +367,18 @@ def resolve_title_to_qid(title: str, *, language_code: str = "en") -> Optional[s
 
 
 def _retry_delay_seconds(response: requests.Response, attempt_index: int) -> float:
-    """Return a short retry delay for rate-limited Wikimedia responses."""
+    """Return a retry delay for rate-limited / lagged Wikimedia responses.
+
+    Honors the server's ``Retry-After`` header when present (this is what a
+    ``maxlag`` 429 sends), otherwise falls back to exponential backoff. Both are
+    capped at :data:`MAX_RETRY_DELAY_SECONDS` so a single stuck call cannot block
+    a batch indefinitely.
+    """
     retry_after = response.headers.get("Retry-After", "").strip()
     if retry_after.isdigit():
-        return min(float(retry_after), 5.0)
+        return min(float(retry_after), MAX_RETRY_DELAY_SECONDS)
     fallback_delay: float = 0.5 * float(2**attempt_index)
-    return min(fallback_delay, 5.0)
+    return min(fallback_delay, MAX_RETRY_DELAY_SECONDS)
 
 
 def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Any]]:

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -19,6 +19,7 @@ from storage.wikidata import (
     _strip_eb1911_sections_index,
     fetch_wikidata_concept_seed,
     normalize_qid,
+    resolve_titles_to_qids,
 )
 
 
@@ -500,3 +501,45 @@ def test_vovere_uses_provided_source_text(monkeypatch) -> None:  # type: ignore[
     assert len(messages) == 1
     assert "provided text" in messages[0]["content"]
     assert "fetched text" not in messages[0]["content"]
+
+
+def test_resolve_titles_to_qids_batches_and_maps_redirects(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    captured: Dict[str, Any] = {}
+
+    def fake_get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+        captured["params"] = params or {}
+        # "Lake Huron" resolves directly; "Mackinac" is a redirect to
+        # "Straits of Mackinac"; "Nowhere" is missing.
+        return {
+            "query": {
+                "redirects": [{"from": "Mackinac", "to": "Straits of Mackinac"}],
+                "pages": [
+                    {"title": "Lake Huron", "pageprops": {"wikibase_item": "Q1383"}},
+                    {
+                        "title": "Straits of Mackinac",
+                        "pageprops": {"wikibase_item": "Q1073685"},
+                    },
+                    {"title": "Nowhere", "missing": True},
+                ],
+            }
+        }
+
+    monkeypatch.setattr("storage.wikidata._get_json", fake_get_json)
+
+    result = resolve_titles_to_qids(["Lake_Huron", "Mackinac", "Nowhere"])
+
+    # All requested titles resolved in a single batched request.
+    assert "|" in str(captured["params"].get("titles", ""))
+    assert result["Lake_Huron"] == "Q1383"
+    assert result["Mackinac"] == "Q1073685"  # mapped back through the redirect
+    assert result["Nowhere"] is None
+
+
+def test_resolve_titles_to_qids_handles_failed_request(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # A None payload simulates a rate-limited request after retries are exhausted.
+    monkeypatch.setattr("storage.wikidata._get_json", lambda url, *, params=None: None)
+
+    result = resolve_titles_to_qids(["Lake Huron", "Michigan"])
+
+    # Titles are left unresolved (None) rather than crashing.
+    assert result == {"Lake Huron": None, "Michigan": None}

--- a/src/tests/wordfreq/test_voverukas.py
+++ b/src/tests/wordfreq/test_voverukas.py
@@ -1,0 +1,86 @@
+"""Tests for wordfreq.voverukas — the concept link-graph ranking algorithm
+(a typed port of slmt's "Powerrank")."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from wordfreq.voverukas import VoverukasRank, build_link_graph, compute_ranks
+
+
+def _rank_order(link_graph: Dict[str, List[str]], seeds: List[str]) -> List[str]:
+    """Return ranked slugs (descending) for a tiny graph, for readable asserts."""
+    ranks = compute_ranks(link_graph, seeds)
+    return [slug for slug, _score in ranks.top(n=len(ranks.scores))]
+
+
+def test_more_referenced_target_outranks_less_referenced() -> None:
+    """A red link cited by many seeds outranks one cited by few."""
+    # Three seed concepts all link to "Popular"; only one links to "Obscure".
+    link_graph = {
+        "A": ["Popular"],
+        "B": ["Popular"],
+        "C": ["Popular", "Obscure"],
+    }
+    ranks = compute_ranks(link_graph, ["A", "B", "C"])
+    assert ranks.get("Popular") > ranks.get("Obscure")
+
+
+def test_dead_end_node_does_not_crash() -> None:
+    """A node with no out-links disperses nothing and is handled gracefully."""
+    link_graph = {"A": ["B"]}  # "B" is a dead-end (never a key).
+    ranks = compute_ranks(link_graph, ["A"])
+    # B accumulated rank from A; running more iterations must not error.
+    assert ranks.get("B") > 0.0
+    more = compute_ranks(link_graph, ["A"], iterations=10)
+    assert more.get("B") > 0.0
+
+
+def test_self_link_folds_back_onto_node() -> None:
+    """An empty-string link target folds rank back onto the source node."""
+    # parse_wiki_links normalizes "#section" anchors to empty targets upstream;
+    # here we exercise the algorithm's self-link handling directly.
+    link_graph = {"A": [""]}
+    ranks = compute_ranks(link_graph, ["A"], iterations=2)
+    # All rank stays on A (retention + the self-directed share), nothing leaks.
+    assert set(ranks.slugs()) == {"A"}
+    assert ranks.get("A") > 0.0
+
+
+def test_top_is_descending_and_tie_broken_by_slug() -> None:
+    """top() sorts by score descending, ties broken alphabetically by slug."""
+    ranks = VoverukasRank()
+    ranks.add("zebra", 1.0)
+    ranks.add("apple", 1.0)
+    ranks.add("middle", 2.0)
+    assert ranks.top() == [("middle", 2.0), ("apple", 1.0), ("zebra", 1.0)]
+
+
+def test_build_link_graph_counts_distinct_inbound() -> None:
+    """build_link_graph parses bodies and counts distinct referencing concepts."""
+    bodies = {
+        "Alpha": "See [[Gamma]] and [[Gamma]] again.",  # duplicate -> still 1 inbound
+        "Beta": "Also [[Gamma]] and [[Delta]].",
+        "Empty": "",
+    }
+    link_graph, inbound = build_link_graph(bodies)
+    # Duplicates preserved in the edge list (weight), counted once for inbound.
+    assert link_graph["Alpha"] == ["Gamma", "Gamma"]
+    assert link_graph["Empty"] == []
+    assert inbound["Gamma"] == 2  # Alpha + Beta
+    assert inbound["Delta"] == 1  # Beta only
+
+
+def test_red_links_are_present_but_excluded_from_seeds() -> None:
+    """Targets absent from the seed set still receive rank (they are red links)."""
+    bodies = {
+        "Alpha": "Links to [[Wanted]].",
+        "Beta": "Also links to [[Wanted]].",
+    }
+    link_graph, _inbound = build_link_graph(bodies)
+    seeds = list(bodies.keys())
+    ranks = compute_ranks(link_graph, seeds)
+    # "Wanted" is not a seed/concept, but it is ranked.
+    assert "Wanted" in set(ranks.slugs())
+    assert "Wanted" not in seeds
+    assert ranks.get("Wanted") > 0.0

--- a/src/wordfreq/voverukas.py
+++ b/src/wordfreq/voverukas.py
@@ -1,0 +1,158 @@
+"""Voverukas ranking: a PageRank-variant over the concept wiki-link graph.
+
+This is a typed, in-memory port of the "Powerrank" algorithm from the slmt
+project. It ranks topics by importance: starting from a seed set of nodes with
+equal mass, it iteratively disperses each node's rank to the targets it links
+to, so a topic referenced by many high-importance topics accumulates a high
+score.
+
+In greenland-mint the nodes are :class:`~storage.models.concept.Concept` slugs
+and the edges are the ``[[wiki links]]`` inside concept bodies. Targets that are
+linked-to but have no concept yet ("red links" / wanted slugs) still receive
+rank, which lets callers prioritise *which* missing topics to create next.
+
+The module is pure: it performs no I/O and depends only on a link graph
+(``{source_slug -> [target_slug, ...]}``) supplied by the caller. Build that
+graph from concept bodies with
+:func:`~storage.models.concept.parse_wiki_links`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple
+
+# Defaults mirror the original slmt Powerrank tuning: each node retains a fifth
+# of its rank and disperses 85% across its out-links (the remainder is lost at
+# dead-ends, which is acceptable for a relative ranking).
+DEFAULT_ITERATIONS: int = 4
+DEFAULT_DAMPING: float = 0.85
+DEFAULT_RETENTION: float = 0.2
+DEFAULT_SEED_MASS: float = 1.0
+# Round dispersed rank like the original to keep float noise out of the scores.
+_RANK_PRECISION: int = 6
+
+
+class VoverukasRank:
+    """An accumulator of per-slug rank scores.
+
+    Replaces the file-backed ``PowerRankFile`` from slmt: scores live entirely
+    in memory because greenland-mint recomputes the ranking on demand rather
+    than persisting generations to disk.
+    """
+
+    def __init__(self) -> None:
+        self.scores: Dict[str, float] = {}
+
+    def add(self, slug: str, amount: float) -> None:
+        """Add ``amount`` to ``slug``'s running score (creating it if new)."""
+        self.scores[slug] = self.scores.get(slug, 0.0) + amount
+
+    def get(self, slug: str) -> float:
+        """Return the current score for ``slug`` (0.0 if absent)."""
+        return self.scores.get(slug, 0.0)
+
+    def slugs(self) -> Iterable[str]:
+        """Return an iterable over all scored slugs."""
+        return self.scores.keys()
+
+    def top(self, n: int = 1000) -> List[Tuple[str, float]]:
+        """Return the ``n`` highest-scoring ``(slug, score)`` pairs, descending.
+
+        Ties are broken by slug for a stable, reproducible ordering.
+        """
+        ranked = sorted(self.scores.items(), key=lambda item: (-item[1], item[0]))
+        return ranked[:n]
+
+
+def _disperse(
+    current: VoverukasRank,
+    link_graph: Mapping[str, Sequence[str]],
+    *,
+    damping: float,
+    retention: float,
+) -> VoverukasRank:
+    """Run a single dispersion pass, returning the next generation's ranks."""
+    nxt = VoverukasRank()
+    for slug, rank in current.scores.items():
+        if rank == 0.0:
+            continue
+        # A fraction of the rank always stays put.
+        nxt.add(slug, retention * rank)
+
+        links = list(link_graph.get(slug, ()))
+        if not links:
+            # Dead-end node: its dispersible share is simply lost.
+            continue
+
+        share = round(damping * rank / len(links), _RANK_PRECISION)
+        for target in links:
+            # A self-link folds back onto the node itself.
+            nxt.add(target if target else slug, share)
+    return nxt
+
+
+def compute_ranks(
+    link_graph: Mapping[str, Sequence[str]],
+    seeds: Iterable[str],
+    *,
+    iterations: int = DEFAULT_ITERATIONS,
+    damping: float = DEFAULT_DAMPING,
+    retention: float = DEFAULT_RETENTION,
+    seed_mass: float = DEFAULT_SEED_MASS,
+) -> VoverukasRank:
+    """Rank nodes by importance over a wiki-link graph.
+
+    Args:
+        link_graph: Mapping of source slug to the slugs it links to. Slugs that
+            never appear as a key are treated as dead-ends (they accumulate
+            rank but disperse none).
+        seeds: The starting node set, each given equal ``seed_mass``. In
+            greenland-mint this is the set of existing concept slugs.
+        iterations: Number of dispersion passes to run.
+        damping: Fraction of a node's rank dispersed across its out-links.
+        retention: Fraction of a node's rank that stays on the node.
+        seed_mass: Initial score assigned to every seed node.
+
+    Returns:
+        A :class:`VoverukasRank` with the final scores. Both seed nodes and any
+        linked-to targets (including red links absent from ``seeds``) are
+        present.
+    """
+    ranks = VoverukasRank()
+    for seed in seeds:
+        ranks.add(seed, seed_mass)
+
+    for _ in range(max(0, iterations)):
+        ranks = _disperse(ranks, link_graph, damping=damping, retention=retention)
+
+    return ranks
+
+
+def build_link_graph(
+    bodies_by_slug: Mapping[str, str],
+) -> Tuple[Dict[str, List[str]], Dict[str, int]]:
+    """Build a link graph and inbound-link counts from concept bodies.
+
+    Args:
+        bodies_by_slug: Mapping of concept slug to its body text (Markdown with
+            ``[[wiki links]]``). A ``None``/empty body contributes no edges.
+
+    Returns:
+        A tuple ``(link_graph, inbound_counts)`` where ``link_graph`` maps each
+        source slug to its list of target slugs (in order of appearance, with
+        duplicates preserved so multiple references weight more), and
+        ``inbound_counts`` maps each target slug to the number of distinct
+        concepts that link to it.
+    """
+    # Imported here to keep the algorithm core import-light and dependency-free
+    # for callers that already hold a precomputed graph.
+    from storage.models.concept import parse_wiki_links
+
+    link_graph: Dict[str, List[str]] = {}
+    inbound_counts: Dict[str, int] = {}
+    for slug, body in bodies_by_slug.items():
+        targets = [link.target_slug for link in parse_wiki_links(body or "") if link.target_slug]
+        link_graph[slug] = targets
+        for target in set(targets):
+            inbound_counts[target] = inbound_counts.get(target, 0) + 1
+    return link_graph, inbound_counts


### PR DESCRIPTION
## Summary

PageRank-variant, the **voverukas** algorithm + agent, to *power the concept crawl*: rank which missing "red-link" topics matter most, resolve them to Wikidata Q-ids, and (optionally) create concepts — closing the loop from ranked topic → live concept.

A red link cited by many high-importance concepts ranks above one cited by a single obscure concept (transitive importance over the concept link-graph, computed on the fly each run).

## What's included

- **`src/wordfreq/voverukas.py`** — in-memory ranking algorithm (`VoverukasRank`, `compute_ranks`, `build_link_graph`). Pure, fully typed, no I/O.
- **`src/agents/voverukas.py`** — read-only ranking agent. `--resolve-qids` batch-resolves ranked titles to Q-ids (single API request) and caches them; `--create` creates a concept per resolved Q-id via the shared service.
- **`src/storage/concept_service.py`** — `create_concept_from_qid()` owns the seed → body → create → link flow so Barsukas and voverukas share one implementation. Body generation injected as a callable to keep storage decoupled from the LLM/agents layer.
- **`src/storage/wikidata.py`** — `resolve_titles_to_qids()` (batched, ≤50 titles/request via `pageprops`, follows redirects). Also hardens Wikimedia 429/maxlag retries (honor `Retry-After`, 5 attempts, 30s cap).
- **`ConceptWikidataIndex.title`** column + migration — cache remote Wikipedia titles for Q-ids with no concept yet (`concept_id` NULL).
- **`storage/crud/concept.py`** — `cache_wikidata_title()` upsert helper.
- **`barsukas/routes/concepts.py`** — Q-id create path now goes through the shared service.

## Verification

- Unit tests: ranking algorithm (6) + batched resolver incl. redirect mapping and rate-limited path (2). All green.
- Live end-to-end against Postgres: ranking, batched Q-id resolution, cache population, and concept creation all confirmed working.