### PR TITLE
Route Wikipedia source URLs through the parse-API codepath in vovere

### DIFF
--- a/src/agents/vovere/vovere.py
+++ b/src/agents/vovere/vovere.py
@@ -113,12 +113,27 @@ class VovereAgent:
     def fetch_source_text(self, url: str) -> str:
         """Fetch a URL and return its extracted text, capped to web-page length.
 
+        Wikipedia article URLs are routed through the dedicated parse-API
+        codepath (:func:`storage.wikidata.fetch_wikipedia_source_from_url`),
+        which extracts the article body and preserves internal links as
+        ``[[wiki link]]`` markers. Generic ``urllib`` + BeautifulSoup scraping
+        of a rendered Wikipedia page only yields page chrome ("Jump to
+        content"), so the URL alone is not enough.
+
         Args:
             url: The source URL to fetch.
 
         Returns:
             Extracted plain text (possibly empty if the fetch failed).
         """
+        from storage.wikidata import fetch_wikipedia_source_from_url
+
+        wikipedia_source = fetch_wikipedia_source_from_url(url)
+        if wikipedia_source is not None:
+            wikipedia_text = str(wikipedia_source.get("text", "")).strip()
+            if wikipedia_text:
+                return wikipedia_text[:PER_SOURCE_CHAR_LIMIT]
+
         request = urllib.request.Request(url, headers={"User-Agent": DEFAULT_USER_AGENT})
         try:
             with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT_SECONDS) as response:

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -9,8 +9,8 @@ import re
 import time
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, Sequence
-from urllib.parse import quote, unquote
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+from urllib.parse import quote, unquote, urlparse
 
 import requests
 
@@ -521,6 +521,49 @@ def _fetch_wikipedia_source(
         "note": note,
         "text": extract[:MAX_SOURCE_TEXT_CHARS],
     }
+
+
+def parse_wikipedia_article_url(url: str) -> Optional[Tuple[str, str]]:
+    """Return ``(language_code, page_title)`` for a Wikipedia article URL, else None.
+
+    Recognizes ``https://<lang>.wikipedia.org/wiki/<Title>`` URLs (and the
+    ``m.wikipedia.org`` mobile variant). Non-article paths (``/w/``, special
+    namespaces such as ``Special:`` or ``File:``) return None so callers fall
+    back to generic fetching.
+    """
+    parsed_url = urlparse(url)
+    host = parsed_url.netloc.casefold()
+    if not host.endswith("wikipedia.org"):
+        return None
+    language_code = host.split(".", 1)[0]
+    if language_code.endswith(".m") or host.startswith("m."):
+        language_code = language_code.removesuffix(".m") or "en"
+    if not language_code or language_code in ("www", "m"):
+        return None
+    prefix = "/wiki/"
+    if not parsed_url.path.startswith(prefix):
+        return None
+    page_title = unquote(parsed_url.path[len(prefix) :]).replace("_", " ").strip()
+    if not page_title:
+        return None
+    # Skip non-article namespaces (Special:, File:, Category:, Help:, etc.).
+    if ":" in page_title and page_title.split(":", 1)[0].lower() not in ("", "list of"):
+        return None
+    return language_code, page_title
+
+
+def fetch_wikipedia_source_from_url(url: str) -> Optional[Dict[str, Any]]:
+    """Fetch a Wikipedia article URL via the parse API, preserving wiki links.
+
+    Returns a source dict (``url``, ``title``, ``note``, ``text``) when ``url``
+    is a recognizable Wikipedia article URL and the article could be fetched;
+    otherwise None so callers can fall back to a generic HTML fetch.
+    """
+    parsed = parse_wikipedia_article_url(url)
+    if parsed is None:
+        return None
+    language_code, page_title = parsed
+    return _fetch_wikipedia_source(page_title, language_code=language_code)
 
 
 def _extract_eb1911_page_qids(entity: Dict[str, Any]) -> List[str]:

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -18,6 +18,7 @@ from storage.wikidata import (
     _limit_eb1911_extract,
     _strip_eb1911_sections_index,
     fetch_wikidata_concept_seed,
+    parse_wikipedia_article_url,
     normalize_qid,
     resolve_titles_to_qids,
 )
@@ -501,6 +502,50 @@ def test_vovere_uses_provided_source_text(monkeypatch) -> None:  # type: ignore[
     assert len(messages) == 1
     assert "provided text" in messages[0]["content"]
     assert "fetched text" not in messages[0]["content"]
+
+
+def test_parse_wikipedia_article_url_recognizes_articles() -> None:
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/wiki/Oprah_Winfrey") == (
+        "en",
+        "Oprah Winfrey",
+    )
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/wiki/Oprah_Winfrey#Career") == (
+        "en",
+        "Oprah Winfrey",
+    )
+    assert parse_wikipedia_article_url("https://de.wikipedia.org/wiki/Kunst") == ("de", "Kunst")
+    assert parse_wikipedia_article_url("https://en.m.wikipedia.org/wiki/Cat") == ("en", "Cat")
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/wiki/List_of_cats") == (
+        "en",
+        "List of cats",
+    )
+
+
+def test_parse_wikipedia_article_url_rejects_non_articles() -> None:
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/wiki/Special:Random") is None
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/wiki/File:Foo.jpg") is None
+    assert parse_wikipedia_article_url("https://en.wikipedia.org/w/index.php?title=Cat") is None
+    assert parse_wikipedia_article_url("https://www.example.com/art-deco") is None
+    assert parse_wikipedia_article_url("https://www.wikidata.org/wiki/Q12345") is None
+
+
+def test_vovere_fetch_source_text_routes_wikipedia_through_parse_api(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    agent = VovereAgent.__new__(VovereAgent)
+
+    def fake_wikipedia_source(url: str) -> Optional[Dict[str, Any]]:
+        assert url == "https://en.wikipedia.org/wiki/Oprah_Winfrey"
+        return {"text": "Oprah Winfrey is a media executive. See [[Chicago]]."}
+
+    def fail_urlopen(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("generic fetch must not run for Wikipedia URLs")
+
+    monkeypatch.setattr("storage.wikidata.fetch_wikipedia_source_from_url", fake_wikipedia_source)
+    monkeypatch.setattr("urllib.request.urlopen", fail_urlopen)
+
+    text = agent.fetch_source_text("https://en.wikipedia.org/wiki/Oprah_Winfrey")
+
+    assert "Oprah Winfrey is a media executive." in text
+    assert "[[Chicago]]" in text
 
 
 def test_resolve_titles_to_qids_batches_and_maps_redirects(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
Generic urllib + BeautifulSoup scraping of a rendered Wikipedia page only yields page chrome ("Jump to content"), so concept bodies generated from a Wikipedia URL had no wiki links. Detect Wikipedia article URLs and fetch them via the dedicated action=parse codepath, which extracts the article body and preserves internal links as [[wiki link]] markers.

Add parse_wikipedia_article_url() and fetch_wikipedia_source_from_url() in storage/wikidata.py; VovereAgent.fetch_source_text() tries the Wikipedia path first and falls back to the generic fetch for non-Wikipedia URLs.