### PR TITLE
Pace Wikimedia requests per host and seed concepts from de/fr wikis

### DIFF
--- a/src/agents/vovere/voveraite.py
+++ b/src/agents/vovere/voveraite.py
@@ -113,6 +113,7 @@ class VoveraiteAgent:
                     raw_qid,
                     body_generator=body_generator,
                     source_model=self.config.model if body_generator else None,
+                    include_regional_wikis=True,
                 )
                 results.append(
                     {
@@ -166,7 +167,7 @@ class VoveraiteAgent:
                     skipped += 1
                     continue
 
-                seed = fetch_wikidata_concept_seed(qid)
+                seed = fetch_wikidata_concept_seed(qid, include_regional_wikis=True)
                 if seed is None:
                     logger.info("SKIP (no seed) [%s]", qid)
                     skipped += 1

--- a/src/agents/vovere/voverukas.py
+++ b/src/agents/vovere/voverukas.py
@@ -209,6 +209,7 @@ class VoverukasAgent:
                     qid,
                     body_generator=body_generator,
                     source_model=self.config.model if body_generator else None,
+                    include_regional_wikis=True,
                 )
                 item["status"] = result.status
                 item["detail"] = result.detail
@@ -285,7 +286,7 @@ class VoverukasAgent:
                 # Cache the qid<->title mapping regardless of batch success.
                 cache_wikidata_title(session, qid, title)
 
-                seed = fetch_wikidata_concept_seed(qid)
+                seed = fetch_wikidata_concept_seed(qid, include_regional_wikis=True)
                 if seed is None:
                     logger.info("SKIP (no seed) [%s] %s", qid, title)
                     skipped += 1

--- a/src/clients/http_rate_limits.py
+++ b/src/clients/http_rate_limits.py
@@ -1,0 +1,41 @@
+"""Per-host minimum-interval rate limits for outbound HTTP requests.
+
+Wikimedia enforces a per-clock-minute request quota: bursting a handful of
+requests trips a ~60s cooldown. To stay under it, outbound GETs are paced to a
+minimum interval *per host*. This module owns the per-host data; the default
+fallback for unlisted hosts lives in :data:`constants.DEFAULT_HTTP_MIN_INTERVAL_SECONDS`.
+
+A value of ``0`` disables pacing for that host.
+"""
+
+from typing import Dict
+from urllib.parse import urlparse
+
+import constants
+
+# Minimum seconds between requests to each host. Hosts not listed here fall back
+# to constants.DEFAULT_HTTP_MIN_INTERVAL_SECONDS.
+HOST_MIN_INTERVAL_SECONDS: Dict[str, float] = {
+    "www.wikidata.org": 6.0,
+    "en.wikipedia.org": 6.0,
+    "de.wikipedia.org": 6.0,
+    "fr.wikipedia.org": 6.0,
+    "en.wikisource.org": 6.0,
+}
+
+
+def min_interval_for_host(host: str) -> float:
+    """Return the minimum seconds between requests for ``host``.
+
+    Args:
+        host: A bare hostname (e.g. ``"en.wikipedia.org"``).
+
+    Returns:
+        The per-host interval if configured, otherwise the project default.
+    """
+    return HOST_MIN_INTERVAL_SECONDS.get(host, constants.DEFAULT_HTTP_MIN_INTERVAL_SECONDS)
+
+
+def min_interval_for_url(url: str) -> float:
+    """Return the minimum seconds between requests for the host in ``url``."""
+    return min_interval_for_host(urlparse(url).hostname or "")

--- a/src/constants.py
+++ b/src/constants.py
@@ -42,6 +42,14 @@ WIKI_CORPUS_PREFIX = "enwiki-20220501"
 # Note: wiki_index.schema is currently in benchmarks/schema but should probably move
 WIKI_INDEX_SCHEMA_PATH = os.path.join(SRC_DIR, "benchmarks", "schema", "wiki_index.schema")
 
+# Default minimum seconds between outbound HTTP requests to a single host, used
+# to stay under Wikimedia's per-minute request quota. Per-host overrides live in
+# clients/http_rate_limits.py; this is the fallback for hosts not listed there.
+# Override at runtime with GREENLAND_HTTP_MIN_INTERVAL_SECONDS (0 disables).
+DEFAULT_HTTP_MIN_INTERVAL_SECONDS = float(
+    os.environ.get("GREENLAND_HTTP_MIN_INTERVAL_SECONDS", "6.0")
+)
+
 # PostgreSQL configuration
 # Template URL with placeholder for password - the actual password is loaded from keys/postgres.key
 POSTGRES_URL_TEMPLATE = "postgresql://postgres:[YOUR-PASSWORD]@db.srouvwdghrmwkxnzyzqz.supabase.co:5432/postgres?sslmode=require"

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from html.parser import HTMLParser
 import os
 import re
@@ -14,6 +15,7 @@ from urllib.parse import quote, unquote, urlparse
 
 import requests
 
+from clients.http_rate_limits import min_interval_for_url
 from storage.models.concept import MAX_CONCEPT_SOURCES
 
 logger = logging.getLogger(__name__)
@@ -33,6 +35,15 @@ DEFAULT_USER_AGENT = os.environ.get(
     "GREENLAND_HTTP_USER_AGENT",
     "Greenland-Barsukas/1.0 (concept seeding; set GREENLAND_HTTP_USER_AGENT with contact)",
 )
+# Wikimedia enforces a per-clock-minute request quota, not just a per-second
+# rate: bursting a handful of requests trips a ~60s cooldown (observed as a
+# Retry-After that bounces every call to the top of the next minute). Each
+# concept seed makes several requests (entity + summary + article + de + fr +
+# EB1911), so we pace GETs to a minimum interval *per host* to stay under that
+# quota. Per-host intervals live in clients/http_rate_limits.py.
+_throttle_lock = threading.Lock()
+_last_request_time_by_host: Dict[str, float] = {}
+
 MAX_SOURCE_TEXT_CHARS = 12000
 WIKIPEDIA_LEAD_THRESHOLD_CHARS = 10_000
 EB1911_MAX_PARAGRAPHS = 10
@@ -381,6 +392,27 @@ def _retry_delay_seconds(response: requests.Response, attempt_index: int) -> flo
     return min(fallback_delay, MAX_RETRY_DELAY_SECONDS)
 
 
+def _throttle(url: str) -> None:
+    """Block until this host's minimum request interval has elapsed.
+
+    Paces GETs per host so a multi-request seed fetch (entity + summary +
+    article + de + fr + EB1911) does not burst past Wikimedia's per-minute
+    quota. The per-host interval comes from
+    :func:`clients.http_rate_limits.min_interval_for_url`. Thread-safe so
+    concurrent callers serialize through the same per-host gate.
+    """
+    interval = min_interval_for_url(url)
+    if interval <= 0:
+        return
+    host = urlparse(url).hostname or ""
+    with _throttle_lock:
+        elapsed = time.monotonic() - _last_request_time_by_host.get(host, 0.0)
+        wait = interval - elapsed
+        if wait > 0:
+            time.sleep(wait)
+        _last_request_time_by_host[host] = time.monotonic()
+
+
 def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[Dict[str, Any]]:
     """Fetch JSON with Wikimedia-friendly headers and limited 429 retries."""
     request_params = dict(params or {})
@@ -391,6 +423,7 @@ def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[
     last_error: Optional[Exception] = None
     for attempt_index in range(MAX_HTTP_ATTEMPTS):
         try:
+            _throttle(url)
             response = requests.get(
                 url,
                 params=request_params or None,

--- a/src/tests/clients/test_http_rate_limits.py
+++ b/src/tests/clients/test_http_rate_limits.py
@@ -1,0 +1,20 @@
+"""Tests for per-host HTTP rate-limit lookups."""
+
+import constants
+from clients.http_rate_limits import min_interval_for_host, min_interval_for_url
+
+
+def test_known_host_uses_configured_interval() -> None:
+    assert min_interval_for_host("en.wikipedia.org") == 6.0
+    assert min_interval_for_url("https://www.wikidata.org/wiki/Special:EntityData/Q42.json") == 6.0
+
+
+def test_unknown_host_falls_back_to_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(constants, "DEFAULT_HTTP_MIN_INTERVAL_SECONDS", 3.5)
+    assert min_interval_for_host("example.com") == 3.5
+    assert min_interval_for_url("https://example.com/path") == 3.5
+
+
+def test_url_without_host_uses_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr(constants, "DEFAULT_HTTP_MIN_INTERVAL_SECONDS", 2.0)
+    assert min_interval_for_url("not-a-url") == 2.0

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -454,6 +454,49 @@ def test_get_json_retries_429_with_wikimedia_headers(monkeypatch) -> None:  # ty
     assert calls[0]["params"]["maxlag"] == "5"
 
 
+def test_throttle_waits_for_min_interval_per_host(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import storage.wikidata as wikidata
+
+    sleeps: list[float] = []
+    clock = {"now": 1000.0}
+
+    monkeypatch.setattr(wikidata, "min_interval_for_url", lambda url: 6.0)
+    monkeypatch.setattr(wikidata, "_last_request_time_by_host", {})
+    monkeypatch.setattr(wikidata.time, "monotonic", lambda: clock["now"])
+
+    def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+        clock["now"] += delay
+
+    monkeypatch.setattr(wikidata.time, "sleep", fake_sleep)
+
+    # First call to a host after a long idle: no wait.
+    wikidata._throttle("https://en.wikipedia.org/w/api.php")
+    assert sleeps == []
+
+    # A different host is tracked independently: still no wait.
+    wikidata._throttle("https://de.wikipedia.org/w/api.php")
+    assert sleeps == []
+
+    # Immediate second call to the *same* host must wait out the interval.
+    wikidata._throttle("https://en.wikipedia.org/w/api.php")
+    assert sleeps == [6.0]
+
+
+def test_throttle_disabled_when_interval_is_zero(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import storage.wikidata as wikidata
+
+    monkeypatch.setattr(wikidata, "min_interval_for_url", lambda url: 0.0)
+    monkeypatch.setattr(
+        wikidata.time,
+        "sleep",
+        lambda delay: pytest.fail("throttle should not sleep when disabled"),
+    )
+
+    wikidata._throttle("https://en.wikipedia.org/w/api.php")
+    wikidata._throttle("https://en.wikipedia.org/w/api.php")
+
+
 def test_vovere_skips_wikidata_generation_sources() -> None:
     agent = VovereAgent.__new__(VovereAgent)
 


### PR DESCRIPTION
Voverukas and voveraite now generate concept bodies from de/fr Wikipedia (plus en + EB1911) by passing include_regional_wikis=True through the create and batch codepaths.

Adding de/fr doubled down on Wikimedia's per-clock-minute request quota, which trips a ~60s cooldown when bursted. Pace all seed-fetch GETs to a per-host minimum interval: clients/http_rate_limits.py owns the per-host intervals, constants.DEFAULT_HTTP_MIN_INTERVAL_SECONDS is the fallback (overridable via GREENLAND_HTTP_MIN_INTERVAL_SECONDS, 0 disables), and storage.wikidata._throttle gates each host independently.