### PR TITLE
Give golden/hosted personas a read-only PostgreSQL concepts connection

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -205,12 +205,18 @@ def create_app(
             use_word2vec=use_word2vec,
         )
 
+        # golden/hosted connect read-only: writes/DDL are rejected at the server,
+        # not merely gated by CONCEPTS_WRITABLE route checks.
+        concepts_readonly = os.environ.get("BARSUKAS_CONCEPTS_READONLY") == "true"
+
         def concepts_session_factory() -> Session:
-            return cast(Session, create_session(concepts_backend_config))
+            return cast(
+                Session, create_session(concepts_backend_config, readonly=concepts_readonly)
+            )
 
         app.concepts_db_session_factory = concepts_session_factory
         app.config["CONCEPTS_BACKEND"] = "postgres"
-        app.config["CONCEPTS_WRITABLE"] = True
+        app.config["CONCEPTS_WRITABLE"] = not concepts_readonly
     else:
         app.config["CONCEPTS_BACKEND"] = backend_config.backend_type.value
         app.config["CONCEPTS_WRITABLE"] = False

--- a/src/barsukas/personas.py
+++ b/src/barsukas/personas.py
@@ -37,6 +37,10 @@ class PersonaConfig:
     use_jsonl: bool = False
     jsonl_data_dir: Optional[str] = None  # Relative to repo root
     use_postgres_concepts: bool = False
+    # When use_postgres_concepts is set, connect to PostgreSQL for concepts in a
+    # read-only transaction (the server rejects writes/DDL). Used by golden/hosted
+    # to browse concepts without granting write access.
+    postgres_concepts_readonly: bool = False
 
     # Access control
     readonly: bool = False
@@ -65,9 +69,11 @@ PERSONAS: dict[PersonaName, PersonaConfig] = {
     ),
     PersonaName.GOLDEN: PersonaConfig(
         name=PersonaName.GOLDEN,
-        description="Golden mode: Read-only JSONL from data/release",
+        description="Golden mode: Read-only JSONL from data/release with read-only PostgreSQL concepts",
         use_jsonl=True,
         jsonl_data_dir="data/release",
+        use_postgres_concepts=True,
+        postgres_concepts_readonly=True,
         readonly=True,
         allow_api_keys=True,
         allow_outbound_calls=True,
@@ -78,6 +84,8 @@ PERSONAS: dict[PersonaName, PersonaConfig] = {
         description="Hosted mode: Read-only JSONL like golden, hardened for shared deployment",
         use_jsonl=True,
         jsonl_data_dir="data/release",
+        use_postgres_concepts=True,
+        postgres_concepts_readonly=True,
         readonly=True,
         allow_api_keys=False,
         allow_outbound_calls=False,

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -178,6 +178,8 @@ def main() -> None:
             args.postgres = True
         if persona.use_postgres_concepts:
             os.environ["BARSUKAS_CONCEPTS_BACKEND"] = "postgres"
+            if persona.postgres_concepts_readonly:
+                os.environ["BARSUKAS_CONCEPTS_READONLY"] = "true"
 
     # Safety rule: read-only mode never starts the background worker.
     if args.readonly and not args.no_worker:
@@ -242,7 +244,10 @@ def main() -> None:
     else:
         logger.info("Task worker DISABLED")
     if persona and persona.use_postgres_concepts:
-        logger.info("Concepts database: PostgreSQL (writable)")
+        if persona.postgres_concepts_readonly:
+            logger.info("Concepts database: PostgreSQL (read-only)")
+        else:
+            logger.info("Concepts database: PostgreSQL (writable)")
     if persona and not persona.allow_api_keys:
         logger.info("API keys: DISABLED (no local keys)")
     if persona and not persona.allow_outbound_calls:

--- a/src/storage/backend/factory.py
+++ b/src/storage/backend/factory.py
@@ -21,11 +21,14 @@ _engine_initialized: set[str] = set()  # Track which engines have had tables ens
 _jsonl_storage_cache: dict[str, Any] = {}  # data_dir -> JSONLStorage
 
 
-def _create_engine(db_path: str) -> "Engine":
+def _create_engine(db_path: str, readonly: bool = False) -> "Engine":
     """Create a SQLAlchemy engine with appropriate settings.
 
     Args:
         db_path: Path to the database file (for SQLite) or connection string
+        readonly: For PostgreSQL, open every connection in a read-only
+            transaction so the server rejects any write or DDL. Ignored for
+            SQLite (there is no per-connection read-only mode used here).
 
     Returns:
         Configured SQLAlchemy engine
@@ -56,6 +59,11 @@ def _create_engine(db_path: str) -> "Engine":
             def _set_pg_search_path(dbapi_conn: Any, connection_record: Any) -> None:
                 cursor = dbapi_conn.cursor()
                 cursor.execute(f"SET search_path TO {pg_schema}")
+                if readonly:
+                    # Enforce read-only at the server: any INSERT/UPDATE/DELETE
+                    # or DDL on this connection fails. This is our DB-layer
+                    # guard since there is no dedicated read-only role.
+                    cursor.execute("SET default_transaction_read_only = on")
                 cursor.close()
 
     else:
@@ -205,7 +213,7 @@ def _get_session_factory() -> "sessionmaker":
     return _global_session_factory
 
 
-def _get_cached_engine(db_path: str) -> "Engine":
+def _get_cached_engine(db_path: str, readonly: bool = False) -> "Engine":
     """Get or create a cached engine for the given connection string.
 
     This avoids creating new database connections on every request, which is
@@ -213,30 +221,42 @@ def _get_cached_engine(db_path: str) -> "Engine":
 
     Args:
         db_path: Database connection string or file path
+        readonly: If True, build a read-only engine (PostgreSQL connections open
+            in a read-only transaction) and skip table-ensuring, which is itself
+            DDL and would fail on a read-only connection. The same db_path can
+            therefore have both a writable and a read-only engine cached.
 
     Returns:
         Cached SQLAlchemy engine
     """
     global _engine_cache, _engine_initialized
 
-    if db_path not in _engine_cache:
-        _engine_cache[db_path] = _create_engine(db_path)
+    # Key by (db_path, readonly) so a read-only engine never aliases a writable
+    # one for the same database.
+    cache_key = f"{db_path}\x00readonly" if readonly else db_path
 
-    engine = _engine_cache[db_path]
+    if cache_key not in _engine_cache:
+        _engine_cache[cache_key] = _create_engine(db_path, readonly=readonly)
 
-    # Only ensure tables exist once per engine
-    if db_path not in _engine_initialized:
+    engine = _engine_cache[cache_key]
+
+    # Only ensure tables exist once per engine. Read-only engines must never run
+    # the table-ensuring DDL; the schema is owned by the writable callers.
+    if not readonly and cache_key not in _engine_initialized:
         _ensure_tables_exist(engine)
-        _engine_initialized.add(db_path)
+        _engine_initialized.add(cache_key)
 
     return engine
 
 
-def create_session(config: Optional[DataSourceConfig] = None) -> "Session":
+def create_session(config: Optional[DataSourceConfig] = None, readonly: bool = False) -> "Session":
     """Create a new database session.
 
     Args:
         config: Optional data source configuration. If not provided, uses global config.
+        readonly: If True (only honored when an explicit config is given), use a
+            read-only engine. For PostgreSQL this opens the connection in a
+            read-only transaction so writes/DDL are rejected at the server.
 
     Returns:
         A new SQLAlchemy Session instance (or JSONLSession for JSONL backend)
@@ -266,7 +286,7 @@ def create_session(config: Optional[DataSourceConfig] = None) -> "Session":
             db_path = config.sqlite_path
 
         # Use cached engine to avoid connection overhead on every request
-        engine = _get_cached_engine(db_path)
+        engine = _get_cached_engine(db_path, readonly=readonly)
         factory = sessionmaker(bind=engine)
         return factory()
     else:


### PR DESCRIPTION
## Summary

The postgres-concepts plumbing already existed but conflated "use postgres" with "writable", so only the `scholar` persona connected — and only in write mode. `golden`/`hosted` got no concepts DB at all, falling back to the JSONL backend, which has no concepts. This was an oversight: the (read-only) credentials are available (same Postgres that benchmarks use).

This splits the two concerns and gives `golden` + `hosted` a **read-only** PostgreSQL concepts connection.

## Read-only enforcement

There's no dedicated read-only Postgres role, so read-only is enforced at the connection/transaction layer rather than only via route gating:

- Read-only postgres engines run `SET default_transaction_read_only = on` on every connection, so the **server** rejects any INSERT/UPDATE/DELETE/DDL.
- They **skip `_ensure_tables_exist`**, which is itself DDL (`CREATE EXTENSION`/`create_all`/`CREATE INDEX`/`ALTER TABLE`) and would fail or wrongly mutate schema on a read-only connection. Schema stays owned by writable callers (`scholar`/benchmarks).
- Engines are cached under a distinct key so a read-only engine never aliases a writable one for the same database.

`CONCEPTS_WRITABLE` route gating is preserved as defense-in-depth.

## Changes

- `barsukas/personas.py` — add `postgres_concepts_readonly` flag; enable on `golden` + `hosted`. `scholar` stays writable.
- `storage/backend/factory.py` — thread `readonly` through `_create_engine`/`_get_cached_engine`/`create_session`.
- `barsukas/unified_app.py` — set `BARSUKAS_CONCEPTS_READONLY`; startup log distinguishes read-only vs writable.
- `barsukas/app.py` — branch on the flag; set `CONCEPTS_WRITABLE = not concepts_readonly`.

## Testing

- Persona flags resolve correctly (golden/hosted read-only, scholar writable, local off).
- `black` clean; `mypy` clean on all modified files.
- Manual browser check of `golden` concept browsing recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)