### PR TITLE
Include backend flag in vovere batch-complete instructions

### DIFF
--- a/src/agents/vovere/voveraite.py
+++ b/src/agents/vovere/voveraite.py
@@ -46,7 +46,7 @@ from agents.common.common_args import (
 )
 from clients.batch_queue import BatchRequestMetadata, get_batch_manager
 from storage.backend import create_session as create_backend_session
-from storage.backend.config import DataSourceConfig
+from storage.backend.config import BackendType, DataSourceConfig
 from storage.concept_service import create_concept_from_qid
 from storage.crud.concept import cache_wikidata_title
 from storage.wikidata import fetch_wikidata_concept_seed, normalize_qid
@@ -231,12 +231,18 @@ class VoveraiteAgent:
                 batch_metadata={"agent": BATCH_AGENT_NAME, "operation": BATCH_OPERATION},
             )
             logger.info("Submitted batch %s with %d requests", batch_id, len(pending))
+            backend_flag = ""
+            if self.config.backend_type == BackendType.POSTGRES:
+                backend_flag = " --postgres"
+            elif self.config.backend_type == BackendType.JSONL:
+                backend_flag = " --backend jsonl"
             logger.info(
                 "Complete it later with: "
                 "PYTHONPATH=src python src/agents/common/batch.py complete "
-                "--batch-id %s --agent %s",
+                "--batch-id %s --agent %s%s",
                 batch_id,
                 BATCH_AGENT_NAME,
+                backend_flag,
             )
             return {"batch_id": batch_id, "queued": queued, "skipped": skipped}
         finally:

--- a/src/agents/vovere/voverukas.py
+++ b/src/agents/vovere/voverukas.py
@@ -50,7 +50,7 @@ import json
 
 from clients.batch_queue import BatchRequestMetadata, get_batch_manager
 from storage.backend import create_session as create_backend_session
-from storage.backend.config import DataSourceConfig
+from storage.backend.config import BackendType, DataSourceConfig
 from storage.concept_service import create_concept_from_qid
 from storage.crud.concept import cache_wikidata_title
 from storage.models.concept import Concept, concept_slug_to_title
@@ -347,12 +347,18 @@ class VoverukasAgent:
                 batch_metadata={"agent": BATCH_AGENT_NAME, "operation": BATCH_OPERATION},
             )
             logger.info("Submitted batch %s with %d requests", batch_id, len(pending))
+            backend_flag = ""
+            if self.config.backend_type == BackendType.POSTGRES:
+                backend_flag = " --postgres"
+            elif self.config.backend_type == BackendType.JSONL:
+                backend_flag = " --backend jsonl"
             logger.info(
                 "Complete it later with: "
                 "PYTHONPATH=src python src/agents/common/batch.py complete "
-                "--batch-id %s --agent %s",
+                "--batch-id %s --agent %s%s",
                 batch_id,
                 BATCH_AGENT_NAME,
+                backend_flag,
             )
             return {"batch_id": batch_id, "queued": queued, "skipped": skipped}
         finally:


### PR DESCRIPTION
## Summary

When the `voveraite` and `voverukas` concept agents submit an LLM batch, they log a "complete it later" command for running `batch.py complete`. That logged command omitted the backend flag, so following it verbatim would run the completion against the default (SQLite) backend even if the batch was created against PostgreSQL or JSONL.

This appends the matching backend flag (`--postgres` or `--backend jsonl`) based on the agent's configured `backend_type`, so the suggested command targets the same backend the batch was created with.

## Changes

- `agents/vovere/voveraite.py` — derive and append the backend flag to the logged completion command.
- `agents/vovere/voverukas.py` — same.

## Testing

- `black` clean; `mypy` clean on both files (the one reported mypy error is pre-existing in an unrelated file, `storage/crud/derivative_form.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)