### PR TITLE
Hide concept edit/create in read-only golden mode; paginate /concepts/

### DIFF
--- a/src/barsukas/routes/concepts.py
+++ b/src/barsukas/routes/concepts.py
@@ -159,19 +159,40 @@ def _body_generator_for_model(model: str) -> Callable[[str, str, List[Dict[str, 
     return generate
 
 
+CONCEPTS_PER_PAGE = 50
+
+
 @bp.route("/")
 def list_concepts_view() -> ResponseReturnValue:
-    """List concepts with optional search and verified filter."""
+    """List concepts with optional search, verified filter, and pagination."""
     search = request.args.get("q", "").strip()
     verified_only = request.args.get("verified") == "1"
-    concepts = list_concepts(_concept_session(), search=search, verified_only=verified_only)
+
+    total = count_concepts(_concept_session(), search=search, verified_only=verified_only)
+    total_pages = max(1, (total + CONCEPTS_PER_PAGE - 1) // CONCEPTS_PER_PAGE)
+
+    try:
+        page = int(request.args.get("page", "1"))
+    except ValueError:
+        page = 1
+    page = max(1, min(page, total_pages))
+
+    concepts = list_concepts(
+        _concept_session(),
+        search=search,
+        verified_only=verified_only,
+        limit=CONCEPTS_PER_PAGE,
+        offset=(page - 1) * CONCEPTS_PER_PAGE,
+    )
     return render_template(
         "concepts/list.html",
         concepts=concepts,
-        total=count_concepts(_concept_session()),
+        total=total,
         search=search,
         verified_only=verified_only,
         readonly=_is_readonly(),
+        page=page,
+        total_pages=total_pages,
     )
 
 

--- a/src/barsukas/templates/concepts/list.html
+++ b/src/barsukas/templates/concepts/list.html
@@ -63,6 +63,28 @@
     </a>
     {% endfor %}
 </div>
+
+{% if total_pages > 1 %}
+<nav aria-label="Concept pages" class="mt-4">
+    <ul class="pagination justify-content-center">
+        <li class="page-item {{ 'disabled' if page <= 1 }}">
+            <a class="page-link"
+               href="{{ url_for('concepts.list_concepts_view', q=search, verified=('1' if verified_only else None), page=page - 1) }}">
+                Previous
+            </a>
+        </li>
+        <li class="page-item disabled">
+            <span class="page-link">Page {{ page }} of {{ total_pages }}</span>
+        </li>
+        <li class="page-item {{ 'disabled' if page >= total_pages }}">
+            <a class="page-link"
+               href="{{ url_for('concepts.list_concepts_view', q=search, verified=('1' if verified_only else None), page=page + 1) }}">
+                Next
+            </a>
+        </li>
+    </ul>
+</nav>
+{% endif %}
 {% else %}
 <div class="alert alert-info">No concepts yet.{% if not readonly %} Use <strong>Create Page</strong> to add one.{% endif %}</div>
 {% endif %}

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -83,7 +83,9 @@ def run_flask_server(
         app.config["ENABLE_WORKER"] = persona.enable_worker
         app.config["ALLOW_RESTART"] = persona.allow_restart
         app.config["ALLOW_EXPORTS"] = persona.allow_exports
-        app.config["CONCEPTS_WRITABLE"] = persona.use_postgres_concepts
+        app.config["CONCEPTS_WRITABLE"] = (
+            persona.use_postgres_concepts and not persona.postgres_concepts_readonly
+        )
     else:
         # Defaults when no persona specified
         app.config["ALLOW_OUTBOUND_CALLS"] = True

--- a/src/storage/queries/concept.py
+++ b/src/storage/queries/concept.py
@@ -6,7 +6,7 @@ scanning concept bodies for ``[[...]]`` references, so they need no link table.
 
 from typing import List, Set
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from storage.models.concept import (
     Concept,
@@ -15,25 +15,12 @@ from storage.models.concept import (
 )
 
 
-def list_concepts(
+def _filtered_concepts_query(
     session: Session,
-    search: str = "",
-    verified_only: bool = False,
-    limit: int = 0,
-) -> List[Concept]:
-    """List concepts, optionally filtered by a search term and verification.
-
-    Args:
-        session: Database session.
-        search: Case-insensitive substring matched against slug and summary.
-            Spaces are treated like underscores so "civil war" matches
-            "Civil_War".
-        verified_only: If True, return only verified concepts.
-        limit: Maximum rows to return; 0 means no limit.
-
-    Returns:
-        Concepts ordered alphabetically by slug.
-    """
+    search: str,
+    verified_only: bool,
+) -> "Query[Concept]":
+    """Return a Concept query with the search/verified filters applied."""
     query = session.query(Concept)
 
     if search.strip():
@@ -46,17 +33,48 @@ def list_concepts(
     if verified_only:
         query = query.filter(Concept.verified.is_(True))
 
+    return query
+
+
+def list_concepts(
+    session: Session,
+    search: str = "",
+    verified_only: bool = False,
+    limit: int = 0,
+    offset: int = 0,
+) -> List[Concept]:
+    """List concepts, optionally filtered by a search term and verification.
+
+    Args:
+        session: Database session.
+        search: Case-insensitive substring matched against slug and summary.
+            Spaces are treated like underscores so "civil war" matches
+            "Civil_War".
+        verified_only: If True, return only verified concepts.
+        limit: Maximum rows to return; 0 means no limit.
+        offset: Number of rows to skip (for pagination); ignored when 0.
+
+    Returns:
+        Concepts ordered alphabetically by slug.
+    """
+    query = _filtered_concepts_query(session, search, verified_only)
     query = query.order_by(Concept.slug.asc())
 
+    if offset > 0:
+        query = query.offset(offset)
     if limit > 0:
         query = query.limit(limit)
 
     return query.all()
 
 
-def count_concepts(session: Session) -> int:
-    """Return the total number of concepts."""
-    return session.query(Concept).count()
+def count_concepts(
+    session: Session,
+    search: str = "",
+    verified_only: bool = False,
+) -> int:
+    """Return the number of concepts matching the search/verified filters."""
+    return _filtered_concepts_query(session, search, verified_only).count()
 
 
 def get_backlinks(session: Session, slug: str) -> List[Concept]:


### PR DESCRIPTION
In golden/hosted personas the PostgreSQL concepts connection is read-only, but the launch path set CONCEPTS_WRITABLE from use_postgres_concepts alone, overwriting the correct value create_app() had computed. This left the Edit and Create Page buttons visible even though writes are rejected. Gate writability on `use_postgres_concepts and not postgres_concepts_readonly`.

Also add pagination to /concepts/: list_concepts now takes an offset, and count_concepts honors the search/verified filters so the filtered total is accurate. The route paginates at 50 per page and the list template renders Previous/Next controls that preserve the search and verified query params.