### PR TITLE
Add Japanese kanji script signal for word levels

### DIFF
--- a/src/langtools/ja/__init__.py
+++ b/src/langtools/ja/__init__.py
@@ -7,6 +7,15 @@ Example usage:
     from langtools.ja.types import NounDeclension, VerbConjugation
 """
 
+from langtools.ja.script_analysis import (
+    JapaneseScriptType,
+    classify_japanese_script,
+    contains_japanese,
+    has_hiragana,
+    has_kanji,
+    has_katakana,
+    kanji_ratio,
+)
 from langtools.ja.types import (
     NounDeclension,
     VerbConjugation,
@@ -16,4 +25,12 @@ __all__ = [
     # Types
     "NounDeclension",
     "VerbConjugation",
+    # Script analysis (word-level signals)
+    "JapaneseScriptType",
+    "classify_japanese_script",
+    "contains_japanese",
+    "has_hiragana",
+    "has_kanji",
+    "has_katakana",
+    "kanji_ratio",
 ]

--- a/src/langtools/ja/romaji_helper.py
+++ b/src/langtools/ja/romaji_helper.py
@@ -7,8 +7,9 @@ for Japanese text. Degrades gracefully if pykakasi is not available.
 """
 
 import logging
-import re
 from typing import Any, Optional
+
+from langtools.ja.script_analysis import contains_japanese
 
 logger = logging.getLogger(__name__)
 
@@ -35,13 +36,9 @@ def is_japanese(text: str) -> bool:
     Returns:
         True if text contains Japanese characters, False otherwise
     """
-    if not text:
-        return False
-    # Check for Hiragana, Katakana, or CJK (kanji) ranges
-    # Hiragana: U+3040-U+309F
-    # Katakana: U+30A0-U+30FF
-    # CJK Unified Ideographs: U+4E00-U+9FFF (shared with Chinese)
-    return bool(re.search(r"[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9fff]", text))
+    # Delegate to the canonical script-range definitions in script_analysis so
+    # the CJK/kana ranges live in exactly one place.
+    return contains_japanese(text)
 
 
 def generate_romaji(japanese_text: str) -> Optional[str]:

--- a/src/langtools/ja/script_analysis.py
+++ b/src/langtools/ja/script_analysis.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Deterministic Japanese script analysis for word-level signals.
+
+A Japanese word's writing system is itself a linguistic signal. Words written
+with kanji tend to be established native or Sino-Japanese vocabulary -- neither
+modern loanwords nor purely grammatical/functional words. This mirrors the
+LLM-judged "modern construction" cue stored on
+``LemmaTranslation.translation_status`` for Latin and other ancient languages,
+but unlike that cue the script of a Japanese string is fully deterministic, so
+it is derived on demand here rather than stored on the translation.
+
+The classification deliberately distinguishes "only part kanji" (``MIXED``,
+e.g. a stem-plus-okurigana verb like 食べる) from "all kanji" (``KANJI``, e.g.
+学校): a word that mixes kanji with kana still carries the kanji signal. Words
+with no kanji split into katakana-only (e.g. パン), which typically marks a
+modern loanword, and hiragana-only (e.g. が, です), which typically marks
+grammatical/functional vocabulary -- exactly the "not modern; not grammatical"
+contrast this signal is meant to capture.
+"""
+
+import re
+from enum import Enum
+
+# Kanji: CJK Unified Ideographs (U+4E00-U+9FFF), Extension A (U+3400-U+4DBF),
+# and Compatibility Ideographs (U+F900-U+FAFF), plus the iteration mark
+# U+3005 (kurikaeshi) and U+3007, which behave like kanji (e.g. 人々, 時々).
+_KANJI_RE = re.compile(r"[々〇㐀-䶿一-鿿豈-﫿]")
+# Hiragana block U+3040-U+309F (includes the hiragana iteration marks).
+_HIRAGANA_RE = re.compile(r"[぀-ゟ]")
+# Katakana block U+30A0-U+30FF plus phonetic extensions (U+31F0-U+31FF) and
+# halfwidth katakana (U+FF66-U+FF9D). The prolonged sound mark U+30FC, common
+# in loanwords, lives in the main block and so counts as katakana.
+_KATAKANA_RE = re.compile(r"[゠-ヿㇰ-ㇿｦ-ﾝ]")
+
+
+class JapaneseScriptType(Enum):
+    """Script composition of a Japanese string, used as a word-level signal.
+
+    The ``KANJI`` and ``MIXED`` members both carry the kanji signal; see
+    :pyattr:`has_kanji`. ``NONE`` is returned for strings with no Japanese
+    script characters at all (empty, romaji, punctuation only).
+    """
+
+    KANJI = "kanji"  # only kanji, e.g. 学校
+    MIXED = "mixed"  # kanji plus kana ("only part kanji"), e.g. 食べる
+    KATAKANA = "katakana"  # katakana only, no kanji, e.g. パン
+    HIRAGANA = "hiragana"  # hiragana only, no kanji, e.g. が
+    KANA = "kana"  # both hiragana and katakana, no kanji (uncommon)
+    NONE = "none"  # no Japanese script characters
+
+    @property
+    def has_kanji(self) -> bool:
+        """Whether this script type contains any kanji (``KANJI`` or ``MIXED``)."""
+        return self in (JapaneseScriptType.KANJI, JapaneseScriptType.MIXED)
+
+
+def has_kanji(text: str) -> bool:
+    """Return True if the text contains at least one kanji character."""
+    return bool(text) and bool(_KANJI_RE.search(text))
+
+
+def has_hiragana(text: str) -> bool:
+    """Return True if the text contains at least one hiragana character."""
+    return bool(text) and bool(_HIRAGANA_RE.search(text))
+
+
+def has_katakana(text: str) -> bool:
+    """Return True if the text contains at least one katakana character."""
+    return bool(text) and bool(_KATAKANA_RE.search(text))
+
+
+def contains_japanese(text: str) -> bool:
+    """Return True if the text contains any kanji, hiragana, or katakana."""
+    return has_kanji(text) or has_hiragana(text) or has_katakana(text)
+
+
+def kanji_ratio(text: str) -> float:
+    """Fraction of Japanese script characters that are kanji (0.0-1.0).
+
+    Only kanji, hiragana, and katakana characters are counted; punctuation,
+    spaces, Latin letters, and digits are ignored. Returns 0.0 when the text
+    has no Japanese script characters. Useful for telling a mostly-kanji word
+    apart from one that is only part kanji.
+    """
+    if not text:
+        return 0.0
+    kanji_count = len(_KANJI_RE.findall(text))
+    kana_count = len(_HIRAGANA_RE.findall(text)) + len(_KATAKANA_RE.findall(text))
+    total = kanji_count + kana_count
+    if total == 0:
+        return 0.0
+    return kanji_count / total
+
+
+def classify_japanese_script(text: str) -> JapaneseScriptType:
+    """Classify the script composition of a Japanese string.
+
+    See :class:`JapaneseScriptType` for the meaning of each category. A string
+    mixing kanji with kana (a stem-plus-okurigana word like 食べる) classifies
+    as ``MIXED`` rather than ``KANJI``.
+    """
+    kanji = has_kanji(text)
+    hiragana = has_hiragana(text)
+    katakana = has_katakana(text)
+
+    if kanji:
+        return JapaneseScriptType.MIXED if (hiragana or katakana) else JapaneseScriptType.KANJI
+    if hiragana and katakana:
+        return JapaneseScriptType.KANA
+    if hiragana:
+        return JapaneseScriptType.HIRAGANA
+    if katakana:
+        return JapaneseScriptType.KATAKANA
+    return JapaneseScriptType.NONE

--- a/src/tests/langtools/test_ja_script_analysis.py
+++ b/src/tests/langtools/test_ja_script_analysis.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python3
+
+"""Unit tests for Japanese script analysis (word-level kanji signal)."""
+
+import unittest
+
+from langtools.ja.script_analysis import (
+    JapaneseScriptType,
+    classify_japanese_script,
+    contains_japanese,
+    has_hiragana,
+    has_kanji,
+    has_katakana,
+    kanji_ratio,
+)
+
+
+class TestHasKanji(unittest.TestCase):
+    def test_kanji_detection(self) -> None:
+        cases = [
+            ("学校", True),  # all kanji
+            ("食べる", True),  # kanji + okurigana (only part kanji)
+            ("人々", True),  # kanji with iteration mark
+            ("パン", False),  # katakana loanword
+            ("が", False),  # hiragana particle
+            ("コーヒー", False),  # katakana with prolonged sound mark
+            ("", False),
+            ("romaji", False),
+            ("123", False),
+        ]
+        for text, expected in cases:
+            with self.subTest(text=text):
+                self.assertEqual(has_kanji(text), expected)
+
+
+class TestKanaDetection(unittest.TestCase):
+    def test_hiragana_and_katakana(self) -> None:
+        self.assertTrue(has_hiragana("食べる"))
+        self.assertFalse(has_hiragana("パン"))
+        self.assertTrue(has_katakana("パン"))
+        self.assertTrue(has_katakana("コーヒー"))  # prolonged sound mark counts
+        self.assertFalse(has_katakana("食べる"))
+
+    def test_contains_japanese(self) -> None:
+        self.assertTrue(contains_japanese("学校"))
+        self.assertTrue(contains_japanese("パン"))
+        self.assertTrue(contains_japanese("が"))
+        self.assertFalse(contains_japanese(""))
+        self.assertFalse(contains_japanese("hello"))
+
+
+class TestClassifyJapaneseScript(unittest.TestCase):
+    def test_categories(self) -> None:
+        cases = [
+            ("学校", JapaneseScriptType.KANJI),
+            ("漢字", JapaneseScriptType.KANJI),
+            ("人々", JapaneseScriptType.KANJI),  # iteration mark is kanji-like
+            ("食べる", JapaneseScriptType.MIXED),
+            ("大きい", JapaneseScriptType.MIXED),
+            ("パン", JapaneseScriptType.KATAKANA),
+            ("コーヒー", JapaneseScriptType.KATAKANA),
+            ("が", JapaneseScriptType.HIRAGANA),
+            ("です", JapaneseScriptType.HIRAGANA),
+            ("オーケーだ", JapaneseScriptType.KANA),  # katakana + hiragana, no kanji
+            ("", JapaneseScriptType.NONE),
+            ("romaji", JapaneseScriptType.NONE),
+        ]
+        for text, expected in cases:
+            with self.subTest(text=text):
+                self.assertEqual(classify_japanese_script(text), expected)
+
+    def test_has_kanji_property(self) -> None:
+        self.assertTrue(JapaneseScriptType.KANJI.has_kanji)
+        self.assertTrue(JapaneseScriptType.MIXED.has_kanji)
+        self.assertFalse(JapaneseScriptType.KATAKANA.has_kanji)
+        self.assertFalse(JapaneseScriptType.HIRAGANA.has_kanji)
+        self.assertFalse(JapaneseScriptType.KANA.has_kanji)
+        self.assertFalse(JapaneseScriptType.NONE.has_kanji)
+
+
+class TestKanjiRatio(unittest.TestCase):
+    def test_ratio(self) -> None:
+        self.assertEqual(kanji_ratio("学校"), 1.0)
+        self.assertEqual(kanji_ratio("パン"), 0.0)
+        self.assertEqual(kanji_ratio(""), 0.0)
+        self.assertEqual(kanji_ratio("romaji"), 0.0)
+        # 食べる: one kanji out of three Japanese characters.
+        self.assertAlmostEqual(kanji_ratio("食べる"), 1 / 3)
+        # Punctuation and Latin are ignored in the denominator.
+        self.assertEqual(kanji_ratio("学校。"), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce a deterministic Japanese script classifier in langtools/ja that
serves as a word-level signal, parallel to the LLM-judged "modern construction"
cue on LemmaTranslation.translation_status. A Japanese word's script is itself
a signal: kanji-bearing words are established native/Sino-Japanese vocabulary
(not modern, not grammatical), katakana-only words are typically modern
loanwords, and hiragana-only words are typically grammatical/functional.

Because script is fully deterministic from the text (unlike the modern cue,
which needs semantic judgment), the signal is derived on demand rather than
stored. classify_japanese_script distinguishes "only part kanji" (MIXED, e.g.
食べる) from "all kanji" (KANJI, e.g. 学校); both carry the kanji signal via
JapaneseScriptType.has_kanji. Also provides has_kanji/has_hiragana/
has_katakana/contains_japanese predicates and kanji_ratio.

romaji_helper.is_japanese now delegates to script_analysis.contains_japanese
so the CJK/kana script ranges are defined in exactly one place.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BBvxxY4sPrQBHfnCBgPxdC