### PR TITLE
Add Trakaido spelling quiz, category choice, and sentence completion activities

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -78,6 +78,7 @@ from barsukas.routes import (
     settings,
     strings_export,
     trakaido,
+    trakaido_activities,
     translations,
     wireword,
 )
@@ -269,6 +270,7 @@ def create_app(
     app.register_blueprint(settings.bp)
     app.register_blueprint(strings_export.bp)
     app.register_blueprint(trakaido.bp)
+    app.register_blueprint(trakaido_activities.bp)
     app.register_blueprint(pattern_sentences.bp)
     app.register_blueprint(peleda.bp)
     app.register_blueprint(rhymes.bp)

--- a/src/barsukas/routes/trakaido_activities.py
+++ b/src/barsukas/routes/trakaido_activities.py
@@ -1,0 +1,502 @@
+#!/usr/bin/python3
+
+"""Trakaido interactive activities served by Barsukas.
+
+Ports the "weird" Trakaido activities (spelling quiz, category choice,
+sentence completion) into server-rendered pages using the Greenland UI
+patterns.  No user state is persisted; a level dropdown on each page
+selects which difficulty band to draw words from.
+"""
+
+import json
+import random
+from typing import Any, Dict, List, Optional, Tuple
+
+from flask import Blueprint, g, render_template, request
+from flask.typing import ResponseReturnValue
+from sqlalchemy import func
+
+from storage.models.schema import (
+    Lemma,
+    LemmaTranslation,
+    Sentence,
+    SentenceWord,
+)
+from storage.translation_helpers import get_supported_languages
+
+bp = Blueprint("trakaido_activities", __name__, url_prefix="/trakaido/activities")
+
+DEFAULT_INTERFACE_LANG = "en"
+DEFAULT_FOREIGN_LANG = "lt"
+_QUESTIONS_PER_ROUND = 10
+_LEVEL_EXPAND_RANGE = 2
+
+CONFUSION_SETS: Dict[str, List[Dict[str, Any]]] = {
+    "lt": [
+        {"id": "fricatives", "options": ["s", "z", "š", "ž"]},
+        {"id": "affricates", "options": ["c", "dz", "č", "dž"]},
+        {"id": "diphthong-ie", "options": ["ie", "e", "ė", "i"]},
+        {"id": "diphthong-uo", "options": ["uo", "o", "u", "ū"]},
+        {"id": "e-variants", "options": ["e", "ė", "ę", "en"]},
+        {"id": "u-long-nasal", "options": ["u", "ū", "ų", "un"]},
+        {"id": "a-nasal", "options": ["a", "ą", "an", "am"]},
+        {"id": "i-variants", "options": ["i", "į", "y", "j"]},
+        {"id": "diphthongs", "options": ["ai", "ei", "au", "eu"]},
+    ],
+    "fr": [
+        {"id": "accented-e", "options": ["e", "é", "è", "ê"]},
+        {"id": "accented-a", "options": ["a", "à", "â"]},
+        {"id": "nasals", "options": ["an", "en", "on", "in"]},
+        {"id": "c-variants", "options": ["c", "ç", "ss", "s"]},
+    ],
+    "es": [
+        {"id": "b-v", "options": ["b", "v"]},
+        {"id": "accented-vowels", "options": ["a", "á", "e", "é"]},
+        {"id": "n-variants", "options": ["n", "ñ"]},
+        {"id": "ll-y", "options": ["ll", "y"]},
+    ],
+    "de": [
+        {"id": "umlauts-a", "options": ["a", "ä"]},
+        {"id": "umlauts-o", "options": ["o", "ö"]},
+        {"id": "umlauts-u", "options": ["u", "ü"]},
+        {"id": "ss-variants", "options": ["ss", "ß", "s"]},
+    ],
+}
+
+CATEGORY_LABELS: Dict[str, str] = {
+    "food": "Food",
+    "beverage": "Beverages",
+    "animal": "Animals",
+    "body_part": "Body Parts",
+    "clothing_accessory": "Clothing & Accessories",
+    "building_structure": "Buildings & Structures",
+    "building_part": "Parts of Buildings",
+    "furniture": "Furniture",
+    "tool": "Tools",
+    "electronic_device": "Electronics",
+    "plant": "Plants",
+    "occupation": "Occupations",
+    "family_relation": "Family & Relations",
+    "small_movable_object": "Everyday Objects",
+    "natural_feature": "Nature & Landscape",
+    "vehicle": "Vehicles",
+    "weapon": "Weapons",
+    "sport": "Sports",
+    "music": "Music",
+}
+
+
+def _parse_activity_params() -> Tuple[int, str, str]:
+    """Read level and language params from the query string."""
+    supported = set(get_supported_languages().keys())
+
+    level_raw = request.args.get("level", "1")
+    try:
+        level = max(1, int(level_raw))
+    except ValueError:
+        level = 1
+
+    interface_lang = (request.args.get("interface_lang") or DEFAULT_INTERFACE_LANG).strip().lower()
+    foreign_lang = (request.args.get("foreign_lang") or DEFAULT_FOREIGN_LANG).strip().lower()
+
+    if interface_lang not in supported:
+        interface_lang = DEFAULT_INTERFACE_LANG
+    if foreign_lang not in supported:
+        foreign_lang = DEFAULT_FOREIGN_LANG
+
+    return level, interface_lang, foreign_lang
+
+
+def _available_levels() -> List[int]:
+    """Return sorted list of difficulty levels that have at least one lemma."""
+    rows = (
+        g.db.query(Lemma.difficulty_level)
+        .filter(Lemma.difficulty_level.isnot(None))
+        .filter(Lemma.difficulty_level > 0)
+        .distinct()
+        .order_by(Lemma.difficulty_level)
+        .all()
+    )
+    return [row[0] for row in rows]
+
+
+def _fetch_words_at_level(level: int, foreign_lang: str, limit: int = 40) -> List[Dict[str, Any]]:
+    """Fetch lemmas near the given difficulty level with foreign translations."""
+    rows = (
+        g.db.query(Lemma, LemmaTranslation.translation)
+        .join(LemmaTranslation, LemmaTranslation.lemma_id == Lemma.id)
+        .filter(LemmaTranslation.language_code == foreign_lang)
+        .filter(LemmaTranslation.translation.isnot(None))
+        .filter(LemmaTranslation.translation != "")
+        .filter(Lemma.difficulty_level.isnot(None))
+        .filter(
+            Lemma.difficulty_level.between(
+                max(1, level - _LEVEL_EXPAND_RANGE),
+                level + _LEVEL_EXPAND_RANGE,
+            )
+        )
+        .order_by(
+            func.abs(Lemma.difficulty_level - level),
+            func.random(),
+        )
+        .limit(limit)
+        .all()
+    )
+
+    words: List[Dict[str, Any]] = []
+    for lemma, translation in rows:
+        words.append(
+            {
+                "id": lemma.id,
+                "english": lemma.lemma_text,
+                "definition": lemma.definition_text,
+                "foreign": translation,
+                "pos_type": lemma.pos_type,
+                "pos_subtype": lemma.pos_subtype,
+                "level": lemma.difficulty_level,
+            }
+        )
+    return words
+
+
+# ---------------------------------------------------------------------------
+# Spelling Quiz
+# ---------------------------------------------------------------------------
+
+
+def _is_vowel(char: str) -> bool:
+    return char.lower() in "aeiouyąęėįųūéèêàâáíóúöüä"
+
+
+def _breaks_vowel_sequence(word: str, start: int, end: int) -> bool:
+    matched = word[start:end].lower()
+    if len(matched) != 1 or not _is_vowel(matched):
+        return False
+    if start > 0 and _is_vowel(word[start - 1]):
+        return True
+    if end < len(word) and _is_vowel(word[end]):
+        return True
+    return False
+
+
+def _find_confusion_positions(
+    word: str, confusion_sets: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Find positions in *word* that match any confusion set option."""
+    lower_word = word.lower()
+    matches: List[Dict[str, Any]] = []
+
+    for cset in confusion_sets:
+        sorted_options = sorted(cset["options"], key=len, reverse=True)
+        for option in sorted_options:
+            search_from = 0
+            while True:
+                idx = lower_word.find(option.lower(), search_from)
+                if idx == -1:
+                    break
+                opt_end = idx + len(option)
+                overlaps = any(idx < m["end"] and opt_end > m["start"] for m in matches)
+                breaks_seq = _breaks_vowel_sequence(lower_word, idx, opt_end)
+                if not overlaps and not breaks_seq:
+                    matches.append(
+                        {
+                            "start": idx,
+                            "end": opt_end,
+                            "options": cset["options"],
+                            "matched": option,
+                            "set_id": cset["id"],
+                        }
+                    )
+                search_from = idx + 1
+
+    matches.sort(key=lambda m: m["start"])
+    return matches
+
+
+def _build_spelling_questions(
+    words: List[Dict[str, Any]], foreign_lang: str
+) -> List[Dict[str, Any]]:
+    """Generate spelling quiz questions from a word list."""
+    csets = CONFUSION_SETS.get(foreign_lang, [])
+    if not csets:
+        return []
+
+    questions: List[Dict[str, Any]] = []
+    for word_data in words:
+        foreign_word: str = word_data["foreign"]
+        positions = _find_confusion_positions(foreign_word, csets)
+        if not positions:
+            continue
+
+        pos = random.choice(positions)
+        correct_answer = foreign_word[pos["start"] : pos["end"]]
+
+        options_pool: List[str] = list(pos["options"])
+        if len(options_pool) > 4:
+            decoys = [o for o in options_pool if o.lower() != correct_answer.lower()]
+            random.shuffle(decoys)
+            final_options = [correct_answer.lower()] + decoys[:3]
+        else:
+            final_options = [o.lower() for o in options_pool]
+
+        display_options = sorted(
+            [o.upper() for o in final_options],
+            key=lambda x: x.lower(),
+        )
+
+        questions.append(
+            {
+                "word": foreign_word,
+                "english": word_data["english"],
+                "definition": word_data["definition"],
+                "blank_start": pos["start"],
+                "blank_end": pos["end"],
+                "correct_answer": correct_answer,
+                "options": display_options,
+            }
+        )
+
+        if len(questions) >= _QUESTIONS_PER_ROUND:
+            break
+
+    random.shuffle(questions)
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Category Choice
+# ---------------------------------------------------------------------------
+
+
+def _build_category_questions(
+    words: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Generate category-choice questions from a word list."""
+    by_subtype: Dict[str, List[Dict[str, Any]]] = {}
+    for w in words:
+        sub = w.get("pos_subtype")
+        if sub and sub in CATEGORY_LABELS:
+            by_subtype.setdefault(sub, []).append(w)
+
+    viable = [(sub, ws) for sub, ws in by_subtype.items() if len(ws) >= 1]
+    if not viable:
+        return []
+
+    all_words = words
+    questions: List[Dict[str, Any]] = []
+
+    attempts = 0
+    while len(questions) < _QUESTIONS_PER_ROUND and attempts < 50:
+        attempts += 1
+        sub, category_words = random.choice(viable)
+        correct = random.choice(category_words)
+
+        decoys = [
+            w
+            for w in all_words
+            if w.get("pos_subtype") != sub and w["foreign"].lower() != correct["foreign"].lower()
+        ]
+        if len(decoys) < 3:
+            continue
+
+        random.shuffle(decoys)
+        option_words = [correct] + decoys[:3]
+        random.shuffle(option_words)
+
+        questions.append(
+            {
+                "category": CATEGORY_LABELS[sub],
+                "correct_foreign": correct["foreign"],
+                "correct_english": correct["english"],
+                "options": [
+                    {
+                        "foreign": o["foreign"],
+                        "english": o["english"],
+                        "correct": o["id"] == correct["id"],
+                    }
+                    for o in option_words
+                ],
+            }
+        )
+
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Sentence Completion
+# ---------------------------------------------------------------------------
+
+
+def _build_sentence_completion_questions(
+    level: int, interface_lang: str, foreign_lang: str
+) -> List[Dict[str, Any]]:
+    """Generate sentence-completion questions."""
+    content_roles = {"verb", "noun", "subject", "object", "adjective", "adverb"}
+
+    sentence_rows = (
+        g.db.query(Sentence)
+        .join(SentenceWord, SentenceWord.sentence_id == Sentence.id)
+        .join(Lemma, Lemma.id == SentenceWord.lemma_id)
+        .filter(Sentence.rejected == False)  # noqa: E712
+        .filter(SentenceWord.language_code == foreign_lang)
+        .filter(Lemma.difficulty_level.isnot(None))
+        .filter(
+            Lemma.difficulty_level.between(
+                max(1, level - _LEVEL_EXPAND_RANGE),
+                level + _LEVEL_EXPAND_RANGE,
+            )
+        )
+        .distinct()
+        .order_by(func.random())
+        .limit(30)
+        .all()
+    )
+
+    decoy_words_rows = (
+        g.db.query(LemmaTranslation.translation)
+        .join(Lemma, Lemma.id == LemmaTranslation.lemma_id)
+        .filter(LemmaTranslation.language_code == foreign_lang)
+        .filter(LemmaTranslation.translation.isnot(None))
+        .filter(LemmaTranslation.translation != "")
+        .filter(Lemma.difficulty_level.isnot(None))
+        .filter(
+            Lemma.difficulty_level.between(
+                max(1, level - _LEVEL_EXPAND_RANGE),
+                level + _LEVEL_EXPAND_RANGE,
+            )
+        )
+        .order_by(func.random())
+        .limit(60)
+        .all()
+    )
+    decoy_pool = [r[0] for r in decoy_words_rows if r[0]]
+
+    questions: List[Dict[str, Any]] = []
+
+    for sentence in sentence_rows:
+        if len(questions) >= _QUESTIONS_PER_ROUND:
+            break
+
+        foreign_words_query = (
+            g.db.query(SentenceWord)
+            .filter(SentenceWord.sentence_id == sentence.id)
+            .filter(SentenceWord.language_code == foreign_lang)
+            .order_by(SentenceWord.position)
+            .all()
+        )
+        interface_words_query = (
+            g.db.query(SentenceWord)
+            .filter(SentenceWord.sentence_id == sentence.id)
+            .filter(SentenceWord.language_code == interface_lang)
+            .order_by(SentenceWord.position)
+            .all()
+        )
+
+        if not foreign_words_query or not interface_words_query:
+            continue
+
+        blankable = [
+            w
+            for w in foreign_words_query
+            if w.word_role in content_roles
+            and w.target_language_text
+            and len(w.target_language_text) > 1
+        ]
+        if not blankable:
+            continue
+
+        target_word = random.choice(blankable)
+        correct_text = target_word.target_language_text
+
+        foreign_sentence = " ".join(w.target_language_text or "" for w in foreign_words_query)
+        blanked_sentence = " ".join(
+            "___" if w.position == target_word.position else (w.target_language_text or "")
+            for w in foreign_words_query
+        )
+        interface_sentence = " ".join(w.target_language_text or "" for w in interface_words_query)
+
+        decoys = [d for d in decoy_pool if d.lower() != correct_text.lower()]
+        if len(decoys) < 3:
+            continue
+
+        random.shuffle(decoys)
+        option_list = [correct_text] + decoys[:3]
+        random.shuffle(option_list)
+
+        questions.append(
+            {
+                "interface_sentence": interface_sentence,
+                "foreign_sentence": foreign_sentence,
+                "blanked_sentence": blanked_sentence,
+                "correct_answer": correct_text,
+                "blank_gloss": target_word.english_text or "",
+                "options": [{"text": o, "correct": o == correct_text} for o in option_list],
+            }
+        )
+
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+def _common_template_vars(level: int, interface_lang: str, foreign_lang: str) -> Dict[str, Any]:
+    return {
+        "level": level,
+        "interface_lang": interface_lang,
+        "foreign_lang": foreign_lang,
+        "supported_languages": get_supported_languages(),
+        "available_levels": _available_levels(),
+    }
+
+
+@bp.route("/")
+def activities_index() -> ResponseReturnValue:
+    """Landing page listing the available Trakaido activities."""
+    return render_template("trakaido/activities/index.html")
+
+
+@bp.route("/spelling-quiz")
+def spelling_quiz() -> ResponseReturnValue:
+    """Spelling quiz activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    words = _fetch_words_at_level(level, foreign_lang, limit=40)
+    questions = _build_spelling_questions(words, foreign_lang)
+
+    return render_template(
+        "trakaido/activities/spelling_quiz.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/category-choice")
+def category_choice() -> ResponseReturnValue:
+    """Category choice activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    words = _fetch_words_at_level(level, foreign_lang, limit=80)
+    questions = _build_category_questions(words)
+
+    return render_template(
+        "trakaido/activities/category_choice.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/sentence-completion")
+def sentence_completion() -> ResponseReturnValue:
+    """Sentence completion activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    questions = _build_sentence_completion_questions(level, interface_lang, foreign_lang)
+
+    return render_template(
+        "trakaido/activities/sentence_completion.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )

--- a/src/barsukas/routes/trakaido_activities.py
+++ b/src/barsukas/routes/trakaido_activities.py
@@ -591,7 +591,7 @@ def _build_listening_questions(
             {
                 "audio_url": word_data["audio_url"],
                 "correct_answer": correct_display,
-                "foreign_word": word_data["foreign"],
+                "target_word": word_data["foreign"],
                 "options": options,
             }
         )

--- a/src/barsukas/routes/trakaido_activities.py
+++ b/src/barsukas/routes/trakaido_activities.py
@@ -10,13 +10,14 @@ selects which difficulty band to draw words from.
 
 import json
 import random
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
-from flask import Blueprint, g, render_template, request
+from flask import Blueprint, g, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from sqlalchemy import func
 
 from storage.models.schema import (
+    AudioQualityReview,
     Lemma,
     LemmaTranslation,
     Sentence,
@@ -438,6 +439,167 @@ def _build_sentence_completion_questions(
 
 
 # ---------------------------------------------------------------------------
+# Multiple Choice
+# ---------------------------------------------------------------------------
+
+_STUDY_MODES = ["target-to-source", "source-to-target"]
+
+
+def _build_multiple_choice_questions(
+    words: List[Dict[str, Any]], study_mode: str
+) -> List[Dict[str, Any]]:
+    """Generate multiple-choice translation questions.
+
+    study_mode:
+      - "target-to-source": show foreign word, pick the English meaning
+      - "source-to-target": show English word, pick the foreign translation
+    """
+    if len(words) < 4:
+        return []
+
+    questions: List[Dict[str, Any]] = []
+    random.shuffle(words)
+
+    for word_data in words:
+        if len(questions) >= _QUESTIONS_PER_ROUND:
+            break
+
+        decoys = [
+            w
+            for w in words
+            if w["id"] != word_data["id"]
+            and w["foreign"].lower() != word_data["foreign"].lower()
+            and w["english"].lower() != word_data["english"].lower()
+        ]
+        if len(decoys) < 3:
+            continue
+
+        random.shuffle(decoys)
+        option_words = [word_data] + decoys[:3]
+        random.shuffle(option_words)
+
+        if study_mode == "source-to-target":
+            prompt_text = word_data["english"]
+            prompt_sub = word_data["definition"] or ""
+            options = [
+                {"text": o["foreign"], "correct": o["id"] == word_data["id"]} for o in option_words
+            ]
+            correct_display = word_data["foreign"]
+        else:
+            prompt_text = word_data["foreign"]
+            prompt_sub = ""
+            options = [
+                {"text": o["english"], "correct": o["id"] == word_data["id"]} for o in option_words
+            ]
+            correct_display = word_data["english"]
+
+        questions.append(
+            {
+                "prompt": prompt_text,
+                "prompt_sub": prompt_sub,
+                "correct_answer": correct_display,
+                "options": options,
+            }
+        )
+
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Listening
+# ---------------------------------------------------------------------------
+
+_AUDIO_STATUS_PRIORITY: Dict[str, int] = {
+    "approved": 0,
+    "approved_with_issues": 1,
+    "pending_review": 2,
+    "needs_replacement": 3,
+}
+
+
+def _pick_lemma_audio(lemma_id: int, language_code: str) -> Optional[AudioQualityReview]:
+    """Return the best available lemma audio review, or None."""
+    reviews = (
+        g.db.query(AudioQualityReview)
+        .filter(AudioQualityReview.lemma_id == lemma_id)
+        .filter(AudioQualityReview.language_code == language_code)
+        .filter(AudioQualityReview.sentence_id.is_(None))
+        .all()
+    )
+    if not reviews:
+        return None
+    reviews.sort(key=lambda r: (_AUDIO_STATUS_PRIORITY.get(r.status, 99), r.id))
+    return cast(AudioQualityReview, reviews[0])
+
+
+def _build_listening_questions(
+    words: List[Dict[str, Any]], foreign_lang: str, study_mode: str
+) -> List[Dict[str, Any]]:
+    """Generate listening quiz questions — only words with audio."""
+    if len(words) < 4:
+        return []
+
+    words_with_audio: List[Dict[str, Any]] = []
+    for word_data in words:
+        audio = _pick_lemma_audio(word_data["id"], foreign_lang)
+        if audio is not None:
+            word_data_copy = dict(word_data)
+            word_data_copy["audio_url"] = url_for(
+                "audio.serve_audio_file",
+                language=audio.language_code,
+                voice=audio.voice_name,
+                filename=audio.filename,
+            )
+            words_with_audio.append(word_data_copy)
+
+    if len(words_with_audio) < 4:
+        return []
+
+    questions: List[Dict[str, Any]] = []
+    random.shuffle(words_with_audio)
+
+    for word_data in words_with_audio:
+        if len(questions) >= _QUESTIONS_PER_ROUND:
+            break
+
+        decoys = [
+            w
+            for w in words_with_audio
+            if w["id"] != word_data["id"]
+            and w["foreign"].lower() != word_data["foreign"].lower()
+            and w["english"].lower() != word_data["english"].lower()
+        ]
+        if len(decoys) < 3:
+            continue
+
+        random.shuffle(decoys)
+        option_words = [word_data] + decoys[:3]
+        random.shuffle(option_words)
+
+        if study_mode == "target-to-target":
+            options = [
+                {"text": o["foreign"], "correct": o["id"] == word_data["id"]} for o in option_words
+            ]
+            correct_display = word_data["foreign"]
+        else:
+            options = [
+                {"text": o["english"], "correct": o["id"] == word_data["id"]} for o in option_words
+            ]
+            correct_display = word_data["english"]
+
+        questions.append(
+            {
+                "audio_url": word_data["audio_url"],
+                "correct_answer": correct_display,
+                "foreign_word": word_data["foreign"],
+                "options": options,
+            }
+        )
+
+    return questions
+
+
+# ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
 
@@ -498,5 +660,50 @@ def sentence_completion() -> ResponseReturnValue:
         "trakaido/activities/sentence_completion.html",
         questions_json=json.dumps(questions, ensure_ascii=False),
         question_count=len(questions),
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/multiple-choice")
+def multiple_choice() -> ResponseReturnValue:
+    """Multiple choice translation activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    study_mode = request.args.get("study_mode", "target-to-source")
+    if study_mode not in _STUDY_MODES:
+        study_mode = "target-to-source"
+
+    words = _fetch_words_at_level(level, foreign_lang, limit=40)
+    questions = _build_multiple_choice_questions(words, study_mode)
+
+    return render_template(
+        "trakaido/activities/multiple_choice.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        study_mode=study_mode,
+        study_modes=_STUDY_MODES,
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+_LISTENING_STUDY_MODES = ["target-to-source", "target-to-target"]
+
+
+@bp.route("/listening")
+def listening() -> ResponseReturnValue:
+    """Listening comprehension activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    study_mode = request.args.get("study_mode", "target-to-source")
+    if study_mode not in _LISTENING_STUDY_MODES:
+        study_mode = "target-to-source"
+
+    words = _fetch_words_at_level(level, foreign_lang, limit=60)
+    questions = _build_listening_questions(words, foreign_lang, study_mode)
+
+    return render_template(
+        "trakaido/activities/listening.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        study_mode=study_mode,
+        study_modes=_LISTENING_STUDY_MODES,
         **_common_template_vars(level, interface_lang, foreign_lang),
     )

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -471,3 +471,222 @@
     font-size: 0.9rem;
     margin-top: 0.2rem;
 }
+
+/* =========================================================
+   Activity quiz styles
+   ========================================================= */
+
+/* Progress bar */
+.tk-progress-wrapper {
+    margin-bottom: 1rem;
+}
+
+.tk-progress-text {
+    font-size: 0.85rem;
+    color: var(--tk-text-muted);
+    margin-bottom: 0.35rem;
+}
+
+.tk-progress-track {
+    height: 6px;
+    background: var(--tk-border);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.tk-progress-fill {
+    height: 100%;
+    background: var(--tk-primary);
+    border-radius: 3px;
+    transition: width 0.3s ease;
+}
+
+/* Activity area */
+.tk-activity-area {
+    min-height: 220px;
+}
+
+/* Option buttons */
+.tk-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.65rem;
+    margin-top: 1.25rem;
+}
+
+.tk-option-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1rem;
+    background: var(--tk-card-bg);
+    border: 2px solid var(--tk-border);
+    border-radius: 8px;
+    font-size: 1.15rem;
+    font-weight: 500;
+    color: var(--tk-text);
+    cursor: pointer;
+    transition: border-color 0.12s ease, background-color 0.12s ease, transform 0.08s ease;
+}
+
+.tk-option-btn:hover:not(:disabled) {
+    border-color: var(--tk-primary);
+    background: rgba(0, 149, 255, 0.04);
+    transform: translateY(-1px);
+}
+
+.tk-option-btn:disabled {
+    cursor: default;
+}
+
+.tk-option-btn.tk-correct {
+    border-color: #16a34a;
+    background: rgba(22, 163, 74, 0.08);
+    color: #15803d;
+}
+
+.tk-option-btn.tk-incorrect {
+    border-color: #dc2626;
+    background: rgba(220, 38, 38, 0.08);
+    color: #b91c1c;
+}
+
+.tk-option-btn.tk-unselected {
+    opacity: 0.45;
+}
+
+.tk-opt-foreign {
+    font-weight: 600;
+}
+
+.tk-opt-english {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 0.82rem;
+    color: var(--tk-text-muted);
+    font-weight: 400;
+}
+
+/* Feedback line */
+.tk-feedback {
+    text-align: center;
+    margin-top: 1rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    min-height: 1.4em;
+}
+
+.tk-fb-correct {
+    color: #16a34a;
+}
+
+.tk-fb-incorrect {
+    color: #dc2626;
+}
+
+/* Navigation buttons */
+.tk-nav-buttons {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.75rem;
+}
+
+/* Spelling Quiz specifics */
+.tk-sq-prompt {
+    text-align: center;
+    margin-bottom: 0.5rem;
+}
+
+.tk-sq-english {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--tk-text);
+}
+
+.tk-sq-definition {
+    font-size: 0.9rem;
+    color: var(--tk-text-muted);
+    margin-top: 0.15rem;
+}
+
+.tk-sq-word {
+    text-align: center;
+    font-size: 2.2rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    margin: 1rem 0;
+    color: var(--tk-text);
+}
+
+.tk-sq-blank {
+    display: inline-block;
+    min-width: 1.2em;
+    border-bottom: 3px solid var(--tk-primary);
+    margin: 0 0.08em;
+    text-align: center;
+    color: transparent;
+}
+
+.tk-sq-blank.tk-sq-revealed {
+    color: var(--tk-primary);
+    border-bottom-color: transparent;
+}
+
+/* Category Choice specifics */
+.tk-cc-prompt {
+    text-align: center;
+    margin-bottom: 0.75rem;
+}
+
+.tk-cc-category {
+    display: inline-block;
+    padding: 0.4rem 1.1rem;
+    background: var(--tk-primary);
+    color: white;
+    border-radius: 999px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.tk-cc-hint {
+    color: var(--tk-text-muted);
+    font-size: 0.9rem;
+    margin-top: 0.6rem;
+}
+
+/* Sentence Completion specifics */
+.tk-sc-prompt {
+    margin-bottom: 0.75rem;
+}
+
+.tk-sc-interface {
+    font-size: 1.05rem;
+    color: var(--tk-text-muted);
+    line-height: 1.4;
+    margin-bottom: 0.6rem;
+}
+
+.tk-sc-foreign {
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: var(--tk-text);
+    line-height: 1.35;
+}
+
+.tk-sc-label {
+    font-weight: 700;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+@media (max-width: 540px) {
+    .tk-options {
+        grid-template-columns: 1fr 1fr;
+    }
+    .tk-sq-word {
+        font-size: 1.6rem;
+    }
+}

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -682,11 +682,77 @@
     letter-spacing: 0.04em;
 }
 
+/* Multiple Choice specifics */
+.tk-mc-prompt {
+    text-align: center;
+    margin-bottom: 0.75rem;
+}
+
+.tk-mc-word {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--tk-text);
+}
+
+.tk-mc-sub {
+    font-size: 0.9rem;
+    color: var(--tk-text-muted);
+    margin-top: 0.25rem;
+}
+
+/* Listening specifics */
+.tk-listen-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.tk-listen-play {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 1rem 2rem;
+    background: var(--tk-primary);
+    color: white;
+    border: none;
+    border-radius: 999px;
+    font-size: 1.15rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.12s ease, transform 0.08s ease;
+}
+
+.tk-listen-play:hover {
+    background: var(--tk-primary-hover);
+    transform: scale(1.03);
+}
+
+.tk-listen-play.is-playing {
+    background: var(--tk-primary-dark);
+}
+
+.tk-listen-icon {
+    font-size: 1.3rem;
+    line-height: 1;
+}
+
+.tk-listen-reveal {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--tk-primary-dark);
+    margin-top: 0.25rem;
+}
+
 @media (max-width: 540px) {
     .tk-options {
         grid-template-columns: 1fr 1fr;
     }
     .tk-sq-word {
         font-size: 1.6rem;
+    }
+    .tk-mc-word {
+        font-size: 1.4rem;
     }
 }

--- a/src/barsukas/static/js/trakaido_activities.js
+++ b/src/barsukas/static/js/trakaido_activities.js
@@ -1,0 +1,119 @@
+/**
+ * Client-side quiz engine for Trakaido activities in Barsukas.
+ *
+ * Each activity page embeds a JSON array of questions in a global variable
+ * (window.TK_QUESTIONS) and calls TrakaidoQuiz.init() with a renderer
+ * callback that knows how to display one question.
+ */
+var TrakaidoQuiz = (function () {
+  var questions = [];
+  var currentIndex = 0;
+  var score = 0;
+  var answered = false;
+  var renderer = null;
+
+  function init(opts) {
+    questions = opts.questions || [];
+    renderer = opts.renderer;
+    currentIndex = 0;
+    score = 0;
+    answered = false;
+
+    if (questions.length === 0) {
+      _showEmpty();
+      return;
+    }
+
+    _updateProgress();
+    _showQuestion();
+  }
+
+  function _showEmpty() {
+    var area = document.getElementById("tk-activity-area");
+    if (area) {
+      area.innerHTML =
+        '<div class="trakaido-empty">' +
+        "Not enough data at this level to build a quiz. Try a different level." +
+        "</div>";
+    }
+    var prog = document.getElementById("tk-progress");
+    if (prog) prog.style.display = "none";
+    var nav = document.getElementById("tk-nav-buttons");
+    if (nav) nav.style.display = "none";
+  }
+
+  function _updateProgress() {
+    var el = document.getElementById("tk-progress-text");
+    if (el) {
+      el.textContent =
+        "Question " +
+        (currentIndex + 1) +
+        " of " +
+        questions.length +
+        "  |  Score: " +
+        score +
+        "/" +
+        (currentIndex + (answered ? 1 : 0));
+    }
+    var bar = document.getElementById("tk-progress-bar");
+    if (bar) {
+      bar.style.width = ((currentIndex / questions.length) * 100).toFixed(1) + "%";
+    }
+  }
+
+  function _showQuestion() {
+    answered = false;
+    _updateProgress();
+    if (renderer) {
+      renderer(questions[currentIndex], currentIndex);
+    }
+    var nextBtn = document.getElementById("tk-next-btn");
+    if (nextBtn) nextBtn.disabled = true;
+  }
+
+  function recordAnswer(isCorrect) {
+    if (answered) return;
+    answered = true;
+    if (isCorrect) score++;
+    _updateProgress();
+    var nextBtn = document.getElementById("tk-next-btn");
+    if (nextBtn) nextBtn.disabled = false;
+  }
+
+  function next() {
+    if (!answered) return;
+    currentIndex++;
+    if (currentIndex >= questions.length) {
+      _showResults();
+    } else {
+      _showQuestion();
+    }
+  }
+
+  function _showResults() {
+    var area = document.getElementById("tk-activity-area");
+    var pct = questions.length > 0 ? Math.round((score / questions.length) * 100) : 0;
+    var emoji = pct >= 80 ? "&#9733;" : pct >= 50 ? "&#9675;" : "&#9744;";
+    if (area) {
+      area.innerHTML =
+        '<div class="trakaido-card" style="text-align:center;padding:2rem">' +
+        '<div style="font-size:3rem;margin-bottom:0.5rem">' + emoji + "</div>" +
+        "<h2>Round Complete</h2>" +
+        '<p style="font-size:1.3rem;margin:0.75rem 0">' +
+        score + " / " + questions.length + " correct (" + pct + "%)" +
+        "</p>" +
+        '<button class="trakaido-button" onclick="location.reload()">Play Again</button>' +
+        "</div>";
+    }
+    var bar = document.getElementById("tk-progress-bar");
+    if (bar) bar.style.width = "100%";
+    var nav = document.getElementById("tk-nav-buttons");
+    if (nav) nav.style.display = "none";
+  }
+
+  function getCurrentIndex() {
+    return currentIndex;
+  }
+
+  return { init: init, recordAnswer: recordAnswer, next: next, getCurrentIndex: getCurrentIndex };
+})();

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -125,6 +125,16 @@
                             <li><a class="dropdown-item" href="{{ url_for('trakaido.lemma_search') }}">
                                 <i class="bi bi-book"></i> Lemma View
                             </a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
+                                <i class="bi bi-pencil"></i> Spelling Quiz
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.category_choice') }}">
+                                <i class="bi bi-grid-3x3-gap"></i> Category Choice
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.sentence_completion') }}">
+                                <i class="bi bi-input-cursor-text"></i> Sentence Completion
+                            </a></li>
                         </ul>
                     </li>
                     {% if not config.get('READONLY', False) %}

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -135,6 +135,12 @@
                             <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.sentence_completion') }}">
                                 <i class="bi bi-input-cursor-text"></i> Sentence Completion
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.multiple_choice') }}">
+                                <i class="bi bi-ui-radios"></i> Multiple Choice
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.listening') }}">
+                                <i class="bi bi-headphones"></i> Listening
+                            </a></li>
                         </ul>
                     </li>
                     {% if not config.get('READONLY', False) %}

--- a/src/barsukas/templates/trakaido/activities/base_activity.html
+++ b/src/barsukas/templates/trakaido/activities/base_activity.html
@@ -33,6 +33,7 @@
                 {% endfor %}
             </select>
         </div>
+        {% block activity_extra_controls %}{% endblock %}
         <input type="hidden" name="interface_lang" value="{{ interface_lang }}">
     </form>
 

--- a/src/barsukas/templates/trakaido/activities/base_activity.html
+++ b/src/barsukas/templates/trakaido/activities/base_activity.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-header">
+        <h1>{% block activity_title %}Activity{% endblock %}</h1>
+        <p class="trakaido-meta">{% block activity_subtitle %}{% endblock %}</p>
+    </div>
+
+    <!-- Controls bar: level + language selectors -->
+    <form class="trakaido-controls" method="get">
+        <div class="trakaido-control">
+            <label for="level-select">Level</label>
+            <select id="level-select" name="level" onchange="this.form.submit()">
+                {% for lvl in available_levels %}
+                <option value="{{ lvl }}" {% if lvl == level %}selected{% endif %}>
+                    Level {{ lvl }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="trakaido-control">
+            <label for="foreign-lang-select">Target language</label>
+            <select id="foreign-lang-select" name="foreign_lang" onchange="this.form.submit()">
+                {% for code, name in supported_languages.items() %}
+                <option value="{{ code }}" {% if code == foreign_lang %}selected{% endif %}>
+                    {{ name }}
+                </option>
+                {% endfor %}
+            </select>
+        </div>
+        <input type="hidden" name="interface_lang" value="{{ interface_lang }}">
+    </form>
+
+    <!-- Progress bar -->
+    <div id="tk-progress" class="tk-progress-wrapper">
+        <div id="tk-progress-text" class="tk-progress-text">Loading…</div>
+        <div class="tk-progress-track">
+            <div id="tk-progress-bar" class="tk-progress-fill" style="width:0%"></div>
+        </div>
+    </div>
+
+    <!-- Activity area (rendered by JS) -->
+    <div id="tk-activity-area" class="trakaido-card tk-activity-area">
+        {% block activity_initial %}{% endblock %}
+    </div>
+
+    <!-- Navigation -->
+    <div id="tk-nav-buttons" class="tk-nav-buttons">
+        <button id="tk-next-btn" class="trakaido-button" disabled onclick="TrakaidoQuiz.next()">
+            Next &#8594;
+        </button>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/trakaido_activities.js') }}"></script>
+{% block activity_scripts %}{% endblock %}
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/category_choice.html
+++ b/src/barsukas/templates/trakaido/activities/category_choice.html
@@ -1,0 +1,85 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Category Choice{% endblock %}
+{% block activity_title %}Category Choice{% endblock %}
+{% block activity_subtitle %}Pick the word that belongs to the shown category.{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-cc-prompt">' +
+        '<div class="tk-cc-category">' + escapeHtml(q.category) + '</div>' +
+        '<div class="tk-cc-hint">Which word belongs to this category?</div>' +
+      '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      var o = q.options[i];
+      html +=
+        '<button class="tk-option-btn" data-idx="' + i + '">' +
+          '<span class="tk-opt-foreign">' + escapeHtml(o.foreign) + '</span>' +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", function (e) {
+        handleClick(e, q);
+      });
+    }
+  }
+
+  function handleClick(e, q) {
+    var btn = e.currentTarget;
+    var selectedIdx = parseInt(btn.getAttribute("data-idx"), 10);
+    var selected = q.options[selectedIdx];
+    var isCorrect = selected.correct;
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = q.options[parseInt(allBtns[k].getAttribute("data-idx"), 10)];
+      if (opt.correct) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (k === selectedIdx && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+      // Show English after answering
+      var eng = document.createElement("span");
+      eng.className = "tk-opt-english";
+      eng.textContent = "(" + opt.english + ")";
+      allBtns[k].appendChild(eng);
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      fb.textContent = isCorrect
+        ? "Correct!"
+        : "Incorrect — the answer is " + q.correct_foreign + " (" + q.correct_english + ")";
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/index.html
+++ b/src/barsukas/templates/trakaido/activities/index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Trakaido Activities{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="trakaido-page">
+    <div class="trakaido-hero">
+        <h1>Trakaido Activities</h1>
+        <p class="trakaido-subtitle">Interactive language-learning activities drawn from the Barsukas database.</p>
+    </div>
+
+    <div class="trakaido-activity-grid">
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
+            <div class="trakaido-activity-icon">&#9998;</div>
+            <h2>Spelling Quiz</h2>
+            <p>A word is shown with a missing letter or digraph. Pick the correct spelling from confusable options.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.category_choice') }}">
+            <div class="trakaido-activity-icon">&#9783;</div>
+            <h2>Category Choice</h2>
+            <p>Given a semantic category (animals, food, etc.), pick the word that belongs.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.sentence_completion') }}">
+            <div class="trakaido-activity-icon">&#9999;</div>
+            <h2>Sentence Completion</h2>
+            <p>A sentence is shown with one word blanked out. Choose the missing word from four options.</p>
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/index.html
+++ b/src/barsukas/templates/trakaido/activities/index.html
@@ -29,6 +29,16 @@
             <h2>Sentence Completion</h2>
             <p>A sentence is shown with one word blanked out. Choose the missing word from four options.</p>
         </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.multiple_choice') }}">
+            <div class="trakaido-activity-icon">&#10004;</div>
+            <h2>Multiple Choice</h2>
+            <p>Translate a word by picking the correct option from four choices.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.listening') }}">
+            <div class="trakaido-activity-icon">&#127911;</div>
+            <h2>Listening</h2>
+            <p>Listen to a word and identify it from four options.</p>
+        </a>
     </div>
 </div>
 {% endblock %}

--- a/src/barsukas/templates/trakaido/activities/listening.html
+++ b/src/barsukas/templates/trakaido/activities/listening.html
@@ -10,7 +10,7 @@
     <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
         {% for mode in study_modes %}
         <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
-            {% if mode == "target-to-source" %}Listen → English{% else %}Listen → Foreign{% endif %}
+            {% if mode == "target-to-source" %}Listen → Interface{% else %}Listen → Target{% endif %}
         </option>
         {% endfor %}
     </select>
@@ -108,12 +108,12 @@
       fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
     }
 
-    // Show the foreign word after answering
+    // Show the target word after answering
     var prompt = document.querySelector(".tk-listen-prompt");
     if (prompt) {
       var reveal = document.createElement("div");
       reveal.className = "tk-listen-reveal";
-      reveal.textContent = q.foreign_word;
+      reveal.textContent = q.target_word;
       prompt.appendChild(reveal);
     }
   }

--- a/src/barsukas/templates/trakaido/activities/listening.html
+++ b/src/barsukas/templates/trakaido/activities/listening.html
@@ -1,0 +1,130 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Listening{% endblock %}
+{% block activity_title %}Listening{% endblock %}
+{% block activity_subtitle %}Listen to the audio and pick the correct answer.{% endblock %}
+
+{% block activity_extra_controls %}
+<div class="trakaido-control">
+    <label for="study-mode-select">Study mode</label>
+    <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
+        {% for mode in study_modes %}
+        <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
+            {% if mode == "target-to-source" %}Listen → English{% else %}Listen → Foreign{% endif %}
+        </option>
+        {% endfor %}
+    </select>
+</div>
+{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+  var audio = new Audio();
+  var currentBtn = null;
+
+  audio.addEventListener("ended", function () {
+    if (currentBtn) currentBtn.classList.remove("is-playing");
+    currentBtn = null;
+  });
+
+  function playAudio(url, btn) {
+    if (currentBtn) currentBtn.classList.remove("is-playing");
+    audio.src = url;
+    audio.play().then(function () {
+      if (btn) {
+        btn.classList.add("is-playing");
+        currentBtn = btn;
+      }
+    }).catch(function () {});
+  }
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-listen-prompt">' +
+        '<button class="tk-listen-play" id="tk-listen-play">' +
+          '<span class="tk-listen-icon">&#9654;</span>' +
+          '<span>Play Audio</span>' +
+        '</button>' +
+      '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      html +=
+        '<button class="tk-option-btn" data-idx="' + i + '">' +
+          escapeHtml(q.options[i].text) +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var playBtn = document.getElementById("tk-listen-play");
+    playBtn.addEventListener("click", function () {
+      playAudio(q.audio_url, playBtn);
+    });
+
+    // Auto-play on render
+    setTimeout(function () {
+      playAudio(q.audio_url, playBtn);
+    }, 200);
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", function (e) {
+        handleClick(e, q);
+      });
+    }
+  }
+
+  function handleClick(e, q) {
+    var btn = e.currentTarget;
+    var selectedIdx = parseInt(btn.getAttribute("data-idx"), 10);
+    var selected = q.options[selectedIdx];
+    var isCorrect = selected.correct;
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = q.options[parseInt(allBtns[k].getAttribute("data-idx"), 10)];
+      if (opt.correct) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (k === selectedIdx && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      var msg = isCorrect ? "Correct!" : "Incorrect — the answer is " + q.correct_answer;
+      fb.textContent = msg;
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+
+    // Show the foreign word after answering
+    var prompt = document.querySelector(".tk-listen-prompt");
+    if (prompt) {
+      var reveal = document.createElement("div");
+      reveal.className = "tk-listen-reveal";
+      reveal.textContent = q.foreign_word;
+      prompt.appendChild(reveal);
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/multiple_choice.html
+++ b/src/barsukas/templates/trakaido/activities/multiple_choice.html
@@ -1,0 +1,94 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Multiple Choice{% endblock %}
+{% block activity_title %}Multiple Choice{% endblock %}
+{% block activity_subtitle %}Pick the correct translation from four options.{% endblock %}
+
+{% block activity_extra_controls %}
+<div class="trakaido-control">
+    <label for="study-mode-select">Study mode</label>
+    <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
+        {% for mode in study_modes %}
+        <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
+            {% if mode == "target-to-source" %}Foreign → English{% else %}English → Foreign{% endif %}
+        </option>
+        {% endfor %}
+    </select>
+</div>
+{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-mc-prompt">' +
+        '<div class="tk-mc-word">' + escapeHtml(q.prompt) + '</div>';
+    if (q.prompt_sub) {
+      html += '<div class="tk-mc-sub">' + escapeHtml(q.prompt_sub) + '</div>';
+    }
+    html += '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      html +=
+        '<button class="tk-option-btn" data-idx="' + i + '">' +
+          escapeHtml(q.options[i].text) +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", function (e) {
+        handleClick(e, q);
+      });
+    }
+  }
+
+  function handleClick(e, q) {
+    var btn = e.currentTarget;
+    var selectedIdx = parseInt(btn.getAttribute("data-idx"), 10);
+    var selected = q.options[selectedIdx];
+    var isCorrect = selected.correct;
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = q.options[parseInt(allBtns[k].getAttribute("data-idx"), 10)];
+      if (opt.correct) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (k === selectedIdx && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      fb.textContent = isCorrect
+        ? "Correct!"
+        : "Incorrect — the answer is " + q.correct_answer;
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/multiple_choice.html
+++ b/src/barsukas/templates/trakaido/activities/multiple_choice.html
@@ -10,7 +10,7 @@
     <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
         {% for mode in study_modes %}
         <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
-            {% if mode == "target-to-source" %}Foreign → English{% else %}English → Foreign{% endif %}
+            {% if mode == "target-to-source" %}Target → Interface{% else %}Interface → Target{% endif %}
         </option>
         {% endfor %}
     </select>

--- a/src/barsukas/templates/trakaido/activities/sentence_completion.html
+++ b/src/barsukas/templates/trakaido/activities/sentence_completion.html
@@ -1,0 +1,94 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Sentence Completion{% endblock %}
+{% block activity_title %}Sentence Completion{% endblock %}
+{% block activity_subtitle %}Choose the missing word to complete the sentence.{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-sc-prompt">' +
+        '<div class="tk-sc-interface">' +
+          '<span class="tk-sc-label">English:</span> ' +
+          escapeHtml(q.interface_sentence) +
+        '</div>' +
+        '<div class="tk-sc-foreign">' +
+          '<span class="tk-sc-label">Complete:</span> ' +
+          '<span id="tk-sc-sentence">' + escapeHtml(q.blanked_sentence) + '</span>' +
+        '</div>' +
+      '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      var o = q.options[i];
+      html +=
+        '<button class="tk-option-btn" data-idx="' + i + '">' +
+          escapeHtml(o.text) +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", function (e) {
+        handleClick(e, q);
+      });
+    }
+  }
+
+  function handleClick(e, q) {
+    var btn = e.currentTarget;
+    var selectedIdx = parseInt(btn.getAttribute("data-idx"), 10);
+    var selected = q.options[selectedIdx];
+    var isCorrect = selected.correct;
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    // Fill in the blank in the sentence
+    var sentenceEl = document.getElementById("tk-sc-sentence");
+    if (sentenceEl) {
+      sentenceEl.innerHTML = escapeHtml(
+        q.blanked_sentence.replace("___", q.correct_answer)
+      );
+    }
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = q.options[parseInt(allBtns[k].getAttribute("data-idx"), 10)];
+      if (opt.correct) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (k === selectedIdx && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      fb.textContent = isCorrect
+        ? "Correct!"
+        : "Incorrect — the answer is " + q.correct_answer;
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/spelling_quiz.html
+++ b/src/barsukas/templates/trakaido/activities/spelling_quiz.html
@@ -1,0 +1,95 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Spelling Quiz{% endblock %}
+{% block activity_title %}Spelling Quiz{% endblock %}
+{% block activity_subtitle %}Pick the correct letter or digraph to complete the word.{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+    var before = q.word.substring(0, q.blank_start);
+    var after = q.word.substring(q.blank_end);
+
+    var html =
+      '<div class="tk-sq-prompt">' +
+        '<div class="tk-sq-english">' + escapeHtml(q.english) + '</div>' +
+        '<div class="tk-sq-definition">' + escapeHtml(q.definition) + '</div>' +
+      '</div>' +
+      '<div class="tk-sq-word">' +
+        '<span>' + escapeHtml(before) + '</span>' +
+        '<span class="tk-sq-blank" id="tk-sq-blank">_</span>' +
+        '<span>' + escapeHtml(after) + '</span>' +
+      '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      html +=
+        '<button class="tk-option-btn" data-option="' + escapeAttr(q.options[i]) + '">' +
+        escapeHtml(q.options[i]) +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", handleClick);
+    }
+  }
+
+  function handleClick(e) {
+    var btn = e.currentTarget;
+    var selected = btn.getAttribute("data-option");
+    var currentQ = questions[TrakaidoQuiz.getCurrentIndex()];
+    if (!currentQ) return;
+
+    var isCorrect = selected.toLowerCase() === currentQ.correct_answer.toLowerCase();
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    // Reveal
+    var blank = document.getElementById("tk-sq-blank");
+    if (blank) {
+      blank.textContent = currentQ.correct_answer;
+      blank.classList.add("tk-sq-revealed");
+    }
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = allBtns[k].getAttribute("data-option");
+      if (opt.toLowerCase() === currentQ.correct_answer.toLowerCase()) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (opt === selected && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      fb.textContent = isCorrect ? "Correct!" : "Incorrect — the answer is " + currentQ.correct_answer;
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  function escapeAttr(s) {
+    return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&#39;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/index.html
+++ b/src/barsukas/templates/trakaido/index.html
@@ -39,6 +39,16 @@
             <h2>Sentence Completion</h2>
             <p>Choose the missing word to complete a sentence.</p>
         </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.multiple_choice') }}">
+            <div class="trakaido-activity-icon">&#10004;</div>
+            <h2>Multiple Choice</h2>
+            <p>Translate a word by picking the correct option from four choices.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.listening') }}">
+            <div class="trakaido-activity-icon">&#127911;</div>
+            <h2>Listening</h2>
+            <p>Listen to a word and identify it from four options.</p>
+        </a>
     </div>
 </div>
 {% endblock %}

--- a/src/barsukas/templates/trakaido/index.html
+++ b/src/barsukas/templates/trakaido/index.html
@@ -15,14 +15,29 @@
 
     <div class="trakaido-activity-grid">
         <a class="trakaido-activity-card" href="{{ url_for('trakaido.compare_random') }}">
-            <div class="trakaido-activity-icon">↔</div>
+            <div class="trakaido-activity-icon">&#8596;</div>
             <h2>Sentence Comparison</h2>
             <p>Word-by-word interlinear view of a random sentence in two languages.</p>
         </a>
         <a class="trakaido-activity-card" href="{{ url_for('trakaido.lemma_search') }}">
-            <div class="trakaido-activity-icon">📖</div>
+            <div class="trakaido-activity-icon">&#128214;</div>
             <h2>Lemma View</h2>
             <p>Look up a lemma to see its translation, forms, and audio in two languages.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
+            <div class="trakaido-activity-icon">&#9998;</div>
+            <h2>Spelling Quiz</h2>
+            <p>Pick the correct letter or digraph to complete a word from confusable options.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.category_choice') }}">
+            <div class="trakaido-activity-icon">&#9783;</div>
+            <h2>Category Choice</h2>
+            <p>Given a semantic category, pick the word that belongs.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.sentence_completion') }}">
+            <div class="trakaido-activity-icon">&#9999;</div>
+            <h2>Sentence Completion</h2>
+            <p>Choose the missing word to complete a sentence.</p>
         </a>
     </div>
 </div>


### PR DESCRIPTION
Port three "weird" Trakaido activities to Greenland's Barsukas web UI:

- Spelling Quiz: shows a foreign word with a missing letter/digraph, user
  picks the correct one from confusable options (supports lt/fr/es/de)
- Category Choice: given a semantic category (animals, food, etc.), user
  picks which word belongs from four options
- Sentence Completion: a sentence is shown with one content word blanked
  out, user picks the missing word from four options

All activities use Greenland UI patterns (Bootstrap + trakaido CSS cards),
with no persistence - just a level selector and language picker on each
page. Quiz logic runs client-side via a shared JS engine; question data
is generated server-side from the linguistics database and embedded as
JSON in the page.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YBbF1xna5ihXHefwA33yCU