### PR TITLE
Gracefully fall back to SQLite when Postgres credentials are unavailable

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -137,8 +137,11 @@ def create_app(
             try:
                 postgres_url = DataSourceConfig.build_postgres_url()
             except Exception as e:
-                print(f"Error building PostgreSQL URL: {e}", file=sys.stderr)
-                sys.exit(1)
+                print(
+                    f"Warning: PostgreSQL credentials not available ({e}), "
+                    f"falling back to SQLite",
+                    file=sys.stderr,
+                )
 
     if postgres_url:
         # PostgreSQL backend
@@ -197,27 +200,36 @@ def create_app(
         try:
             concepts_postgres_url = DataSourceConfig.build_postgres_url()
         except Exception as concepts_exc:
-            print(f"Error building PostgreSQL URL for concepts: {concepts_exc}", file=sys.stderr)
-            sys.exit(1)
+            print(
+                f"Warning: Concepts PostgreSQL credentials not available ({concepts_exc}), "
+                f"concepts DB disabled",
+                file=sys.stderr,
+            )
+            concepts_postgres_url = None
 
-        concepts_backend_config = DataSourceConfig(
-            backend_type=BackendType.POSTGRES,
-            postgres_url=concepts_postgres_url,
-            use_word2vec=use_word2vec,
-        )
-
-        # golden/hosted connect read-only: writes/DDL are rejected at the server,
-        # not merely gated by CONCEPTS_WRITABLE route checks.
-        concepts_readonly = os.environ.get("BARSUKAS_CONCEPTS_READONLY") == "true"
-
-        def concepts_session_factory() -> Session:
-            return cast(
-                Session, create_session(concepts_backend_config, readonly=concepts_readonly)
+        if concepts_postgres_url:
+            concepts_backend_config = DataSourceConfig(
+                backend_type=BackendType.POSTGRES,
+                postgres_url=concepts_postgres_url,
+                use_word2vec=use_word2vec,
             )
 
-        app.concepts_db_session_factory = concepts_session_factory
-        app.config["CONCEPTS_BACKEND"] = "postgres"
-        app.config["CONCEPTS_WRITABLE"] = not concepts_readonly
+            # golden/hosted connect read-only: writes/DDL are rejected at the server,
+            # not merely gated by CONCEPTS_WRITABLE route checks.
+            concepts_readonly = os.environ.get("BARSUKAS_CONCEPTS_READONLY") == "true"
+
+            def concepts_session_factory() -> Session:
+                return cast(
+                    Session,
+                    create_session(concepts_backend_config, readonly=concepts_readonly),
+                )
+
+            app.concepts_db_session_factory = concepts_session_factory
+            app.config["CONCEPTS_BACKEND"] = "postgres"
+            app.config["CONCEPTS_WRITABLE"] = not concepts_readonly
+        else:
+            app.config["CONCEPTS_BACKEND"] = backend_config.backend_type.value
+            app.config["CONCEPTS_WRITABLE"] = False
     else:
         app.config["CONCEPTS_BACKEND"] = backend_config.backend_type.value
         app.config["CONCEPTS_WRITABLE"] = False

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -200,6 +200,7 @@ def main() -> None:
         os.environ["USE_WORD2VEC"] = "true"
 
     # Determine backend type
+    db_display: Optional[str] = None
     if args.postgres or os.environ.get("USE_POSTGRES_BACKEND") == "true":
         # PostgreSQL mode - build URL from template + key
         try:
@@ -209,9 +210,10 @@ def main() -> None:
             logger.info("PostgreSQL mode: connecting to Supabase")
             db_display = "PostgreSQL (Supabase)"
         except Exception as e:
-            logger.error(f"Failed to build PostgreSQL URL: {e}")
-            sys.exit(1)
-    elif persona and persona.use_jsonl:
+            logger.warning(f"PostgreSQL credentials not available ({e}), falling back to SQLite")
+            args.postgres = False
+
+    if db_display is None and persona and persona.use_jsonl:
         # JSONL mode from persona (e.g., GOLDEN)
         repo_root = Path(__file__).parent.parent.parent
         jsonl_dir = repo_root / (persona.jsonl_data_dir or "data/release")
@@ -221,11 +223,11 @@ def main() -> None:
         os.environ["STORAGE_BACKEND"] = "jsonl"
         os.environ["JSONL_DATA_DIR"] = str(jsonl_dir)
         db_display = f"JSONL ({jsonl_dir})"
-    elif os.environ.get("STORAGE_BACKEND") == "jsonl":
+    elif db_display is None and os.environ.get("STORAGE_BACKEND") == "jsonl":
         # JSONL mode from environment
         jsonl_dir_env = os.environ.get("JSONL_DATA_DIR", "data/release")
         db_display = f"JSONL ({jsonl_dir_env})"
-    else:
+    elif db_display is None:
         # SQLite mode - validate database exists
         if not Path(Config.DB_PATH).exists():
             logger.error(f"Database not found at {Config.DB_PATH}")


### PR DESCRIPTION
Instead of calling sys.exit(1) when keys/postgres.key is missing, barsukas
now warns and falls back to the SQLite backend. This applies to the main
DB connection in app.py, the concepts DB connection, and the unified_app.py
launcher. The benchmarks section already handled this gracefully.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018e3W3M8LkuoeqEN1FA28ZE