### PR TITLE
Finish Trakaido activities port: flashcards, typing, verb forms; weighted levels; shared session tracking

### DIFF
--- a/.agents/peer-repo/greenland-status.md
+++ b/.agents/peer-repo/greenland-status.md
@@ -55,6 +55,16 @@ All agents follow standardized command-line interfaces via `src/agents/common_ar
 - Manage word relationships
 - Quality control and validation
 
+Barsukas also hosts the **Trakaido activities** (`/trakaido/activities/`):
+server-rendered, multi-language versions of the Trakaido web study modes
+(spelling quiz, category choice, sentence completion, multiple choice,
+listening, flashcards, typing, verb forms). These are stateless and take only
+a level parameter — the selected level acts as a ceiling, with lower-level
+words quizzed less often. Per-user stat tracking stays in the Trakaido apps
+(which are migrating to Lithuanian-only); a lightweight sessionStorage-based
+practice session (accuracy, streaks) is shared across the Greenland
+activities client-side.
+
 ### Language Support
 
 The system maintains comprehensive language code mappings in `src/storage/translation_helpers.py`, which serves as the single source of truth for:

--- a/src/barsukas/routes/trakaido_activities.py
+++ b/src/barsukas/routes/trakaido_activities.py
@@ -2,10 +2,13 @@
 
 """Trakaido interactive activities served by Barsukas.
 
-Ports the "weird" Trakaido activities (spelling quiz, category choice,
-sentence completion) into server-rendered pages using the Greenland UI
-patterns.  No user state is persisted; a level dropdown on each page
-selects which difficulty band to draw words from.
+Ports the Trakaido web activities (spelling quiz, category choice,
+sentence completion, multiple choice, listening, flashcards, typing,
+verb forms) into server-rendered pages using the Greenland UI patterns.
+No user state is persisted server-side; a level dropdown on each page
+selects the difficulty ceiling to draw words from.  Words below the
+selected level are still quizzed, but with exponentially decreasing
+frequency the further below the level they sit.
 """
 
 import json
@@ -16,6 +19,7 @@ from flask import Blueprint, g, render_template, request, url_for
 from flask.typing import ResponseReturnValue
 from sqlalchemy import func
 
+from storage.models.grammar_fact import GrammarFact
 from storage.models.schema import (
     AudioQualityReview,
     Lemma,
@@ -30,7 +34,13 @@ bp = Blueprint("trakaido_activities", __name__, url_prefix="/trakaido/activities
 DEFAULT_INTERFACE_LANG = "en"
 DEFAULT_FOREIGN_LANG = "lt"
 _QUESTIONS_PER_ROUND = 10
-_LEVEL_EXPAND_RANGE = 2
+
+# Level weighting: the selected level is the ceiling.  Each level below the
+# selected one is _LEVEL_DECAY times as likely to be drawn as the level above
+# it, with a floor so long-learned words still show up occasionally.
+_LEVEL_DECAY = 0.5
+_LEVEL_WEIGHT_FLOOR = 0.05
+_POOL_FETCH_CAP = 400
 
 CONFUSION_SETS: Dict[str, List[Dict[str, Any]]] = {
     "lt": [
@@ -121,8 +131,48 @@ def _available_levels() -> List[int]:
     return [row[0] for row in rows]
 
 
+def _level_weight(selected_level: int, item_level: int) -> float:
+    """Relative draw weight for an item at *item_level* when quizzing *selected_level*."""
+    return max(_LEVEL_WEIGHT_FLOOR, _LEVEL_DECAY ** (selected_level - item_level))
+
+
+def _weighted_sample_by_level(
+    items: List[Dict[str, Any]], selected_level: int, count: int
+) -> List[Dict[str, Any]]:
+    """Sample up to *count* items, favoring the selected level.
+
+    Each item must carry a ``level`` key.  The selected level gets the
+    highest draw weight; each level below it is exponentially less likely.
+    Items are drawn without replacement, so if the preferred levels run
+    out the remaining slots fall through to whatever is left.
+    """
+    by_level: Dict[int, List[Dict[str, Any]]] = {}
+    for item in items:
+        by_level.setdefault(int(item["level"]), []).append(item)
+    for bucket in by_level.values():
+        random.shuffle(bucket)
+
+    picked: List[Dict[str, Any]] = []
+    while len(picked) < count and by_level:
+        levels = list(by_level.keys())
+        weights = [_level_weight(selected_level, lvl) for lvl in levels]
+        chosen_level = random.choices(levels, weights=weights, k=1)[0]
+        bucket = by_level[chosen_level]
+        picked.append(bucket.pop())
+        if not bucket:
+            del by_level[chosen_level]
+
+    random.shuffle(picked)
+    return picked
+
+
 def _fetch_words_at_level(level: int, foreign_lang: str, limit: int = 40) -> List[Dict[str, Any]]:
-    """Fetch lemmas near the given difficulty level with foreign translations."""
+    """Fetch lemmas at or below the given difficulty level with foreign translations.
+
+    The selected level is a ceiling: words above it never appear, and words
+    below it are included with exponentially decreasing frequency the further
+    below the level they sit (see _weighted_sample_by_level).
+    """
     rows = (
         g.db.query(Lemma, LemmaTranslation.translation)
         .join(LemmaTranslation, LemmaTranslation.lemma_id == Lemma.id)
@@ -130,17 +180,9 @@ def _fetch_words_at_level(level: int, foreign_lang: str, limit: int = 40) -> Lis
         .filter(LemmaTranslation.translation.isnot(None))
         .filter(LemmaTranslation.translation != "")
         .filter(Lemma.difficulty_level.isnot(None))
-        .filter(
-            Lemma.difficulty_level.between(
-                max(1, level - _LEVEL_EXPAND_RANGE),
-                level + _LEVEL_EXPAND_RANGE,
-            )
-        )
-        .order_by(
-            func.abs(Lemma.difficulty_level - level),
-            func.random(),
-        )
-        .limit(limit)
+        .filter(Lemma.difficulty_level.between(1, level))
+        .order_by(func.random())
+        .limit(_POOL_FETCH_CAP)
         .all()
     )
 
@@ -157,7 +199,7 @@ def _fetch_words_at_level(level: int, foreign_lang: str, limit: int = 40) -> Lis
                 "level": lemma.difficulty_level,
             }
         )
-    return words
+    return _weighted_sample_by_level(words, level, limit)
 
 
 # ---------------------------------------------------------------------------
@@ -334,24 +376,28 @@ def _build_sentence_completion_questions(
     """Generate sentence-completion questions."""
     content_roles = {"verb", "noun", "subject", "object", "adjective", "adverb"}
 
+    # A sentence's level is the hardest word it contains; only sentences whose
+    # hardest word is at or below the selected level qualify, and easier
+    # sentences are drawn less often via the shared level weighting.
     sentence_rows = (
-        g.db.query(Sentence)
+        g.db.query(Sentence, func.max(Lemma.difficulty_level).label("sentence_level"))
         .join(SentenceWord, SentenceWord.sentence_id == Sentence.id)
         .join(Lemma, Lemma.id == SentenceWord.lemma_id)
         .filter(Sentence.rejected == False)  # noqa: E712
         .filter(SentenceWord.language_code == foreign_lang)
         .filter(Lemma.difficulty_level.isnot(None))
-        .filter(
-            Lemma.difficulty_level.between(
-                max(1, level - _LEVEL_EXPAND_RANGE),
-                level + _LEVEL_EXPAND_RANGE,
-            )
-        )
-        .distinct()
+        .filter(Lemma.difficulty_level >= 1)
+        .group_by(Sentence.id)
+        .having(func.max(Lemma.difficulty_level) <= level)
         .order_by(func.random())
-        .limit(30)
+        .limit(120)
         .all()
     )
+    sentence_items: List[Dict[str, Any]] = [
+        {"sentence": sentence, "level": sentence_level}
+        for sentence, sentence_level in sentence_rows
+    ]
+    sampled_sentences = _weighted_sample_by_level(sentence_items, level, 30)
 
     decoy_words_rows = (
         g.db.query(LemmaTranslation.translation)
@@ -360,12 +406,7 @@ def _build_sentence_completion_questions(
         .filter(LemmaTranslation.translation.isnot(None))
         .filter(LemmaTranslation.translation != "")
         .filter(Lemma.difficulty_level.isnot(None))
-        .filter(
-            Lemma.difficulty_level.between(
-                max(1, level - _LEVEL_EXPAND_RANGE),
-                level + _LEVEL_EXPAND_RANGE,
-            )
-        )
+        .filter(Lemma.difficulty_level.between(1, level))
         .order_by(func.random())
         .limit(60)
         .all()
@@ -374,7 +415,8 @@ def _build_sentence_completion_questions(
 
     questions: List[Dict[str, Any]] = []
 
-    for sentence in sentence_rows:
+    for sentence_item in sampled_sentences:
+        sentence = sentence_item["sentence"]
         if len(questions) >= _QUESTIONS_PER_ROUND:
             break
 
@@ -499,6 +541,171 @@ def _build_multiple_choice_questions(
                 "prompt_sub": prompt_sub,
                 "correct_answer": correct_display,
                 "options": options,
+            }
+        )
+
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Flashcards
+# ---------------------------------------------------------------------------
+
+
+def _build_flashcard_questions(
+    words: List[Dict[str, Any]], study_mode: str
+) -> List[Dict[str, Any]]:
+    """Generate self-graded flashcards from a word list.
+
+    study_mode:
+      - "target-to-source": show foreign word, reveal the English meaning
+      - "source-to-target": show English word, reveal the foreign translation
+    """
+    cards: List[Dict[str, Any]] = []
+    for word_data in words:
+        if study_mode == "target-to-source":
+            front = word_data["foreign"]
+            front_sub = ""
+            back = word_data["english"]
+            back_sub = word_data["definition"] or ""
+        else:
+            front = word_data["english"]
+            front_sub = word_data["definition"] or ""
+            back = word_data["foreign"]
+            back_sub = ""
+
+        cards.append(
+            {
+                "front": front,
+                "front_sub": front_sub,
+                "back": back,
+                "back_sub": back_sub,
+            }
+        )
+        if len(cards) >= _QUESTIONS_PER_ROUND:
+            break
+    return cards
+
+
+# ---------------------------------------------------------------------------
+# Typing
+# ---------------------------------------------------------------------------
+
+
+def _build_typing_questions(words: List[Dict[str, Any]], study_mode: str) -> List[Dict[str, Any]]:
+    """Generate typing questions: show a word, type its translation.
+
+    study_mode:
+      - "source-to-target": show English word, type the foreign translation
+      - "target-to-source": show foreign word, type the English meaning
+    """
+    questions: List[Dict[str, Any]] = []
+    for word_data in words:
+        if study_mode == "target-to-source":
+            prompt = word_data["foreign"]
+            prompt_sub = ""
+            answer = word_data["english"]
+        else:
+            prompt = word_data["english"]
+            prompt_sub = word_data["definition"] or ""
+            answer = word_data["foreign"]
+
+        questions.append(
+            {
+                "prompt": prompt,
+                "prompt_sub": prompt_sub,
+                "answer": answer,
+            }
+        )
+        if len(questions) >= _QUESTIONS_PER_ROUND:
+            break
+    return questions
+
+
+# ---------------------------------------------------------------------------
+# Verb Forms
+# ---------------------------------------------------------------------------
+
+_VERB_FORM_LABELS: Dict[str, str] = {
+    "3s_present": "he / she / it — present tense",
+    "3s_past": "he / she / it — past tense",
+}
+
+
+def _fetch_verbs_with_forms(level: int, foreign_lang: str) -> List[Dict[str, Any]]:
+    """Fetch verb lemmas at or below *level* that have conjugation grammar facts."""
+    fact_types = list(_VERB_FORM_LABELS.keys()) + ["infinitive"]
+    rows = (
+        g.db.query(GrammarFact, Lemma)
+        .join(Lemma, Lemma.id == GrammarFact.lemma_id)
+        .filter(GrammarFact.language_code == foreign_lang)
+        .filter(GrammarFact.fact_type.in_(fact_types))
+        .filter(GrammarFact.fact_value.isnot(None))
+        .filter(GrammarFact.fact_value != "")
+        .filter(Lemma.difficulty_level.isnot(None))
+        .filter(Lemma.difficulty_level.between(1, level))
+        .all()
+    )
+
+    by_lemma: Dict[int, Dict[str, Any]] = {}
+    for fact, lemma in rows:
+        entry = by_lemma.setdefault(
+            lemma.id,
+            {
+                "id": lemma.id,
+                "english": lemma.lemma_text,
+                "definition": lemma.definition_text,
+                "level": lemma.difficulty_level,
+                "facts": {},
+            },
+        )
+        entry["facts"][fact.fact_type] = fact.fact_value
+
+    return [
+        verb
+        for verb in by_lemma.values()
+        if any(ftype in verb["facts"] for ftype in _VERB_FORM_LABELS)
+    ]
+
+
+def _build_verb_form_questions(verbs: List[Dict[str, Any]], level: int) -> List[Dict[str, Any]]:
+    """Generate conjugation questions: pick the correct verb form."""
+    if len(verbs) < 4:
+        return []
+
+    sampled = _weighted_sample_by_level(verbs, level, _QUESTIONS_PER_ROUND)
+    questions: List[Dict[str, Any]] = []
+
+    for verb in sampled:
+        available_forms = [ftype for ftype in _VERB_FORM_LABELS if ftype in verb["facts"]]
+        if not available_forms:
+            continue
+        form_type = random.choice(available_forms)
+        correct_text: str = verb["facts"][form_type]
+
+        decoys = [
+            v["facts"][form_type]
+            for v in verbs
+            if v["id"] != verb["id"]
+            and form_type in v["facts"]
+            and v["facts"][form_type].lower() != correct_text.lower()
+        ]
+        decoys = list(dict.fromkeys(decoys))
+        if len(decoys) < 3:
+            continue
+
+        random.shuffle(decoys)
+        option_list = [correct_text] + decoys[:3]
+        random.shuffle(option_list)
+
+        questions.append(
+            {
+                "english": verb["english"],
+                "definition": verb["definition"] or "",
+                "infinitive": verb["facts"].get("infinitive", ""),
+                "form_label": _VERB_FORM_LABELS[form_type],
+                "correct_answer": correct_text,
+                "options": [{"text": o, "correct": o == correct_text} for o in option_list],
             }
         )
 
@@ -681,6 +888,63 @@ def multiple_choice() -> ResponseReturnValue:
         question_count=len(questions),
         study_mode=study_mode,
         study_modes=_STUDY_MODES,
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/flashcards")
+def flashcards() -> ResponseReturnValue:
+    """Self-graded flashcard activity."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    study_mode = request.args.get("study_mode", "source-to-target")
+    if study_mode not in _STUDY_MODES:
+        study_mode = "source-to-target"
+
+    words = _fetch_words_at_level(level, foreign_lang, limit=_QUESTIONS_PER_ROUND)
+    questions = _build_flashcard_questions(words, study_mode)
+
+    return render_template(
+        "trakaido/activities/flashcards.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        study_mode=study_mode,
+        study_modes=_STUDY_MODES,
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/typing")
+def typing() -> ResponseReturnValue:
+    """Typing activity: type the translation of the shown word."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    study_mode = request.args.get("study_mode", "source-to-target")
+    if study_mode not in _STUDY_MODES:
+        study_mode = "source-to-target"
+
+    words = _fetch_words_at_level(level, foreign_lang, limit=_QUESTIONS_PER_ROUND)
+    questions = _build_typing_questions(words, study_mode)
+
+    return render_template(
+        "trakaido/activities/typing.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
+        study_mode=study_mode,
+        study_modes=_STUDY_MODES,
+        **_common_template_vars(level, interface_lang, foreign_lang),
+    )
+
+
+@bp.route("/verb-forms")
+def verb_forms() -> ResponseReturnValue:
+    """Verb conjugation activity: pick the correct form of a verb."""
+    level, interface_lang, foreign_lang = _parse_activity_params()
+    verbs = _fetch_verbs_with_forms(level, foreign_lang)
+    questions = _build_verb_form_questions(verbs, level)
+
+    return render_template(
+        "trakaido/activities/verb_forms.html",
+        questions_json=json.dumps(questions, ensure_ascii=False),
+        question_count=len(questions),
         **_common_template_vars(level, interface_lang, foreign_lang),
     )
 

--- a/src/barsukas/static/css/trakaido.css
+++ b/src/barsukas/static/css/trakaido.css
@@ -476,29 +476,128 @@
    Activity quiz styles
    ========================================================= */
 
-/* Progress bar */
+/* Progress header: batch dots + session line */
 .tk-progress-wrapper {
     margin-bottom: 1rem;
 }
 
-.tk-progress-text {
-    font-size: 0.85rem;
-    color: var(--tk-text-muted);
+.tk-progress-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
     margin-bottom: 0.35rem;
 }
 
-.tk-progress-track {
-    height: 6px;
-    background: var(--tk-border);
-    border-radius: 3px;
-    overflow: hidden;
+.tk-dots {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
 }
 
-.tk-progress-fill {
-    height: 100%;
-    background: var(--tk-primary);
-    border-radius: 3px;
-    transition: width 0.3s ease;
+.tk-dot {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    background: var(--tk-border);
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.tk-dot-current {
+    background: var(--tk-card-bg);
+    box-shadow: inset 0 0 0 2px var(--tk-primary);
+}
+
+.tk-dot-correct {
+    background: #16a34a;
+}
+
+.tk-dot-wrong {
+    background: #dc2626;
+}
+
+.tk-batch-score {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--tk-text);
+    white-space: nowrap;
+}
+
+.tk-session-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: 1.4em;
+}
+
+.tk-session-line {
+    font-size: 0.85rem;
+    color: var(--tk-text-muted);
+}
+
+.tk-session-reset {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.8rem;
+    color: var(--tk-text-muted);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.tk-session-reset:hover {
+    color: var(--tk-text);
+}
+
+/* Reset link in the activity header is hidden until there is a session. */
+.tk-session-row .tk-session-reset {
+    visibility: hidden;
+}
+
+/* Session summary strip on the activities index */
+.tk-session-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    background: var(--tk-card-bg);
+    border: 1px solid var(--tk-border);
+    border-radius: var(--tk-radius);
+    padding: 0.65rem 1rem;
+    margin-bottom: 1.25rem;
+    box-shadow: var(--tk-shadow);
+}
+
+/* Between-round card */
+.tk-round-card {
+    text-align: center;
+    padding: 1.5rem 1rem;
+}
+
+.tk-round-headline {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--tk-text);
+}
+
+.tk-round-session {
+    margin-top: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--tk-text-muted);
+}
+
+.tk-round-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    margin-top: 1.25rem;
+}
+
+.tk-round-link {
+    font-size: 0.9rem;
+    color: var(--tk-primary-dark);
 }
 
 /* Activity area */
@@ -745,6 +844,129 @@
     margin-top: 0.25rem;
 }
 
+/* Flashcards specifics */
+.tk-flashcard {
+    min-height: 180px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1.5rem 1rem;
+    border: 2px dashed var(--tk-border);
+    border-radius: var(--tk-radius);
+    cursor: pointer;
+    text-align: center;
+    transition: border-color 0.12s ease;
+}
+
+.tk-flashcard:hover {
+    border-color: var(--tk-primary);
+}
+
+.tk-fc-word {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: var(--tk-text);
+}
+
+.tk-fc-back .tk-fc-word {
+    color: var(--tk-primary-dark);
+}
+
+.tk-fc-sub {
+    font-size: 0.9rem;
+    color: var(--tk-text-muted);
+    margin-top: 0.25rem;
+}
+
+.tk-fc-hint {
+    font-size: 0.85rem;
+    color: var(--tk-text-muted);
+    font-style: italic;
+}
+
+.tk-fc-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.65rem;
+    margin-top: 1rem;
+}
+
+.tk-fc-got:hover:not(:disabled) {
+    border-color: #16a34a;
+    background: rgba(22, 163, 74, 0.08);
+}
+
+.tk-fc-missed:hover:not(:disabled) {
+    border-color: #dc2626;
+    background: rgba(220, 38, 38, 0.08);
+}
+
+/* Typing specifics */
+.tk-typing-row {
+    display: flex;
+    gap: 0.65rem;
+    justify-content: center;
+    margin-top: 1.25rem;
+}
+
+.tk-typing-input {
+    flex: 1;
+    max-width: 380px;
+    padding: 0.65rem 0.8rem;
+    border: 2px solid var(--tk-border);
+    border-radius: 8px;
+    font-size: 1.1rem;
+    color: var(--tk-text);
+}
+
+.tk-typing-input:focus {
+    outline: none;
+    border-color: var(--tk-primary);
+}
+
+.tk-typing-input.tk-typing-correct {
+    border-color: #16a34a;
+    background: rgba(22, 163, 74, 0.08);
+}
+
+.tk-typing-input.tk-typing-incorrect {
+    border-color: #dc2626;
+    background: rgba(220, 38, 38, 0.08);
+}
+
+.tk-typing-giveup-row {
+    text-align: center;
+    margin-top: 0.6rem;
+}
+
+.tk-typing-giveup {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 0.85rem;
+    color: var(--tk-text-muted);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.tk-typing-giveup:hover:not(:disabled) {
+    color: var(--tk-text);
+}
+
+/* Verb Forms specifics */
+.tk-vf-label {
+    display: inline-block;
+    padding: 0.3rem 0.9rem;
+    background: var(--tk-primary);
+    color: white;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.6rem;
+}
+
 @media (max-width: 540px) {
     .tk-options {
         grid-template-columns: 1fr 1fr;
@@ -754,5 +976,12 @@
     }
     .tk-mc-word {
         font-size: 1.4rem;
+    }
+    .tk-typing-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .tk-typing-input {
+        max-width: none;
     }
 }

--- a/src/barsukas/static/js/trakaido_activities.js
+++ b/src/barsukas/static/js/trakaido_activities.js
@@ -1,31 +1,160 @@
 /**
  * Client-side quiz engine for Trakaido activities in Barsukas.
  *
- * Each activity page embeds a JSON array of questions in a global variable
- * (window.TK_QUESTIONS) and calls TrakaidoQuiz.init() with a renderer
- * callback that knows how to display one question.
+ * Each activity page embeds a JSON array of questions in a template script
+ * block and calls TrakaidoQuiz.init() with a renderer callback that knows
+ * how to display one question.
+ *
+ * Progress is tracked at two layers:
+ *  - the current batch of questions, shown as a row of dots that fill in
+ *    green/red as they are answered; and
+ *  - a cumulative practice session (TrakaidoSession) persisted in
+ *    sessionStorage and shared by every activity: total answered, accuracy,
+ *    current/best streak, and a per-activity breakdown.  Finishing a batch
+ *    offers "keep going" (a plain reload fetches fresh questions while the
+ *    session carries on) rather than a hard restart.
  */
+
+var TrakaidoSession = (function () {
+  var STORAGE_KEY = "tk-session-v1";
+
+  function _blank(lang) {
+    return {
+      lang: lang || "",
+      startedAt: Date.now(),
+      answered: 0,
+      correct: 0,
+      streak: 0,
+      bestStreak: 0,
+      activities: {},
+    };
+  }
+
+  function load(lang) {
+    var data = null;
+    try {
+      var raw = window.sessionStorage.getItem(STORAGE_KEY);
+      if (raw) data = JSON.parse(raw);
+    } catch (e) {
+      data = null;
+    }
+    if (!data || typeof data.answered !== "number") {
+      return _blank(lang);
+    }
+    // Switching target language starts a fresh session.
+    if (lang && data.lang && data.lang !== lang) {
+      return _blank(lang);
+    }
+    return data;
+  }
+
+  function _save(data) {
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      /* private browsing etc. — session stats just won't persist */
+    }
+  }
+
+  function record(lang, activity, isCorrect) {
+    var s = load(lang);
+    s.lang = lang || s.lang;
+    s.answered++;
+    if (isCorrect) {
+      s.correct++;
+      s.streak++;
+      if (s.streak > s.bestStreak) s.bestStreak = s.streak;
+    } else {
+      s.streak = 0;
+    }
+    var key = activity || "activity";
+    if (!s.activities[key]) s.activities[key] = { answered: 0, correct: 0 };
+    s.activities[key].answered++;
+    if (isCorrect) s.activities[key].correct++;
+    _save(s);
+    return s;
+  }
+
+  function reset() {
+    try {
+      window.sessionStorage.removeItem(STORAGE_KEY);
+    } catch (e) {
+      /* ignore */
+    }
+  }
+
+  function accuracy(s) {
+    if (!s || s.answered === 0) return 0;
+    return Math.round((s.correct / s.answered) * 100);
+  }
+
+  function summaryText(s) {
+    if (!s || s.answered === 0) return "";
+    var text =
+      "Session: " + s.answered + " answered · " + accuracy(s) + "% correct";
+    if (s.streak >= 2) text += " · streak " + s.streak;
+    if (s.bestStreak >= 3) text += " · best " + s.bestStreak;
+    return text;
+  }
+
+  return {
+    load: load,
+    record: record,
+    reset: reset,
+    accuracy: accuracy,
+    summaryText: summaryText,
+  };
+})();
+
 var TrakaidoQuiz = (function () {
   var questions = [];
+  var results = []; // per-question: true / false / undefined
   var currentIndex = 0;
-  var score = 0;
   var answered = false;
   var renderer = null;
+  var meta = { lang: "", activity: "", indexUrl: "" };
 
   function init(opts) {
     questions = opts.questions || [];
     renderer = opts.renderer;
+    results = [];
     currentIndex = 0;
-    score = 0;
     answered = false;
+
+    var prog = document.getElementById("tk-progress");
+    if (prog) {
+      meta.lang = prog.getAttribute("data-lang") || "";
+      meta.indexUrl = prog.getAttribute("data-index-url") || "";
+    }
+    meta.activity = opts.activity || _activityFromPath();
+
+    _bindResetButton();
 
     if (questions.length === 0) {
       _showEmpty();
       return;
     }
 
-    _updateProgress();
+    _renderDots();
+    _renderSessionLine(TrakaidoSession.load(meta.lang));
     _showQuestion();
+  }
+
+  function _activityFromPath() {
+    var parts = window.location.pathname.split("/");
+    for (var i = parts.length - 1; i >= 0; i--) {
+      if (parts[i]) return parts[i];
+    }
+    return "activity";
+  }
+
+  function _bindResetButton() {
+    var btn = document.getElementById("tk-session-reset");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      TrakaidoSession.reset();
+      _renderSessionLine(TrakaidoSession.load(meta.lang));
+    });
   }
 
   function _showEmpty() {
@@ -42,28 +171,57 @@ var TrakaidoQuiz = (function () {
     if (nav) nav.style.display = "none";
   }
 
-  function _updateProgress() {
-    var el = document.getElementById("tk-progress-text");
-    if (el) {
-      el.textContent =
-        "Question " +
-        (currentIndex + 1) +
-        " of " +
-        questions.length +
-        "  |  Score: " +
-        score +
-        "/" +
-        (currentIndex + (answered ? 1 : 0));
+  function _batchScore() {
+    var right = 0;
+    var done = 0;
+    for (var i = 0; i < results.length; i++) {
+      if (results[i] === true) {
+        right++;
+        done++;
+      } else if (results[i] === false) {
+        done++;
+      }
     }
-    var bar = document.getElementById("tk-progress-bar");
-    if (bar) {
-      bar.style.width = ((currentIndex / questions.length) * 100).toFixed(1) + "%";
+    return { right: right, done: done };
+  }
+
+  function _renderDots() {
+    var container = document.getElementById("tk-dots");
+    if (!container) return;
+    container.innerHTML = "";
+    for (var i = 0; i < questions.length; i++) {
+      var dot = document.createElement("span");
+      dot.className = "tk-dot";
+      if (results[i] === true) {
+        dot.className += " tk-dot-correct";
+      } else if (results[i] === false) {
+        dot.className += " tk-dot-wrong";
+      } else if (i === currentIndex) {
+        dot.className += " tk-dot-current";
+      }
+      container.appendChild(dot);
+    }
+    var scoreEl = document.getElementById("tk-batch-score");
+    if (scoreEl) {
+      var s = _batchScore();
+      scoreEl.textContent = s.done > 0 ? s.right + "/" + s.done + " this round" : "";
+    }
+  }
+
+  function _renderSessionLine(session) {
+    var el = document.getElementById("tk-session-line");
+    if (el) {
+      el.textContent = TrakaidoSession.summaryText(session);
+    }
+    var btn = document.getElementById("tk-session-reset");
+    if (btn) {
+      btn.style.visibility = session && session.answered > 0 ? "visible" : "hidden";
     }
   }
 
   function _showQuestion() {
     answered = false;
-    _updateProgress();
+    _renderDots();
     if (renderer) {
       renderer(questions[currentIndex], currentIndex);
     }
@@ -74,41 +232,72 @@ var TrakaidoQuiz = (function () {
   function recordAnswer(isCorrect) {
     if (answered) return;
     answered = true;
-    if (isCorrect) score++;
-    _updateProgress();
+    results[currentIndex] = !!isCorrect;
+    var session = TrakaidoSession.record(meta.lang, meta.activity, !!isCorrect);
+    _renderDots();
+    _renderSessionLine(session);
     var nextBtn = document.getElementById("tk-next-btn");
-    if (nextBtn) nextBtn.disabled = false;
+    if (nextBtn) {
+      nextBtn.disabled = false;
+      if (currentIndex === questions.length - 1) {
+        nextBtn.innerHTML = "Finish round &#8594;";
+      }
+    }
   }
 
   function next() {
     if (!answered) return;
     currentIndex++;
     if (currentIndex >= questions.length) {
-      _showResults();
+      _showRoundComplete();
     } else {
       _showQuestion();
     }
   }
 
-  function _showResults() {
+  function _showRoundComplete() {
     var area = document.getElementById("tk-activity-area");
-    var pct = questions.length > 0 ? Math.round((score / questions.length) * 100) : 0;
-    var emoji = pct >= 80 ? "&#9733;" : pct >= 50 ? "&#9675;" : "&#9744;";
+    var s = _batchScore();
+    var session = TrakaidoSession.load(meta.lang);
+    var pct = questions.length > 0 ? Math.round((s.right / questions.length) * 100) : 0;
+
     if (area) {
-      area.innerHTML =
-        '<div class="trakaido-card" style="text-align:center;padding:2rem">' +
-        '<div style="font-size:3rem;margin-bottom:0.5rem">' + emoji + "</div>" +
-        "<h2>Round Complete</h2>" +
-        '<p style="font-size:1.3rem;margin:0.75rem 0">' +
-        score + " / " + questions.length + " correct (" + pct + "%)" +
-        "</p>" +
-        '<button class="trakaido-button" onclick="location.reload()">Play Again</button>' +
+      var html =
+        '<div class="tk-round-card">' +
+        '<div class="tk-round-headline">' +
+        s.right + " / " + questions.length + " this round (" + pct + "%)" +
         "</div>";
+      var sessionText = TrakaidoSession.summaryText(session);
+      if (sessionText) {
+        html += '<div class="tk-round-session">' + _escapeHtml(sessionText) + "</div>";
+      }
+      html +=
+        '<div class="tk-round-actions">' +
+        '<button class="trakaido-button" onclick="location.reload()">' +
+        "Keep going &#8594;</button>";
+      if (meta.indexUrl) {
+        html +=
+          '<a class="tk-round-link" href="' +
+          _escapeAttr(meta.indexUrl) +
+          '">Choose another activity</a>';
+      }
+      html += "</div></div>";
+      area.innerHTML = html;
     }
-    var bar = document.getElementById("tk-progress-bar");
-    if (bar) bar.style.width = "100%";
+
+    _renderDots();
     var nav = document.getElementById("tk-nav-buttons");
     if (nav) nav.style.display = "none";
+  }
+
+  function _escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  function _escapeAttr(s) {
+    return _escapeHtml(s).replace(/"/g, "&quot;");
   }
 
   function getCurrentIndex() {
@@ -117,3 +306,26 @@ var TrakaidoQuiz = (function () {
 
   return { init: init, recordAnswer: recordAnswer, next: next, getCurrentIndex: getCurrentIndex };
 })();
+
+/* Session summary on the activities index page. */
+document.addEventListener("DOMContentLoaded", function () {
+  var summary = document.getElementById("tk-session-summary");
+  if (!summary) return;
+  var session = TrakaidoSession.load(null);
+  var text = TrakaidoSession.summaryText(session);
+  if (!text) return;
+  var line = document.createElement("span");
+  line.className = "tk-session-line";
+  line.textContent = text;
+  var reset = document.createElement("button");
+  reset.type = "button";
+  reset.className = "tk-session-reset";
+  reset.textContent = "Reset session";
+  reset.addEventListener("click", function () {
+    TrakaidoSession.reset();
+    summary.hidden = true;
+  });
+  summary.appendChild(line);
+  summary.appendChild(reset);
+  summary.hidden = false;
+});

--- a/src/barsukas/templates/trakaido/activities/base_activity.html
+++ b/src/barsukas/templates/trakaido/activities/base_activity.html
@@ -37,11 +37,17 @@
         <input type="hidden" name="interface_lang" value="{{ interface_lang }}">
     </form>
 
-    <!-- Progress bar -->
-    <div id="tk-progress" class="tk-progress-wrapper">
-        <div id="tk-progress-text" class="tk-progress-text">Loading…</div>
-        <div class="tk-progress-track">
-            <div id="tk-progress-bar" class="tk-progress-fill" style="width:0%"></div>
+    <!-- Progress: batch dots + shared session stats -->
+    <div id="tk-progress" class="tk-progress-wrapper"
+         data-lang="{{ foreign_lang }}"
+         data-index-url="{{ url_for('trakaido_activities.activities_index') }}">
+        <div class="tk-progress-row">
+            <div id="tk-dots" class="tk-dots"></div>
+            <div id="tk-batch-score" class="tk-batch-score"></div>
+        </div>
+        <div class="tk-session-row">
+            <span id="tk-session-line" class="tk-session-line"></span>
+            <button type="button" id="tk-session-reset" class="tk-session-reset">Reset session</button>
         </div>
     </div>
 

--- a/src/barsukas/templates/trakaido/activities/flashcards.html
+++ b/src/barsukas/templates/trakaido/activities/flashcards.html
@@ -1,0 +1,94 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Flashcards{% endblock %}
+{% block activity_title %}Flashcards{% endblock %}
+{% block activity_subtitle %}Flip the card, then grade yourself honestly.{% endblock %}
+
+{% block activity_extra_controls %}
+<div class="trakaido-control">
+    <label for="study-mode-select">Study mode</label>
+    <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
+        {% for mode in study_modes %}
+        <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
+            {% if mode == "target-to-source" %}Target → Interface{% else %}Interface → Target{% endif %}
+        </option>
+        {% endfor %}
+    </select>
+</div>
+{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-flashcard" id="tk-flashcard" tabindex="0">' +
+        '<div class="tk-fc-front">' +
+          '<div class="tk-fc-word">' + escapeHtml(q.front) + '</div>';
+    if (q.front_sub) {
+      html += '<div class="tk-fc-sub">' + escapeHtml(q.front_sub) + '</div>';
+    }
+    html += '</div>' +
+        '<div class="tk-fc-back" id="tk-fc-back" hidden>' +
+          '<div class="tk-fc-word">' + escapeHtml(q.back) + '</div>';
+    if (q.back_sub) {
+      html += '<div class="tk-fc-sub">' + escapeHtml(q.back_sub) + '</div>';
+    }
+    html += '</div>' +
+        '<div class="tk-fc-hint" id="tk-fc-hint">Click to reveal</div>' +
+      '</div>' +
+      '<div class="tk-fc-actions" id="tk-fc-actions" hidden>' +
+        '<button class="tk-option-btn tk-fc-missed" id="tk-fc-missed">&#10007; Missed it</button>' +
+        '<button class="tk-option-btn tk-fc-got" id="tk-fc-got">&#10003; Got it</button>' +
+      '</div>';
+
+    area.innerHTML = html;
+
+    var card = document.getElementById("tk-flashcard");
+    card.addEventListener("click", reveal);
+    card.addEventListener("keydown", function (e) {
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        reveal();
+      }
+    });
+    document.getElementById("tk-fc-got").addEventListener("click", function () {
+      grade(true);
+    });
+    document.getElementById("tk-fc-missed").addEventListener("click", function () {
+      grade(false);
+    });
+  }
+
+  function reveal() {
+    var back = document.getElementById("tk-fc-back");
+    if (!back || !back.hidden) return;
+    back.hidden = false;
+    document.getElementById("tk-fc-hint").hidden = true;
+    document.getElementById("tk-fc-actions").hidden = false;
+  }
+
+  function grade(gotIt) {
+    TrakaidoQuiz.recordAnswer(gotIt);
+    TrakaidoQuiz.next();
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  // Flashcards advance as soon as they are graded, so the shared Next
+  // button is redundant here.
+  var nav = document.getElementById("tk-nav-buttons");
+  if (nav) nav.style.display = "none";
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/index.html
+++ b/src/barsukas/templates/trakaido/activities/index.html
@@ -13,6 +13,8 @@
         <p class="trakaido-subtitle">Interactive language-learning activities drawn from the Barsukas database.</p>
     </div>
 
+    <div id="tk-session-summary" class="tk-session-summary" hidden></div>
+
     <div class="trakaido-activity-grid">
         <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
             <div class="trakaido-activity-icon">&#9998;</div>
@@ -39,6 +41,25 @@
             <h2>Listening</h2>
             <p>Listen to a word and identify it from four options.</p>
         </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.flashcards') }}">
+            <div class="trakaido-activity-icon">&#9635;</div>
+            <h2>Flashcards</h2>
+            <p>Flip the card to reveal the translation, then grade yourself.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.typing') }}">
+            <div class="trakaido-activity-icon">&#9000;</div>
+            <h2>Typing</h2>
+            <p>Type the translation of the word shown — spelling counts.</p>
+        </a>
+        <a class="trakaido-activity-card" href="{{ url_for('trakaido_activities.verb_forms') }}">
+            <div class="trakaido-activity-icon">&#10227;</div>
+            <h2>Verb Forms</h2>
+            <p>Pick the correct conjugated form of a verb for the requested tense.</p>
+        </a>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ url_for('static', filename='js/trakaido_activities.js') }}"></script>
 {% endblock %}

--- a/src/barsukas/templates/trakaido/activities/typing.html
+++ b/src/barsukas/templates/trakaido/activities/typing.html
@@ -1,0 +1,107 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Typing{% endblock %}
+{% block activity_title %}Typing{% endblock %}
+{% block activity_subtitle %}Type the translation of the word shown.{% endblock %}
+
+{% block activity_extra_controls %}
+<div class="trakaido-control">
+    <label for="study-mode-select">Study mode</label>
+    <select id="study-mode-select" name="study_mode" onchange="this.form.submit()">
+        {% for mode in study_modes %}
+        <option value="{{ mode }}" {% if mode == study_mode %}selected{% endif %}>
+            {% if mode == "target-to-source" %}Target → Interface{% else %}Interface → Target{% endif %}
+        </option>
+        {% endfor %}
+    </select>
+</div>
+{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function normalize(s) {
+    return s.normalize("NFC").toLowerCase().trim().replace(/\s+/g, " ");
+  }
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-mc-prompt">' +
+        '<div class="tk-mc-word">' + escapeHtml(q.prompt) + '</div>';
+    if (q.prompt_sub) {
+      html += '<div class="tk-mc-sub">' + escapeHtml(q.prompt_sub) + '</div>';
+    }
+    html += '</div>' +
+      '<div class="tk-typing-row">' +
+        '<input type="text" id="tk-typing-input" class="tk-typing-input"' +
+        ' autocomplete="off" autocapitalize="off" spellcheck="false"' +
+        ' placeholder="Type the translation…">' +
+        '<button class="trakaido-button" id="tk-typing-check">Check</button>' +
+      '</div>' +
+      '<div class="tk-typing-giveup-row">' +
+        '<button class="tk-typing-giveup" id="tk-typing-giveup">Show answer</button>' +
+      '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var input = document.getElementById("tk-typing-input");
+    input.focus();
+    input.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        check(q);
+      }
+    });
+    document.getElementById("tk-typing-check").addEventListener("click", function () {
+      check(q);
+    });
+    document.getElementById("tk-typing-giveup").addEventListener("click", function () {
+      finish(q, false, true);
+    });
+  }
+
+  function check(q) {
+    var input = document.getElementById("tk-typing-input");
+    if (!input || input.disabled) return;
+    if (normalize(input.value) === "") return;
+    finish(q, normalize(input.value) === normalize(q.answer), false);
+  }
+
+  function finish(q, isCorrect, gaveUp) {
+    var input = document.getElementById("tk-typing-input");
+    if (!input || input.disabled) return;
+    input.disabled = true;
+    input.classList.add(isCorrect ? "tk-typing-correct" : "tk-typing-incorrect");
+    document.getElementById("tk-typing-check").disabled = true;
+    document.getElementById("tk-typing-giveup").disabled = true;
+
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      if (isCorrect) {
+        fb.textContent = "Correct!";
+      } else if (gaveUp) {
+        fb.textContent = "The answer is " + q.answer;
+      } else {
+        fb.textContent = "Incorrect — the answer is " + q.answer;
+      }
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}

--- a/src/barsukas/templates/trakaido/activities/verb_forms.html
+++ b/src/barsukas/templates/trakaido/activities/verb_forms.html
@@ -1,0 +1,85 @@
+{% extends "trakaido/activities/base_activity.html" %}
+
+{% block title %}Verb Forms{% endblock %}
+{% block activity_title %}Verb Forms{% endblock %}
+{% block activity_subtitle %}Pick the correct conjugated form of the verb.{% endblock %}
+
+{% block activity_scripts %}
+<script>
+(function () {
+  var questions = {{ questions_json|safe }};
+
+  function render(q, idx) {
+    var area = document.getElementById("tk-activity-area");
+
+    var html =
+      '<div class="tk-mc-prompt">' +
+        '<div class="tk-vf-label">' + escapeHtml(q.form_label) + '</div>' +
+        '<div class="tk-mc-word">' + escapeHtml(q.english) + '</div>';
+    if (q.infinitive) {
+      html += '<div class="tk-mc-sub">infinitive: ' + escapeHtml(q.infinitive) + '</div>';
+    }
+    if (q.definition) {
+      html += '<div class="tk-mc-sub">' + escapeHtml(q.definition) + '</div>';
+    }
+    html += '</div>' +
+      '<div class="tk-options" id="tk-options">';
+
+    for (var i = 0; i < q.options.length; i++) {
+      html +=
+        '<button class="tk-option-btn" data-idx="' + i + '">' +
+          escapeHtml(q.options[i].text) +
+        '</button>';
+    }
+    html += '</div>' +
+      '<div class="tk-feedback" id="tk-feedback"></div>';
+
+    area.innerHTML = html;
+
+    var buttons = area.querySelectorAll(".tk-option-btn");
+    for (var j = 0; j < buttons.length; j++) {
+      buttons[j].addEventListener("click", function (e) {
+        handleClick(e, q);
+      });
+    }
+  }
+
+  function handleClick(e, q) {
+    var btn = e.currentTarget;
+    var selectedIdx = parseInt(btn.getAttribute("data-idx"), 10);
+    var selected = q.options[selectedIdx];
+    var isCorrect = selected.correct;
+    TrakaidoQuiz.recordAnswer(isCorrect);
+
+    var allBtns = document.querySelectorAll("#tk-options .tk-option-btn");
+    for (var k = 0; k < allBtns.length; k++) {
+      allBtns[k].disabled = true;
+      var opt = q.options[parseInt(allBtns[k].getAttribute("data-idx"), 10)];
+      if (opt.correct) {
+        allBtns[k].classList.add("tk-correct");
+      } else if (k === selectedIdx && !isCorrect) {
+        allBtns[k].classList.add("tk-incorrect");
+      } else {
+        allBtns[k].classList.add("tk-unselected");
+      }
+    }
+
+    var fb = document.getElementById("tk-feedback");
+    if (fb) {
+      fb.textContent = isCorrect
+        ? "Correct!"
+        : "Incorrect — the answer is " + q.correct_answer;
+      fb.className = "tk-feedback " + (isCorrect ? "tk-fb-correct" : "tk-fb-incorrect");
+    }
+  }
+
+  function escapeHtml(s) {
+    var d = document.createElement("div");
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  TrakaidoQuiz.init({ questions: questions, renderer: render });
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Finishes porting the Trakaido web activities to Barsukas, in line with the migration plan: Trakaido apps go Lithuanian-only with per-user stat tracking, while Greenland hosts multi-language activities that take only a level parameter.

### New activities
- **Flashcards** — self-graded flip cards, in either study direction
- **Typing** — type the translation (NFC/case/whitespace-normalized comparison, "show answer" give-up)
- **Verb Forms** — pick the correct conjugation (3s present/past) built from `GrammarFact` rows, for languages that have them (currently Lithuanian)

### Level parameter is now a ceiling with weighted sampling
- The selected level dominates; each level below is exponentially less likely (decay 0.5, small floor so long-learned words still appear occasionally). At level 8 the measured distribution is roughly 42% level 8, 25% level 7, 15% level 6, tapering off below.
- Words above the selected level never appear (previously the band extended 2 levels above).
- Applies to all word-based activities and to sentence completion, where a sentence's level is the difficulty of its hardest word.

### Shared session tracking (replaces "score out of ten, continue or restart")
- `trakaido_activities.js` now has a `TrakaidoSession` store (sessionStorage) shared by every activity: total answered, accuracy, current/best streak, per-activity breakdown. Switching target language starts a fresh session.
- The per-round header is a row of progress dots (green/red as you answer) plus a running session line, instead of "Question X of 10 | Score".
- Finishing a batch shows the round result in the context of the session and offers "Keep going" (plain reload → fresh questions, session carries on) and "Choose another activity"; the activities index shows the running session summary with a reset link.

## Testing
- `black` and `mypy` pass on the modified Python.
- Smoke-tested all eight activity routes against the JSONL/golden backend (`STORAGE_BACKEND=jsonl JSONL_DATA_DIR=data/release`): all return 200 and build full 10-question rounds (listening builds 0 in release data only because it contains no audio reviews).
- Verified the level-weighting distribution empirically and sampled verb-form questions (e.g. *paimti* → *paėmė* with plausible past-tense decoys).
- Please give the new pages a spin in a local browser — flashcards, typing, and verb-forms UX especially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115NCXGzTV3kwEPQukHFYFG

---
_Generated by [Claude Code](https://claude.ai/code/session_0115NCXGzTV3kwEPQukHFYFG)_