### PR TITLE
Fix --debug logging and route text works to the concepts backend

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -428,7 +428,10 @@ def create_app(
             return
 
         g.db = app.db_session_factory()
-        if endpoint_name.startswith("concepts.") and app.concepts_db_session_factory is not None:
+        if (
+            endpoint_name.startswith(("concepts.", "texts."))
+            and app.concepts_db_session_factory is not None
+        ):
             g.concepts_db = app.concepts_db_session_factory()
 
     @app.teardown_appcontext
@@ -566,6 +569,13 @@ def main() -> None:
         help="Enable pgvector embedding read/write operations (opt-in)",
     )
     args = parser.parse_args()
+
+    # create_app() calls logging.basicConfig() off Config.DEBUG, which is read
+    # from the environment at import time -- so --debug has to land here, before
+    # create_app(), or the root logger stays at INFO and debug logs never emit.
+    if args.debug:
+        os.environ["BARSUKAS_DEBUG"] = "true"
+        Config.DEBUG = True
 
     app = create_app(db_url=args.db_url, use_word2vec=args.use_word2vec)
 

--- a/src/barsukas/launch.sh
+++ b/src/barsukas/launch.sh
@@ -25,6 +25,10 @@ while [[ $# -gt 0 ]]; do
             STORAGE_FORMAT="$2"
             shift 2
             ;;
+        --format=*)
+            STORAGE_FORMAT="${1#*=}"
+            shift
+            ;;
         -a|--all-interfaces)
             HOST_ARGS="--host 0.0.0.0"
             shift
@@ -33,9 +37,17 @@ while [[ $# -gt 0 ]]; do
             PORT="$2"
             shift 2
             ;;
+        --port=*)
+            PORT="${1#*=}"
+            shift
+            ;;
         --db-path)
             DB_PATH="$2"
             shift 2
+            ;;
+        --db-path=*)
+            DB_PATH="${1#*=}"
+            shift
             ;;
         --postgres)
             USE_POSTGRES="true"
@@ -45,9 +57,17 @@ while [[ $# -gt 0 ]]; do
             VENV_PATH="$2"
             shift 2
             ;;
+        --venv=*)
+            VENV_PATH="${1#*=}"
+            shift
+            ;;
         --persona)
             PERSONA="$2"
             shift 2
+            ;;
+        --persona=*)
+            PERSONA="${1#*=}"
+            shift
             ;;
         --list-personas)
             echo "Available personas:"

--- a/src/barsukas/routes/texts.py
+++ b/src/barsukas/routes/texts.py
@@ -89,9 +89,21 @@ def _texts_session() -> "Session":
     """Return the session that owns text-work reads and writes.
 
     Text works live in the concepts database/backend (same posture as
-    concepts: outside the lemma machinery).
+    concepts: outside the lemma machinery). When a separate concepts backend
+    is configured, falling back to g.db would read and write the lemma
+    backend instead -- which under the JSONL personas silently discards
+    writes -- so that case is an error rather than a fallback.
     """
-    return cast("Session", getattr(g, "concepts_db", g.db))
+    app: "BarsukasFlask" = current_app  # type: ignore[assignment]
+    concepts_db = getattr(g, "concepts_db", None)
+    if concepts_db is not None:
+        return cast("Session", concepts_db)
+    if app.concepts_db_session_factory is not None:
+        raise RuntimeError(
+            "Text-work request has no concepts_db session even though a concepts "
+            "backend is configured; before_request must open one for this endpoint."
+        )
+    return cast("Session", g.db)
 
 
 def _outbound_allowed() -> bool:
@@ -211,6 +223,16 @@ def create() -> ResponseReturnValue:
     summary = request.form.get("summary", "").strip()
     notes = request.form.get("notes", "").strip() or None
 
+    logger.debug(
+        "texts.create: spine=%s text_type=%s qid=%s title=%r backend=%s writable=%s",
+        "qid" if wikidata_qid is not None else "manual",
+        text_type,
+        wikidata_qid,
+        title,
+        current_app.config.get("CONCEPTS_BACKEND"),
+        current_app.config.get("CONCEPTS_WRITABLE"),
+    )
+
     # Q-id-seeded creation goes through the shared service (seed fetch,
     # idempotency), mirroring the concepts create flow.
     if wikidata_qid is not None:
@@ -222,6 +244,12 @@ def create() -> ResponseReturnValue:
             attribution=attribution,
             notes=notes,
         )
+        logger.debug(
+            "texts.create: qid spine -> status=%s title=%r detail=%r",
+            result.status,
+            result.title,
+            result.detail,
+        )
         if result.status == "exists":
             flash(f"Wikidata ID {wikidata_qid}: {result.detail}.", "error")
             if result.work is not None:
@@ -230,7 +258,11 @@ def create() -> ResponseReturnValue:
         if result.work is None:
             flash(f"Could not create the work: {result.detail or result.status}.", "error")
             return redirect(url_for("texts.new_work"))
-        flash(f"Added {result.work.title!r} to the library.", "success")
+        flash(
+            f"Added {result.work.title!r} ({result.work.text_type}) from {wikidata_qid}. "
+            f"No telling yet -- generate one below.",
+            "success",
+        )
         return redirect(url_for("texts.detail", slug=result.work.slug))
 
     # Manual creation (the only route for conversations, which have no Q-id).
@@ -254,7 +286,16 @@ def create() -> ResponseReturnValue:
         flash("Failed to create the work.", "error")
         return redirect(url_for("texts.new_work"))
 
-    flash(f"Added {work.title!r} to the library.", "success")
+    logger.debug(
+        "texts.create: manual spine -> created id=%s slug=%r type=%s (no versions yet)",
+        work.id,
+        work.slug,
+        work.text_type,
+    )
+    flash(
+        f"Added {work.title!r} ({work.text_type}). No telling yet -- generate one below.",
+        "success",
+    )
     return redirect(url_for("texts.detail", slug=work.slug))
 
 
@@ -403,6 +444,14 @@ def generate(slug: str) -> ResponseReturnValue:
     # Imported lazily so the route module stays importable without LLM clients.
     from agents.ozys import OzysAgent
 
+    logger.debug(
+        "texts.generate: slug=%r type=%s model=%s difficulty=%s slot=%s",
+        work.slug,
+        work.text_type,
+        model,
+        difficulty_level,
+        "regenerate" if existing is not None else "new",
+    )
     try:
         agent = OzysAgent(_get_config(), model=model)
         body = agent.generate_for_work(work, difficulty_level=difficulty_level)
@@ -410,6 +459,7 @@ def generate(slug: str) -> ResponseReturnValue:
         logger.exception("Text generation failed for %r", work.slug)
         flash(f"Generation failed: {exc}", "error")
         return redirect(url_for("texts.detail", slug=slug))
+    logger.debug("texts.generate: %r produced %d chars from %s", work.slug, len(body or ""), model)
 
     if existing is not None:
         version = update_text_version(

--- a/src/barsukas/unified_app.py
+++ b/src/barsukas/unified_app.py
@@ -188,7 +188,14 @@ def main() -> None:
         logger.info("Read-only mode enabled: disabling task worker")
         args.no_worker = True
 
-    # Set up logging
+    # Set up logging. create_app() re-runs basicConfig(force=True) off
+    # Config.DEBUG, which reads BARSUKAS_DEBUG from the environment -- so the
+    # env var has to be set here or that call resets the level back to INFO
+    # and --debug logs never emit.
+    if args.debug:
+        os.environ["BARSUKAS_DEBUG"] = "true"
+        Config.DEBUG = True
+
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,

--- a/src/storage/text_work_service.py
+++ b/src/storage/text_work_service.py
@@ -92,8 +92,22 @@ def create_text_work_from_qid(
             detail=f"text type {text_type!r} has no intake yet",
         )
 
+    logger.debug(
+        "create_text_work_from_qid: qid=%s (raw=%r) text_type=%s attribution_qid=%s",
+        normalized_qid,
+        qid,
+        text_type,
+        attribution_qid,
+    )
+
     existing = get_text_work_by_qid(session, normalized_qid)
     if existing is not None:
+        logger.debug(
+            "create_text_work_from_qid: %s already exists as slug=%r id=%s; no Wikidata fetch",
+            normalized_qid,
+            existing.slug,
+            existing.id,
+        )
         return TextWorkCreationResult(
             qid=normalized_qid,
             title=existing.title,
@@ -102,8 +116,12 @@ def create_text_work_from_qid(
             detail=f"already in the library as {existing.slug!r} [{existing.text_type}]",
         )
 
+    logger.debug(
+        "create_text_work_from_qid: fetching Wikidata/Wikipedia seed for %s", normalized_qid
+    )
     seed = fetch_wikidata_concept_seed(normalized_qid)
     if seed is None:
+        logger.debug("create_text_work_from_qid: %s did not resolve to a seed", normalized_qid)
         return TextWorkCreationResult(
             qid=normalized_qid,
             title="",
@@ -111,8 +129,20 @@ def create_text_work_from_qid(
             status="unresolved",
             detail="Wikidata seed could not be resolved",
         )
+    logger.debug(
+        "create_text_work_from_qid: %s resolved to title=%r summary=%r (%d source(s): %s)",
+        normalized_qid,
+        seed.title,
+        seed.summary,
+        len(seed.sources),
+        ", ".join(str(s.get("url", "?")) for s in seed.sources) or "none",
+    )
 
     if get_text_work_by_slug(session, seed.title) is not None:
+        logger.debug(
+            "create_text_work_from_qid: seeded title %r collides with an existing work",
+            seed.title,
+        )
         return TextWorkCreationResult(
             qid=normalized_qid,
             title=seed.title,
@@ -132,6 +162,9 @@ def create_text_work_from_qid(
         notes=notes,
     )
     if created is None:
+        logger.debug(
+            "create_text_work_from_qid: create_text_work returned None for title=%r", seed.title
+        )
         return TextWorkCreationResult(
             qid=normalized_qid,
             title=seed.title,
@@ -140,6 +173,16 @@ def create_text_work_from_qid(
             detail="create_text_work returned None",
         )
 
+    logger.debug(
+        "create_text_work_from_qid: created work id=%s slug=%r title=%r type=%s qid=%s "
+        "summary=%r (no versions yet)",
+        created.id,
+        created.slug,
+        created.title,
+        created.text_type,
+        created.qid,
+        created.summary,
+    )
     return TextWorkCreationResult(
         qid=normalized_qid,
         title=created.title,


### PR DESCRIPTION
Two independent fixes plus the debug logging they were needed to diagnose.

--debug was a no-op for log level. Both entry points parse --debug, but create_app() calls logging.basicConfig(force=True) with a level derived from Config.DEBUG, which is read from the environment at import time. Whatever level the caller set was reset back to INFO before the first request, so debug logs never emitted. Set BARSUKAS_DEBUG and Config.DEBUG before create_app() in both app.py and unified_app.py.

Text works were reading and writing the wrong backend. before_request only opened g.concepts_db for concepts.* endpoints, but text works live in the concepts database too, so texts.* routes fell through _texts_session()'s getattr(g, "concepts_db", g.db) fallback onto the lemma backend -- which under the JSONL personas silently discards the write. Open the session for texts.* as well, and make the fallback an error when a concepts backend is configured rather than letting a misrouted session fail quietly.

Also add debug logging along the text-work creation and generation paths, report text type and Q-id in the create flash messages, and accept the --flag=value form in launch.sh, which previously only handled --flag value and silently ignored the equals form.