### PR TITLE
Tolerate benign "already exists" race in create_all

### DIFF
--- a/src/storage/backend/factory.py
+++ b/src/storage/backend/factory.py
@@ -106,11 +106,22 @@ def _ensure_tables_exist(engine: "Engine") -> None:
     import storage.models  # noqa: F401
     from storage.models.schema import Base
 
+    from sqlalchemy.exc import OperationalError
+
     if engine.dialect.name == "postgresql":
         with engine.begin() as conn:
             conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
 
-    Base.metadata.create_all(engine)
+    try:
+        Base.metadata.create_all(engine)
+    except OperationalError as create_error:
+        # create_all(checkfirst=True) inspects the schema first, but a second
+        # connection with a stale WAL view (e.g. the metrics-instrumentation
+        # probe session opening concurrently on first run) can still race and
+        # lose to another creator, raising "table ... already exists". That is
+        # benign: the table now exists, which is all we wanted.
+        if "already exists" not in str(create_error).lower():
+            raise
 
     # Add missing columns to existing tables
     from storage.utils.session import ensure_tables_exist


### PR DESCRIPTION
On first run, a second connection with a stale WAL view (e.g. the metrics-instrumentation probe session opening concurrently) can lose the race to create tables and raise "table ... already exists", even though create_all uses checkfirst=True. That surfaced as a WARNING and caused session creation to fail, silently skipping metrics instrumentation.

Catch the benign OperationalError at the source so all callers tolerate the race; re-raise anything else.