### PR TITLE
Add build info metrics (revision, branch, version)

### DIFF
--- a/src/barsukas/app.py
+++ b/src/barsukas/app.py
@@ -35,6 +35,7 @@ from barsukas.metrics import (
     get_metrics_output,
     instrument_sqlalchemy_engine,
     record_llm_call,
+    set_build_info_metrics,
     set_server_mode_metrics,
 )
 from sqlalchemy.orm import Session
@@ -180,6 +181,9 @@ def create_app(
         readonly=bool(app.config.get("READONLY", False)),
         debug=bool(app.config.get("DEBUG", False)),
     )
+
+    # Record deployed git revision/branch/version (resolved once, then cached).
+    set_build_info_metrics()
 
     # Register LLM metrics callback so unified_client reports metrics
     try:

--- a/src/barsukas/metrics.py
+++ b/src/barsukas/metrics.py
@@ -9,10 +9,12 @@ This module provides metrics instrumentation for:
 - Resource usage (CPU, memory)
 """
 
+import os
 import time
 from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Callable, Generator, TypeVar
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, Optional, TypeVar
 
 try:
     from prometheus_client import Counter, Gauge, Histogram, generate_latest
@@ -81,6 +83,14 @@ if HAS_PROMETHEUS:
         "barsukas_db_queries_total",
         "Total number of database queries",
         ["operation"],
+        registry=REGISTRY,
+    )
+
+    # Build/version metadata
+    BUILD_INFO = Gauge(
+        "barsukas_build_info",
+        "Deployed build metadata (value is always 1); labels carry the git revision",
+        ["revision", "branch", "version"],
         registry=REGISTRY,
     )
 
@@ -168,6 +178,7 @@ else:
     LLM_CALL_COUNT = _NOOP  # type: ignore[assignment]
     LLM_CALL_LATENCY = _NOOP  # type: ignore[assignment]
     LLM_TOKENS_TOTAL = _NOOP  # type: ignore[assignment]
+    BUILD_INFO = _NOOP  # type: ignore[assignment]
     SERVER_MODE_INFO = _NOOP  # type: ignore[assignment]
     SERVER_READ_ONLY = _NOOP  # type: ignore[assignment]
     SERVER_DEBUG = _NOOP  # type: ignore[assignment]
@@ -250,6 +261,130 @@ def set_server_mode_metrics(
     ).set(1.0)
     SERVER_READ_ONLY.set(1.0 if readonly else 0.0)
     SERVER_DEBUG.set(1.0 if debug else 0.0)
+
+
+# Repo root is three levels up from this file: <root>/src/barsukas/metrics.py
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_UNKNOWN = "unknown"
+
+# Cache the resolved build info; reading git metadata touches disk and must not
+# run on every /metrics scrape.
+_build_info_cache: Optional[Dict[str, str]] = None
+
+
+def _resolve_git_dir(repo_root: Path) -> Optional[Path]:
+    """Return the ``.git`` directory for a checkout.
+
+    Handles the normal case (``.git`` is a directory) and the worktree/submodule
+    case (``.git`` is a file containing ``gitdir: <path>``). Returns ``None`` if
+    no git metadata is found.
+    """
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return git_path
+    if git_path.is_file():
+        try:
+            content = git_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if content.startswith("gitdir:"):
+            target = Path(content[len("gitdir:") :].strip())
+            if not target.is_absolute():
+                target = (repo_root / target).resolve()
+            return target if target.is_dir() else None
+    return None
+
+
+def _resolve_ref(git_dir: Path, ref_name: str) -> str:
+    """Resolve a ref (e.g. ``refs/heads/main``) to a commit SHA.
+
+    Checks the loose ref file first, then falls back to ``packed-refs`` (which is
+    where refs live after a ``git gc``). Returns ``""`` if unresolved.
+    """
+    loose = git_dir / ref_name
+    try:
+        return loose.read_text(encoding="utf-8").strip()
+    except OSError:
+        pass
+    packed = git_dir / "packed-refs"
+    try:
+        for line in packed.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith(("#", "^")):
+                continue
+            sha, _, packed_ref = line.partition(" ")
+            if packed_ref == ref_name:
+                return sha
+    except OSError:
+        pass
+    return ""
+
+
+def read_build_info(repo_path: Optional[str] = None) -> Dict[str, str]:
+    """Read the deployed git build info (revision, branch, version).
+
+    Reads ``.git`` metadata directly with the standard library -- no ``git``
+    subprocess and no third-party dependency. Values may be overridden via the
+    environment (``BARSUKAS_BUILD_REVISION`` / ``BARSUKAS_BUILD_BRANCH`` /
+    ``BARSUKAS_BUILD_VERSION``), which lets a deploy step inject them when a
+    ``.git`` directory is not available. Anything that cannot be resolved falls
+    back to ``"unknown"`` rather than raising.
+
+    Args:
+        repo_path: Path to the git checkout. Defaults to the Barsukas repo root.
+
+    Returns:
+        A dict with ``revision``, ``branch`` and ``version`` keys.
+    """
+    info: Dict[str, str] = {
+        "revision": os.environ.get("BARSUKAS_BUILD_REVISION", ""),
+        "branch": os.environ.get("BARSUKAS_BUILD_BRANCH", ""),
+        "version": os.environ.get("BARSUKAS_BUILD_VERSION", ""),
+    }
+
+    if not (info["revision"] and info["branch"]):
+        repo_root = Path(repo_path) if repo_path else _REPO_ROOT
+        git_dir = _resolve_git_dir(repo_root)
+        if git_dir is not None:
+            try:
+                head = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+            except OSError:
+                head = ""
+            if head.startswith("ref: "):
+                ref_name = head[len("ref: ") :].strip()
+                if not info["branch"]:
+                    info["branch"] = ref_name.replace("refs/heads/", "", 1)
+                if not info["revision"]:
+                    info["revision"] = _resolve_ref(git_dir, ref_name)
+            elif head:
+                # Detached HEAD: the file contains the SHA directly.
+                if not info["revision"]:
+                    info["revision"] = head
+                if not info["branch"]:
+                    info["branch"] = "detached"
+
+    # Default the human-facing version to the short revision when not supplied.
+    if not info["version"] and info["revision"]:
+        info["version"] = info["revision"][:12]
+
+    return {key: (value or _UNKNOWN) for key, value in info.items()}
+
+
+def set_build_info_metrics(repo_path: Optional[str] = None) -> None:
+    """Populate the ``barsukas_build_info`` gauge once (idempotent).
+
+    The build info is static for the life of the process, so it is resolved a
+    single time and cached; repeated calls are cheap no-ops.
+    """
+    global _build_info_cache
+    if _build_info_cache is None:
+        _build_info_cache = read_build_info(repo_path)
+    BUILD_INFO.labels(
+        revision=_build_info_cache["revision"],
+        branch=_build_info_cache["branch"],
+        version=_build_info_cache["version"],
+    ).set(1.0)
 
 
 def _extract_sql_operation(statement: str) -> str:

--- a/src/tests/barsukas/test_metrics_build_info.py
+++ b/src/tests/barsukas/test_metrics_build_info.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+
+"""Tests for git build-info resolution in barsukas.metrics.
+
+These exercise the pure-stdlib ``.git`` reader (no git subprocess) across the
+cases that matter for deploys: a normal branch checkout with a loose ref, a
+checkout whose refs have been packed by ``git gc``, a detached HEAD, and the
+graceful fallbacks (env overrides, missing ``.git``).
+"""
+
+import os
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from barsukas.metrics import read_build_info
+
+_SHA = "2c90ee25d7f501e1eec330b546aa778ceb059475"
+
+
+@pytest.fixture(autouse=True)
+def _clear_build_env() -> Iterator[None]:
+    """Ensure BARSUKAS_BUILD_* overrides don't leak between tests."""
+    saved = {
+        key: os.environ.pop(key, None)
+        for key in ("BARSUKAS_BUILD_REVISION", "BARSUKAS_BUILD_BRANCH", "BARSUKAS_BUILD_VERSION")
+    }
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
+
+
+def _make_git_dir(root: Path, head: str) -> Path:
+    git_dir = root / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text(head, encoding="utf-8")
+    return git_dir
+
+
+def test_loose_ref_on_branch(tmp_path: Path) -> None:
+    git_dir = _make_git_dir(tmp_path, "ref: refs/heads/main\n")
+    ref = git_dir / "refs" / "heads" / "main"
+    ref.parent.mkdir(parents=True)
+    ref.write_text(_SHA + "\n", encoding="utf-8")
+
+    info = read_build_info(str(tmp_path))
+    assert info["revision"] == _SHA
+    assert info["branch"] == "main"
+    assert info["version"] == _SHA[:12]
+
+
+def test_packed_ref_fallback(tmp_path: Path) -> None:
+    """After git gc the loose ref is gone; the SHA lives in packed-refs."""
+    git_dir = _make_git_dir(tmp_path, "ref: refs/heads/main\n")
+    (git_dir / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{_SHA} refs/heads/main\n"
+        "^0000000000000000000000000000000000000000\n",
+        encoding="utf-8",
+    )
+
+    info = read_build_info(str(tmp_path))
+    assert info["revision"] == _SHA
+    assert info["branch"] == "main"
+
+
+def test_detached_head(tmp_path: Path) -> None:
+    _make_git_dir(tmp_path, _SHA + "\n")
+
+    info = read_build_info(str(tmp_path))
+    assert info["revision"] == _SHA
+    assert info["branch"] == "detached"
+
+
+def test_env_overrides_win(tmp_path: Path) -> None:
+    _make_git_dir(tmp_path, "ref: refs/heads/main\n")
+    os.environ["BARSUKAS_BUILD_REVISION"] = "deadbeef"
+    os.environ["BARSUKAS_BUILD_BRANCH"] = "release"
+    os.environ["BARSUKAS_BUILD_VERSION"] = "v1.2.3"
+
+    info = read_build_info(str(tmp_path))
+    assert info == {"revision": "deadbeef", "branch": "release", "version": "v1.2.3"}
+
+
+def test_missing_git_dir_is_unknown(tmp_path: Path) -> None:
+    info = read_build_info(str(tmp_path))
+    assert info == {"revision": "unknown", "branch": "unknown", "version": "unknown"}


### PR DESCRIPTION
## Summary
Add support for tracking deployed git build metadata (revision, branch, version) as Prometheus metrics. This enables monitoring systems to correlate metrics with specific deployed versions without requiring external git tooling.

## Key Changes
- **New `BUILD_INFO` gauge metric**: Exposes git revision, branch, and version as labels on a gauge that is always set to 1.0
- **Pure stdlib git reader**: Implemented `read_build_info()` function that reads `.git` metadata directly without subprocess calls or third-party dependencies
  - Handles normal branch checkouts with loose refs
  - Falls back to `packed-refs` (after `git gc`)
  - Supports detached HEAD state
  - Gracefully handles missing `.git` directory
- **Environment variable overrides**: Supports `BARSUKAS_BUILD_REVISION`, `BARSUKAS_BUILD_BRANCH`, and `BARSUKAS_BUILD_VERSION` environment variables for deploy-time injection when `.git` is unavailable
- **Caching**: Build info is resolved once at startup and cached to avoid repeated disk I/O on every `/metrics` scrape
- **Integration**: Added `set_build_info_metrics()` call in app initialization to populate metrics once
- **Comprehensive tests**: Added test suite covering loose refs, packed refs, detached HEAD, env overrides, and missing git directory cases

## Implementation Details
- The git directory resolution handles both normal `.git` directories and the worktree/submodule case where `.git` is a file containing `gitdir: <path>`
- Ref resolution checks loose ref files first, then falls back to `packed-refs` for efficiency
- Version defaults to the short (12-char) revision SHA when not explicitly provided
- All unresolved values fall back to `"unknown"` rather than raising exceptions, ensuring robustness in various deployment scenarios
- Added type hints throughout per project conventions

https://claude.ai/code/session_011p5XXWJM1fzF3kLxNdiKGX