### PR TITLE
Improve Wikidata request efficiency

### DIFF
--- a/src/agents/vovere/sub_concept_wikidata_query.py
+++ b/src/agents/vovere/sub_concept_wikidata_query.py
@@ -19,8 +19,6 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import requests
-
 # Add src directory to path (this file lives at src/agents/vovere/)
 GREENLAND_SRC_PATH = str(Path(__file__).parent.parent.parent)
 if GREENLAND_SRC_PATH not in sys.path:
@@ -31,11 +29,10 @@ from storage.backend import create_session as create_backend_session
 from storage.backend.config import DataSourceConfig
 from storage.concept_service import file_sub_concept_from_qid
 from storage.models.concept import ALL_SUB_CONCEPT_CATEGORIES
-from storage.wikidata import normalize_qid
+from storage.wikidata import normalize_qid, query_wikidata_sparql
 
 logger = logging.getLogger(__name__)
 
-WIKIDATA_QUERY_ENDPOINT = "https://query.wikidata.org/sparql"
 
 PRESET_CLASS_QIDS: Dict[str, str] = {
     "geography_administrative_division": "Q56061",
@@ -74,14 +71,9 @@ class SubConceptWikidataQueryAgent:
 
     def query_qids(self, sparql: str) -> List[str]:
         """Run a SPARQL query and return Q-ids from a ``?item`` binding."""
-        response = requests.get(
-            WIKIDATA_QUERY_ENDPOINT,
-            params={"query": sparql, "format": "json"},
-            headers={"User-Agent": "greenland-sub-concept-query/0.1"},
-            timeout=60,
-        )
-        response.raise_for_status()
-        data = response.json()
+        data = query_wikidata_sparql(sparql)
+        if data is None:
+            raise RuntimeError("Wikidata SPARQL query failed after retries")
         qids: List[str] = []
         for binding in data.get("results", {}).get("bindings", []):
             item_uri = binding.get("item", {}).get("value", "")

--- a/src/clients/http_rate_limits.py
+++ b/src/clients/http_rate_limits.py
@@ -17,6 +17,7 @@ import constants
 # to constants.DEFAULT_HTTP_MIN_INTERVAL_SECONDS.
 HOST_MIN_INTERVAL_SECONDS: Dict[str, float] = {
     "www.wikidata.org": 6.0,
+    "query.wikidata.org": 6.0,
     "en.wikipedia.org": 6.0,
     "de.wikipedia.org": 6.0,
     "fr.wikipedia.org": 6.0,

--- a/src/storage/wikidata.py
+++ b/src/storage/wikidata.py
@@ -21,11 +21,12 @@ from storage.models.concept import MAX_CONCEPT_SOURCES
 logger = logging.getLogger(__name__)
 
 QID_RE = re.compile(r"^Q[1-9][0-9]*$", re.IGNORECASE)
-WIKIDATA_ENTITY_URL = "https://www.wikidata.org/wiki/Special:EntityData/{qid}.json"
+WIKIDATA_ACTION_API_URL = "https://www.wikidata.org/w/api.php"
 WIKIPEDIA_SUMMARY_URL = "https://en.wikipedia.org/api/rest_v1/page/summary/{title}"
 WIKIPEDIA_EXTRACT_URL = "https://{language_code}.wikipedia.org/w/api.php"
 WIKISOURCE_SEARCH_URL = "https://en.wikisource.org/w/api.php"
 DEFAULT_TIMEOUT_SECONDS = 10
+WIKIDATA_ENTITY_BATCH_SIZE = 50
 # 429 (rate limit) and 503-with-maxlag are transient Wikimedia conditions worth
 # waiting out, so allow several attempts with a longer backoff cap than a normal
 # request would use.
@@ -33,8 +34,22 @@ MAX_HTTP_ATTEMPTS = 5
 MAX_RETRY_DELAY_SECONDS = 30.0
 DEFAULT_USER_AGENT = os.environ.get(
     "GREENLAND_HTTP_USER_AGENT",
-    "Greenland-Barsukas/1.0 (concept seeding; set GREENLAND_HTTP_USER_AGENT with contact)",
+    "Greenland/1.0 (https://github.com/jmikedupont2/greenland; contact: set GREENLAND_HTTP_USER_AGENT)",
 )
+
+
+def _wikimedia_headers(*, accept: Optional[str] = None) -> Dict[str, str]:
+    """Return Wikimedia-friendly request headers with project identity."""
+    headers = {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Api-User-Agent": DEFAULT_USER_AGENT,
+        "Accept-Encoding": "gzip, deflate",
+    }
+    if accept is not None:
+        headers["Accept"] = accept
+    return headers
+
+
 # Wikimedia enforces a per-clock-minute request quota, not just a per-second
 # rate: bursting a handful of requests trips a ~60s cooldown (observed as a
 # Retry-After that bounces every call to the top of the next minute). Each
@@ -428,10 +443,7 @@ def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[
                 url,
                 params=request_params or None,
                 timeout=DEFAULT_TIMEOUT_SECONDS,
-                headers={
-                    "User-Agent": DEFAULT_USER_AGENT,
-                    "Api-User-Agent": DEFAULT_USER_AGENT,
-                },
+                headers=_wikimedia_headers(),
             )
             if response.status_code in {429, 503} and attempt_index < MAX_HTTP_ATTEMPTS - 1:
                 time.sleep(_retry_delay_seconds(response, attempt_index))
@@ -454,6 +466,52 @@ def _get_json(url: str, *, params: Optional[Dict[str, str]] = None) -> Optional[
     return None
 
 
+def _post_json(
+    url: str,
+    *,
+    data: Optional[Dict[str, str]] = None,
+    timeout: tuple[float, float] = (10.0, 90.0),
+    accept: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """POST for JSON with Wikimedia identity headers and transient retries."""
+    last_error: Optional[Exception] = None
+    for attempt_index in range(MAX_HTTP_ATTEMPTS):
+        try:
+            _throttle(url)
+            response = requests.post(
+                url,
+                data=dict(data or {}),
+                timeout=timeout,
+                headers=_wikimedia_headers(accept=accept),
+            )
+            if (
+                response.status_code in {429, 502, 503, 504}
+                and attempt_index < MAX_HTTP_ATTEMPTS - 1
+            ):
+                time.sleep(_retry_delay_seconds(response, attempt_index))
+                continue
+            response.raise_for_status()
+            payload = response.json()
+        except (requests.RequestException, ValueError) as error:
+            last_error = error
+            break
+        if isinstance(payload, dict):
+            return payload
+        return None
+
+    logger.warning("Failed to POST JSON from %s: %s", url, last_error)
+    return None
+
+
+def query_wikidata_sparql(sparql: str) -> Optional[Dict[str, Any]]:
+    """Run a WDQS SPARQL query as a POST with Wikimedia-friendly retries."""
+    return _post_json(
+        "https://query.wikidata.org/sparql",
+        data={"query": sparql},
+        accept="application/sparql-results+json",
+    )
+
+
 def _extract_entity_qid(snak: Dict[str, Any]) -> Optional[str]:
     """Extract a Wikidata entity Q-id from a claim snak."""
     data_value = snak.get("datavalue", {})
@@ -469,13 +527,43 @@ def _extract_entity_qid(snak: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _fetch_wikidata_entities(qids: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    """Fetch Wikidata entities via the cheaper batched Action API."""
+    normalized_qids: List[str] = []
+    seen_qids: set[str] = set()
+    for raw_qid in qids:
+        normalized_qid = normalize_qid(raw_qid)
+        if normalized_qid is not None and normalized_qid not in seen_qids:
+            normalized_qids.append(normalized_qid)
+            seen_qids.add(normalized_qid)
+
+    entities_by_qid: Dict[str, Dict[str, Any]] = {}
+    for start in range(0, len(normalized_qids), WIKIDATA_ENTITY_BATCH_SIZE):
+        batch_qids = normalized_qids[start : start + WIKIDATA_ENTITY_BATCH_SIZE]
+        payload = _get_json(
+            WIKIDATA_ACTION_API_URL,
+            params={
+                "action": "wbgetentities",
+                "ids": "|".join(batch_qids),
+                "props": "labels|descriptions|aliases|claims|sitelinks",
+                "languages": "en",
+                "languagefallback": "1",
+                "formatversion": "2",
+            },
+        )
+        for entity_qid, entity in (payload or {}).get("entities", {}).items():
+            normalized_entity_qid = normalize_qid(str(entity_qid))
+            if normalized_entity_qid is not None and isinstance(entity, dict):
+                entities_by_qid[normalized_entity_qid] = entity
+    return entities_by_qid
+
+
 def _fetch_wikidata_entity(qid: str) -> Optional[Dict[str, Any]]:
-    """Fetch a single Wikidata entity JSON object."""
-    payload = _get_json(WIKIDATA_ENTITY_URL.format(qid=qid))
-    entity = (payload or {}).get("entities", {}).get(qid)
-    if isinstance(entity, dict):
-        return entity
-    return None
+    """Fetch a single Wikidata entity JSON object via the Action API."""
+    normalized_qid = normalize_qid(qid)
+    if normalized_qid is None:
+        return None
+    return _fetch_wikidata_entities([normalized_qid]).get(normalized_qid)
 
 
 def _extract_english_value(values: Dict[str, Dict[str, str]]) -> str:

--- a/src/tests/clients/test_http_rate_limits.py
+++ b/src/tests/clients/test_http_rate_limits.py
@@ -6,7 +6,8 @@ from clients.http_rate_limits import min_interval_for_host, min_interval_for_url
 
 def test_known_host_uses_configured_interval() -> None:
     assert min_interval_for_host("en.wikipedia.org") == 6.0
-    assert min_interval_for_url("https://www.wikidata.org/wiki/Special:EntityData/Q42.json") == 6.0
+    assert min_interval_for_url("https://www.wikidata.org/w/api.php") == 6.0
+    assert min_interval_for_url("https://query.wikidata.org/sparql") == 6.0
 
 
 def test_unknown_host_falls_back_to_default(monkeypatch) -> None:  # type: ignore[no-untyped-def]

--- a/src/tests/storage/test_wikidata_concepts.py
+++ b/src/tests/storage/test_wikidata_concepts.py
@@ -305,7 +305,7 @@ def test_fetch_wikidata_seed_builds_sources_from_mocked_apis(monkeypatch) -> Non
     def fake_get_json(
         url: str, *, params: Optional[Dict[str, str]] = None
     ) -> Optional[Dict[str, Any]]:
-        if "Special:EntityData" in url:
+        if "www.wikidata.org/w/api.php" in url:
             return {
                 "entities": {
                     "Q42": {
@@ -346,7 +346,7 @@ def test_fetch_wikidata_seed_caches_repeated_qid_lookups(monkeypatch) -> None:  
         url: str, *, params: Optional[Dict[str, str]] = None
     ) -> Optional[Dict[str, Any]]:
         calls.append(url)
-        if "Special:EntityData" in url:
+        if "www.wikidata.org/w/api.php" in url:
             return {
                 "entities": {
                     "Q555": {
@@ -374,7 +374,7 @@ def test_fetch_wikidata_seed_caches_repeated_qid_lookups(monkeypatch) -> None:  
     assert second_seed is not None
     assert second_seed.title == "Cached concept"
     assert [source["title"] for source in second_seed.sources] == ["Wikipedia: Cached concept"]
-    assert sum("Special:EntityData" in url for url in calls) == 1
+    assert sum("www.wikidata.org/w/api.php" in url for url in calls) == 1
     _fetch_wikidata_concept_seed_cached.cache_clear()
 
 
@@ -382,7 +382,7 @@ def test_fetch_wikidata_seed_can_include_regional_wikipedia_sources(monkeypatch)
     def fake_get_json(
         url: str, *, params: Optional[Dict[str, str]] = None
     ) -> Optional[Dict[str, Any]]:
-        if "Special:EntityData" in url:
+        if "www.wikidata.org/w/api.php" in url:
             return {
                 "entities": {
                     "Q1204": {
@@ -451,7 +451,74 @@ def test_get_json_retries_429_with_wikimedia_headers(monkeypatch) -> None:  # ty
     }
     assert len(calls) == 2
     assert calls[0]["headers"]["Api-User-Agent"]
+    assert calls[0]["headers"]["Accept-Encoding"] == "gzip, deflate"
     assert calls[0]["params"]["maxlag"] == "5"
+
+
+def test_fetch_wikidata_entities_batches_action_api(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import storage.wikidata as wikidata
+
+    calls: list[dict[str, str]] = []
+
+    def fake_get_json(
+        url: str, *, params: Optional[Dict[str, str]] = None
+    ) -> Optional[Dict[str, Any]]:
+        assert url == wikidata.WIKIDATA_ACTION_API_URL
+        assert params is not None
+        calls.append(params)
+        return {
+            "entities": {
+                qid: {"labels": {"en": {"value": qid}}} for qid in params["ids"].split("|")
+            }
+        }
+
+    monkeypatch.setattr(wikidata, "_get_json", fake_get_json)
+
+    entities = wikidata._fetch_wikidata_entities([f"Q{index}" for index in range(1, 53)])
+
+    assert len(calls) == 2
+    assert calls[0]["action"] == "wbgetentities"
+    assert calls[0]["ids"].startswith("Q1|Q2")
+    assert len(calls[0]["ids"].split("|")) == 50
+    assert set(entities) == {f"Q{index}" for index in range(1, 53)}
+
+
+def test_post_json_uses_sparql_post_headers_and_retries(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import storage.wikidata as wikidata
+
+    calls: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+            self.headers: dict[str, str] = {"Retry-After": "0"}
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError("unexpected status")
+
+        def json(self) -> dict[str, Any]:
+            return {"results": {"bindings": []}}
+
+    def fake_post(url: str, **kwargs: Any) -> FakeResponse:
+        calls.append({"url": url, **kwargs})
+        return FakeResponse(503 if len(calls) == 1 else 200)
+
+    monkeypatch.setattr(wikidata.requests, "post", fake_post)
+    monkeypatch.setattr(wikidata.time, "sleep", lambda delay: None)
+    monkeypatch.setattr(wikidata, "min_interval_for_url", lambda url: 0.0)
+
+    payload = wikidata._post_json(
+        "https://query.wikidata.org/sparql",
+        data={"query": "SELECT * WHERE {}"},
+        accept="application/sparql-results+json",
+    )
+
+    assert payload == {"results": {"bindings": []}}
+    assert len(calls) == 2
+    assert calls[0]["data"] == {"query": "SELECT * WHERE {}"}
+    assert calls[0]["headers"]["Accept"] == "application/sparql-results+json"
+    assert calls[0]["headers"]["User-Agent"]
 
 
 def test_throttle_waits_for_min_interval_per_host(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
### Motivation

- Wikidata/SPARQL calls were slow and subject to Wikimedia rate-limiting, causing long-running agent jobs and per-item query bursts. 
- The goal is to reduce live WDQS pressure by using proper Wikimedia headers, batching entity fetches, and POSTing SPARQL queries to WDQS.

### Description

- Added a reusable Wikimedia headers helper `_wikimedia_headers` and swapped individual `User-Agent` usages to send contact-bearing headers and gzip/deflate support via `_wikimedia_headers`.
- Implemented a `_post_json` helper with retry/backoff logic for POST requests and added `query_wikidata_sparql` to run WDQS POST queries with appropriate Accept headers.
- Replaced single-item Special:EntityData fetches with `_fetch_wikidata_entities` that batches Q-ids into `wbgetentities` Action API calls (with `WIKIDATA_ENTITY_BATCH_SIZE = 50`) and made `_fetch_wikidata_entity` use the batched path.
- Updated the SPARQL sub-concept agent to use the shared `query_wikidata_sparql` POST helper instead of issuing its own GET, and added `query.wikidata.org` to the per-host pacing table to ensure WDQS requests are throttled.
- Added/updated tests to assert header usage, SPARQL POST retry behavior, Action API batching behavior, and the updated host-rate configuration.

### Testing

- Ran unit tests with `PYTHONPATH=src python -m pytest src/tests/storage/test_wikidata_concepts.py src/tests/clients/test_http_rate_limits.py -q`, and all tests passed (`32 passed`).
- Ran static checks and formatting with `mypy` and `black` on the modified files and there were no type or formatting issues.
- Performed a `git diff --check` to validate no whitespace/git issues remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a607f21788327af50e7e6cd7c66ef)