### PR TITLE
Refactor lemma view into tabbed subpages

### DIFF
--- a/src/barsukas/helpers/lemma_display.py
+++ b/src/barsukas/helpers/lemma_display.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from storage.queries.lemma import get_difficulty_stats
 
-
 LemmaPronunciationRow = Dict[str, Optional[str]]
 
 
@@ -164,9 +163,68 @@ def build_lemma_pronunciation_rows(
     return pronunciation_rows
 
 
+def build_language_coverage_rows(
+    language_names: Mapping[str, str],
+    translations: Mapping[str, Optional[str]],
+    forms_by_language: Mapping[str, Sequence[Any]],
+    pronunciation_forms_by_language: Mapping[str, Sequence[Any]],
+    lemma_pronunciation_rows: Mapping[str, LemmaPronunciationRow],
+    audio_files: Sequence[Any],
+    default_languages: Sequence[str],
+) -> List[Dict[str, Any]]:
+    """Build the per-language coverage summary shown on the lemma overview page.
+
+    Default (high-priority) languages are always listed so absences are visible;
+    secondary languages appear only when they actually have forms, pronunciation,
+    or audio data.
+    """
+    audio_total_by_language: Dict[str, int] = {}
+    audio_approved_by_language: Dict[str, int] = {}
+    for audio in audio_files:
+        language_code = audio.language_code
+        audio_total_by_language[language_code] = audio_total_by_language.get(language_code, 0) + 1
+        if audio.status in ("approved", "approved_with_issues"):
+            audio_approved_by_language[language_code] = (
+                audio_approved_by_language.get(language_code, 0) + 1
+            )
+
+    ordered_languages: List[str] = [
+        lang_code for lang_code in default_languages if lang_code in language_names
+    ]
+    extra_languages = sorted(
+        (
+            set(forms_by_language)
+            | set(pronunciation_forms_by_language)
+            | set(lemma_pronunciation_rows)
+            | set(audio_total_by_language)
+        )
+        - set(ordered_languages)
+    )
+    ordered_languages.extend(
+        lang_code for lang_code in extra_languages if lang_code in language_names
+    )
+
+    coverage_rows: List[Dict[str, Any]] = []
+    for lang_code in ordered_languages:
+        coverage_rows.append(
+            {
+                "lang_code": lang_code,
+                "lang_name": language_names[lang_code],
+                "has_translation": bool((translations.get(lang_code) or "").strip()),
+                "forms_count": len(forms_by_language.get(lang_code, [])),
+                "pronunciation_count": len(pronunciation_forms_by_language.get(lang_code, [])),
+                "has_lemma_pronunciation": lang_code in lemma_pronunciation_rows,
+                "audio_total": audio_total_by_language.get(lang_code, 0),
+                "audio_approved": audio_approved_by_language.get(lang_code, 0),
+            }
+        )
+    return coverage_rows
+
+
 # Re-export for backwards compatibility and convenience
 # Routes can import from here for UI-related helpers
 __all__ = [
+    "build_language_coverage_rows",
     "build_lemma_pronunciation_rows",
     "get_difficulty_stats",
     "get_pronunciation_languages",

--- a/src/barsukas/routes/lemmas.py
+++ b/src/barsukas/routes/lemmas.py
@@ -33,7 +33,6 @@ from storage.models.schema import DerivativeForm, Lemma, LemmaTranslation
 from storage.queries.lemma import build_lemma_search_query
 from storage.translation_helpers import (
     DEFAULT_GENERATION_LANGUAGES,
-    get_all_translations,
     get_supported_languages,
 )
 
@@ -311,47 +310,24 @@ def list_lemmas() -> ResponseReturnValue:
     )
 
 
-@bp.route("/<int:lemma_id>")
-def view_lemma(lemma_id: int) -> ResponseReturnValue:
-    """View a single lemma with all details."""
+def _get_lemma_page_context(lemma_id: int) -> Optional[Dict[str, Any]]:
+    """Build the template context shared by all lemma subpages.
+
+    Returns None when the lemma does not exist. The context includes the
+    grouped derivative-form data plus the per-tab counts used by the lemma
+    sub-navigation, so every subpage can render the same nav.
+    """
     from barsukas.helpers.db_optimization import get_lemma_view_data
-    from storage.crud.guid_tombstone import get_tombstones_by_lemma_id
-    from storage.lexeme import get_lexeme
-    from storage.models.schema import (
-        ExternalLexemeAnnotation,
-        LemmaTier,
-        TierDefinition,
-    )
-    from wordfreq.lexeme_frequency import get_lexeme_frequencies_all_corpora
-    from storage.config.grammar_fact_registry import get_generatable_fact_definitions
 
-    # Get all lemma data in optimized bulk queries (replaces 10+ separate queries)
     data = get_lemma_view_data(g.db, lemma_id)
-
     lemma = data["lemma"]
     if not lemma:
-        flash("Lemma not found", "error")
-        return redirect(url_for("lemmas.list_lemmas"))
+        return None
 
-    # Extract pre-fetched data
     translations = data["translations"]
-    definitions = data["definitions"]
-    translation_disambiguations = data["translation_disambiguations"]
-    translation_pronunciations = data["translation_pronunciations"]
     language_names = get_supported_languages()
-    overrides = data["overrides"]
-    effective_levels = data["effective_levels"]
     derivative_forms = data["derivative_forms"]
-    grammar_facts = data["grammar_facts"]
-    audio_files = data["audio_files"]
-    sentence_count = data["sentence_count"]
-    needs_disambiguation_check = data["needs_disambiguation_check"]
-    related_lemmas = data["related_lemmas"]
 
-    # Get difficulty level distribution for same POS type/subtype
-    difficulty_stats = get_difficulty_stats(g.db, lemma.pos_type, lemma.pos_subtype)
-
-    # Group forms by language and type
     (
         forms_by_language,
         synonyms_by_language,
@@ -359,92 +335,101 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
         all_synonym_languages,
     ) = group_derivative_forms(derivative_forms)
     pronunciation_forms_by_language = group_populated_pronunciations(derivative_forms)
-    pronunciation_languages = get_pronunciation_languages(derivative_forms, translations)
     lemma_pronunciation_rows = build_lemma_pronunciation_rows(
         derivative_forms,
         translations,
-        translation_pronunciations,
+        data["translation_pronunciations"],
     )
 
-    # Get tombstone entries for this lemma
-    tombstones = get_tombstones_by_lemma_id(g.db, lemma_id)
+    forms_total = sum(len(forms) for forms in forms_by_language.values())
+    related_total = (
+        sum(len(forms) for forms in synonyms_by_language.values())
+        + sum(len(forms) for forms in alternative_forms_by_language.values())
+        + len(data["related_lemmas"])
+    )
+
+    return {
+        "lemma": lemma,
+        "translations": translations,
+        "definitions": data["definitions"],
+        "translation_disambiguations": data["translation_disambiguations"],
+        "language_names": language_names,
+        "overrides": data["overrides"],
+        "effective_levels": data["effective_levels"],
+        "derivative_forms": derivative_forms,
+        "forms_by_language": forms_by_language,
+        "synonyms_by_language": synonyms_by_language,
+        "alternative_forms_by_language": alternative_forms_by_language,
+        "all_synonym_languages": all_synonym_languages,
+        "pronunciation_forms_by_language": pronunciation_forms_by_language,
+        "lemma_pronunciation_rows": lemma_pronunciation_rows,
+        "grammar_facts": data["grammar_facts"],
+        "audio_files": data["audio_files"],
+        "sentence_count": data["sentence_count"],
+        "needs_disambiguation_check": data["needs_disambiguation_check"],
+        "related_lemmas": data["related_lemmas"],
+        "hidden_languages": set(language_names) - set(DEFAULT_GENERATION_LANGUAGES),
+        # Per-tab counts for the lemma sub-navigation
+        "nav_counts": {
+            "forms": forms_total + len(data["grammar_facts"]),
+            "audio": len(data["audio_files"]),
+            "related": related_total,
+            "levels": len(data["overrides"]),
+        },
+    }
+
+
+@bp.route("/<int:lemma_id>")
+def view_lemma(lemma_id: int) -> ResponseReturnValue:
+    """Lemma overview: details, translations, and per-language coverage summary."""
+    from barsukas.helpers.lemma_display import build_language_coverage_rows
+    from storage.crud.concept import get_link_for_lemma
+
+    context = _get_lemma_page_context(lemma_id)
+    if context is None:
+        flash("Lemma not found", "error")
+        return redirect(url_for("lemmas.list_lemmas"))
 
     # Paired concept (one-to-one, by Q-id). The link lives in the lemma/main DB,
     # so it is available here even when concepts are hosted in a separate,
     # read-only database. Only surfaced when the lemma is actually paired.
-    from storage.crud.concept import get_link_for_lemma
-
     concept_link = get_link_for_lemma(g.db, lemma_id)
 
-    # Prepare voice options for audio generation
-    openai_voices = [
-        "ash",
-        "alloy",
-        "nova",
-        "ballad",
-        "coral",
-        "echo",
-        "fable",
-        "onyx",
-        "sage",
-        "shimmer",
-    ]
-
-    # eSpeak-NG voices by language
-    espeak_voices = {}
-    for lang_code in language_names.keys():
-        espeak_voice_list = EspeakVoice.get_voices_for_language(lang_code)
-        espeak_voices[lang_code] = [{"name": v.name, "gender": v.gender} for v in espeak_voice_list]
-
-    # Piper voices by language
-    piper_voices = {}
-    for lang_code in language_names.keys():
-        piper_voice_list = PiperVoice.get_voices_for_language(lang_code)
-        piper_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in piper_voice_list
-        ]
-
-    # Coqui voices by language
-    coqui_voices = {}
-    for lang_code in language_names.keys():
-        coqui_voice_list = CoquiVoice.get_voices_for_language(lang_code)
-        coqui_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in coqui_voice_list
-        ]
-
-    # Qwen3 voices by language
-    qwen3_voices = {}
-    for lang_code in language_names.keys():
-        qwen3_voice_list = QwenVoice.get_voices_for_language(lang_code)
-        qwen3_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in qwen3_voice_list
-        ]
-
-    # Amazon Polly voices by language
-    polly_voices = {}
-    for lang_code in language_names.keys():
-        polly_voice_list = PollyVoice.get_voices_for_language(lang_code)
-        polly_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in polly_voice_list
-        ]
-
-    # Azure TTS voices by language
-    azure_voices = {}
-    for lang_code in language_names.keys():
-        azure_voice_list = AzureVoice.get_voices_for_language(lang_code)
-        azure_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in azure_voice_list
-        ]
-
-    # Google Cloud TTS voices by language
-    google_voices = {}
-    for lang_code in language_names.keys():
-        google_voice_list = GoogleTtsVoice.get_voices_for_language(lang_code)
-        google_voices[lang_code] = [
-            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender} for v in google_voice_list
-        ]
+    coverage_rows = build_language_coverage_rows(
+        language_names=context["language_names"],
+        translations=context["translations"],
+        forms_by_language=context["forms_by_language"],
+        pronunciation_forms_by_language=context["pronunciation_forms_by_language"],
+        lemma_pronunciation_rows=context["lemma_pronunciation_rows"],
+        audio_files=context["audio_files"],
+        default_languages=DEFAULT_GENERATION_LANGUAGES,
+    )
 
     queued_tasks = get_tasks_for_target(g.db, "lemma", lemma_id, limit=8)
+
+    return render_template(
+        "lemmas/view.html",
+        active_tab="overview",
+        concept_link=concept_link,
+        coverage_rows=coverage_rows,
+        queued_tasks=queued_tasks,
+        **context,
+    )
+
+
+@bp.route("/<int:lemma_id>/forms")
+def view_lemma_forms(lemma_id: int) -> ResponseReturnValue:
+    """Grammatical forms, pronunciations, and grammar facts for a lemma."""
+    from storage.config.grammar_fact_registry import get_generatable_fact_definitions
+
+    context = _get_lemma_page_context(lemma_id)
+    if context is None:
+        flash("Lemma not found", "error")
+        return redirect(url_for("lemmas.list_lemmas"))
+
+    pronunciation_languages = get_pronunciation_languages(
+        context["derivative_forms"], context["translations"]
+    )
     generatable_grammar_fact_defs = [
         {
             "fact_type": definition.fact_type,
@@ -453,8 +438,70 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
             "description": definition.description,
         }
         for definition in get_generatable_fact_definitions().values()
-        if lemma.pos_type in definition.required_pos
+        if context["lemma"].pos_type in definition.required_pos
     ]
+
+    return render_template(
+        "lemmas/forms.html",
+        active_tab="forms",
+        pronunciation_languages=pronunciation_languages,
+        generatable_grammar_fact_defs=generatable_grammar_fact_defs,
+        **context,
+    )
+
+
+@bp.route("/<int:lemma_id>/audio")
+def view_lemma_audio(lemma_id: int) -> ResponseReturnValue:
+    """Audio files and audio generation for a lemma."""
+    context = _get_lemma_page_context(lemma_id)
+    if context is None:
+        flash("Lemma not found", "error")
+        return redirect(url_for("lemmas.list_lemmas"))
+
+    return render_template(
+        "lemmas/audio.html",
+        active_tab="audio",
+        **_build_voice_options(context["language_names"]),
+        **context,
+    )
+
+
+@bp.route("/<int:lemma_id>/related")
+def view_lemma_related(lemma_id: int) -> ResponseReturnValue:
+    """Synonyms, alternative forms, related lemmas, and example sentences."""
+    context = _get_lemma_page_context(lemma_id)
+    if context is None:
+        flash("Lemma not found", "error")
+        return redirect(url_for("lemmas.list_lemmas"))
+
+    return render_template(
+        "lemmas/related.html",
+        active_tab="related",
+        **context,
+    )
+
+
+@bp.route("/<int:lemma_id>/levels")
+def view_lemma_levels(lemma_id: int) -> ResponseReturnValue:
+    """Frequency/tier signals and per-language difficulty overrides for a lemma."""
+    from storage.lexeme import get_lexeme
+    from storage.models.schema import (
+        ExternalLexemeAnnotation,
+        LemmaTier,
+        TierDefinition,
+    )
+    from wordfreq.frequency.corpus import get_enabled_corpus_configs
+    from wordfreq.lexeme_frequency import get_lexeme_frequencies_all_corpora
+
+    context = _get_lemma_page_context(lemma_id)
+    if context is None:
+        flash("Lemma not found", "error")
+        return redirect(url_for("lemmas.list_lemmas"))
+
+    lemma = context["lemma"]
+
+    # Get difficulty level distribution for same POS type/subtype
+    difficulty_stats = get_difficulty_stats(g.db, lemma.pos_type, lemma.pos_subtype)
 
     lemma_tiers = (
         g.db.query(LemmaTier)
@@ -489,8 +536,6 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
         if tier.source in ranks_by_source
     }
 
-    from wordfreq.frequency.corpus import get_enabled_corpus_configs
-
     target_corpora = ["19th_books", "20th_books", "cooking", "wiki_vital"]
     enabled_corpora = {cfg.name for cfg in get_enabled_corpus_configs()}
     lexeme_frequency_by_corpus = {}
@@ -521,40 +566,9 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
             lexeme_rank_by_corpus[corpus_name] = best_rank
 
     return render_template(
-        "lemmas/view.html",
-        lemma=lemma,
-        translations=translations,
-        definitions=definitions,
-        translation_disambiguations=translation_disambiguations,
-        language_names=language_names,
-        overrides=overrides,
-        effective_levels=effective_levels,
+        "lemmas/levels.html",
+        active_tab="levels",
         difficulty_stats=difficulty_stats,
-        forms_by_language=forms_by_language,
-        derivative_forms=derivative_forms,
-        pronunciation_forms_by_language=pronunciation_forms_by_language,
-        pronunciation_languages=pronunciation_languages,
-        lemma_pronunciation_rows=lemma_pronunciation_rows,
-        audio_files=audio_files,
-        synonyms_by_language=synonyms_by_language,
-        alternative_forms_by_language=alternative_forms_by_language,
-        all_synonym_languages=all_synonym_languages,
-        sentence_count=sentence_count,
-        needs_disambiguation_check=needs_disambiguation_check,
-        grammar_facts=grammar_facts,
-        generatable_grammar_fact_defs=generatable_grammar_fact_defs,
-        tombstones=tombstones,
-        openai_voices=openai_voices,
-        espeak_voices=espeak_voices,
-        piper_voices=piper_voices,
-        coqui_voices=coqui_voices,
-        qwen3_voices=qwen3_voices,
-        polly_voices=polly_voices,
-        azure_voices=azure_voices,
-        google_voices=google_voices,
-        related_lemmas=related_lemmas,
-        concept_link=concept_link,
-        queued_tasks=queued_tasks,
         lemma_tiers=lemma_tiers,
         tier_display_by_source_name=tier_display_by_source_name,
         tier_ordinal_by_source_name=tier_ordinal_by_source_name,
@@ -562,8 +576,72 @@ def view_lemma(lemma_id: int) -> ResponseReturnValue:
         tier_rank_by_source_name=tier_rank_by_source_name,
         lexeme_frequency_by_corpus=lexeme_frequency_by_corpus,
         lexeme_rank_by_corpus=lexeme_rank_by_corpus,
-        hidden_languages=set(language_names) - set(DEFAULT_GENERATION_LANGUAGES),
+        **context,
     )
+
+
+def _build_voice_options(language_names: Dict[str, str]) -> Dict[str, Any]:
+    """Build the per-engine voice option lists used by the audio generation modal."""
+    openai_voices = [
+        "ash",
+        "alloy",
+        "nova",
+        "ballad",
+        "coral",
+        "echo",
+        "fable",
+        "onyx",
+        "sage",
+        "shimmer",
+    ]
+
+    espeak_voices: Dict[str, List[Dict[str, Any]]] = {}
+    piper_voices: Dict[str, List[Dict[str, Any]]] = {}
+    coqui_voices: Dict[str, List[Dict[str, Any]]] = {}
+    qwen3_voices: Dict[str, List[Dict[str, Any]]] = {}
+    polly_voices: Dict[str, List[Dict[str, Any]]] = {}
+    azure_voices: Dict[str, List[Dict[str, Any]]] = {}
+    google_voices: Dict[str, List[Dict[str, Any]]] = {}
+    for lang_code in language_names.keys():
+        espeak_voices[lang_code] = [
+            {"name": v.name, "gender": v.gender}
+            for v in EspeakVoice.get_voices_for_language(lang_code)
+        ]
+        piper_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in PiperVoice.get_voices_for_language(lang_code)
+        ]
+        coqui_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in CoquiVoice.get_voices_for_language(lang_code)
+        ]
+        qwen3_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in QwenVoice.get_voices_for_language(lang_code)
+        ]
+        polly_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in PollyVoice.get_voices_for_language(lang_code)
+        ]
+        azure_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in AzureVoice.get_voices_for_language(lang_code)
+        ]
+        google_voices[lang_code] = [
+            {"name": v.name, "ui_name": v.ui_name, "gender": v.gender}
+            for v in GoogleTtsVoice.get_voices_for_language(lang_code)
+        ]
+
+    return {
+        "openai_voices": openai_voices,
+        "espeak_voices": espeak_voices,
+        "piper_voices": piper_voices,
+        "coqui_voices": coqui_voices,
+        "qwen3_voices": qwen3_voices,
+        "polly_voices": polly_voices,
+        "azure_voices": azure_voices,
+        "google_voices": google_voices,
+    }
 
 
 @bp.route("/<int:lemma_id>/edit", methods=["GET", "POST"])
@@ -759,7 +837,7 @@ def delete_synonym(lemma_id: int, form_id: int) -> ResponseReturnValue:
 
     if current_app.config.get("READONLY", False):
         flash("Cannot delete: running in read-only mode", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))
 
     # Verify the form belongs to this lemma
     form = (
@@ -770,7 +848,7 @@ def delete_synonym(lemma_id: int, form_id: int) -> ResponseReturnValue:
 
     if not form:
         flash("Synonym or alternative form not found", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))
 
     # Store form details for flash message and grammar fact update
     form_text = form.derivative_form_text
@@ -802,7 +880,7 @@ def delete_synonym(lemma_id: int, form_id: int) -> ResponseReturnValue:
     else:
         flash(f'Failed to delete {form_type}: "{form_text}"', "error")
 
-    return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+    return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))
 
 
 @bp.route("/<int:lemma_id>/delete-all-synonyms", methods=["POST"])
@@ -814,7 +892,7 @@ def delete_all_synonyms(lemma_id: int) -> ResponseReturnValue:
 
     if current_app.config.get("READONLY", False):
         flash("Cannot delete: running in read-only mode", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))
 
     # Get optional filters from request
     lang_code = request.form.get("lang_code")  # Optional: filter by language
@@ -860,7 +938,7 @@ def delete_all_synonyms(lemma_id: int) -> ResponseReturnValue:
 
     if not forms_to_delete:
         flash("No matching forms found to delete", "warning")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))
 
     # Collect affected languages for grammar fact updates
     affected_languages = set(form.language_code for form in forms_to_delete)
@@ -903,4 +981,4 @@ def delete_all_synonyms(lemma_id: int) -> ResponseReturnValue:
     else:
         flash("Failed to delete forms", "error")
 
-    return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+    return redirect(url_for("lemmas.view_lemma_related", lemma_id=lemma_id))

--- a/src/barsukas/routes/overrides.py
+++ b/src/barsukas/routes/overrides.py
@@ -28,7 +28,7 @@ def add_override(lemma_id: int) -> Response:
 
     if current_app.config.get("READONLY", False):
         flash_and_log("Cannot add override: running in read-only mode", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
     lemma = g.db.query(Lemma).get(lemma_id)
     if not lemma:
@@ -43,7 +43,7 @@ def add_override(lemma_id: int) -> Response:
     # Validate language code
     if lang_code not in get_supported_languages():
         flash_and_log("Invalid language code", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
     # Validate difficulty level
     try:
@@ -56,10 +56,10 @@ def add_override(lemma_id: int) -> Response:
                 f"Difficulty level must be -1 or between {Config.MIN_DIFFICULTY_LEVEL} and {Config.MAX_DIFFICULTY_LEVEL}",
                 "error",
             )
-            return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+            return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
     except ValueError:
         flash_and_log("Invalid difficulty level", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
     # Check if override already exists
     old_override = get_difficulty_override(g.db, lemma_id, lang_code)
@@ -92,7 +92,7 @@ def add_override(lemma_id: int) -> Response:
     lang_name = get_supported_languages()[lang_code]
     flash(f"{action} difficulty override for {lang_name}: Level {difficulty_level}", "success")
 
-    return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+    return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
 
 @bp.route("/<int:lemma_id>/<lang_code>/delete", methods=["POST"])
@@ -102,7 +102,7 @@ def delete_override(lemma_id: int, lang_code: str) -> Response:
 
     if current_app.config.get("READONLY", False):
         flash_and_log("Cannot delete override: running in read-only mode", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
     lemma = g.db.query(Lemma).get(lemma_id)
     if not lemma:
@@ -113,7 +113,7 @@ def delete_override(lemma_id: int, lang_code: str) -> Response:
     old_override = get_difficulty_override(g.db, lemma_id, lang_code)
     if not old_override:
         flash_and_log("Override not found", "error")
-        return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+        return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))
 
     old_level = old_override.difficulty_level
 
@@ -139,4 +139,4 @@ def delete_override(lemma_id: int, lang_code: str) -> Response:
     else:
         flash_and_log("Failed to delete override", "error")
 
-    return redirect(url_for("lemmas.view_lemma", lemma_id=lemma_id))
+    return redirect(url_for("lemmas.view_lemma_levels", lemma_id=lemma_id))

--- a/src/barsukas/templates/barsukas_tasks/list.html
+++ b/src/barsukas/templates/barsukas_tasks/list.html
@@ -1,12 +1,14 @@
 {% extends "base.html" %}
 
-{% block title %}Worker Tasks{% endblock %}
+{% block title %}Jobs - Worker Tasks{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
+{% set active_jobs_tab = 'worker' %}
+{% include 'shared/_jobs_nav.html' %}
+
+<div class="row mb-3">
     <div class="col">
-        <h2><i class="bi bi-list-task"></i> Worker Tasks</h2>
-        <p class="text-muted">Barsukas in-process workqueue tasks (<code>barsukas_tasks</code> table). Distinct from OpenAI batch jobs.</p>
+        <p class="text-muted mb-0">Barsukas in-process workqueue tasks (<code>barsukas_tasks</code> table).</p>
     </div>
 </div>
 

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -73,11 +73,6 @@
                             <li><a class="dropdown-item" href="{{ url_for('ipa_reference') }}">
                                 <i class="bi bi-soundwave"></i> {{ STRINGS.navigation.get('ipa_reference', 'IPA Reference') }}
                             </a></li>
-                            <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('workflow', 'Workflow') }}</h6></li>
-                            <li><a class="dropdown-item" href="{{ url_for('pending_imports.list_pending_imports') }}">
-                                <i class="bi bi-inbox"></i> {{ STRINGS.navigation.get('pending_imports', 'Pending Imports') }}
-                            </a></li>
                         </ul>
                     </li>
                     <!-- Tools dropdown -->
@@ -98,6 +93,9 @@
                                 <i class="bi bi-speedometer2"></i> {{ STRINGS.navigation.get('rapid_review', 'Rapid Review') }}
                             </a></li>
                             {% endif %}
+                            <li><a class="dropdown-item" href="{{ url_for('pending_imports.list_pending_imports') }}">
+                                <i class="bi bi-inbox"></i> {{ STRINGS.navigation.get('pending_imports', 'Pending Imports') }}
+                            </a></li>
                             {% if not config.get('READONLY', False) or config.get('ALLOW_OUTBOUND_CALLS', True) %}
                             <li><hr class="dropdown-divider"></li>
                             <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('generation', 'Generation') }}</h6></li>
@@ -115,23 +113,15 @@
                                 <i class="bi bi-cloud-arrow-up"></i> {{ STRINGS.navigation.get('api_client', 'API Client') }}
                             </a></li>
                             {% endif %}
-                            {% if config.get('ALLOW_EXPORTS', True) %}
                             <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('exports', 'Exports') }}</h6></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('data_and_jobs', 'Data & Jobs') }}</h6></li>
+                            {% if config.get('ALLOW_EXPORTS', True) %}
                             <li><a class="dropdown-item" href="{{ url_for('exports.exports_page') }}">
                                 <i class="bi bi-download"></i> {{ STRINGS.navigation.get('exports', 'Exports') }}
                             </a></li>
-                            <li><a class="dropdown-item" href="{{ url_for('gyvate.export_page') }}">
-                                <i class="bi bi-translate"></i> GYVATE STRINGS Export
-                            </a></li>
                             {% endif %}
-                            <li><hr class="dropdown-divider"></li>
-                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('jobs', 'Jobs') }}</h6></li>
-                            <li><a class="dropdown-item" href="{{ url_for('batch_operations.list_batches') }}">
-                                <i class="bi bi-collection"></i> {{ STRINGS.navigation.get('batch_jobs', 'Batch Jobs') }}
-                            </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('barsukas_tasks.list_tasks') }}">
-                                <i class="bi bi-list-task"></i> {{ STRINGS.navigation.get('worker_tasks', 'Worker Tasks') }}
+                                <i class="bi bi-list-task"></i> {{ STRINGS.navigation.get('jobs', 'Jobs') }}
                             </a></li>
                         </ul>
                     </li>
@@ -145,20 +135,33 @@
                                 <i class="bi bi-arrow-left-right"></i> Sentence Comparison
                             </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('trakaido.lemma_search') }}">
-                                <i class="bi bi-book"></i> Lemma View
+                                <i class="bi bi-book"></i> Learner Word View
                             </a></li>
                             <li><hr class="dropdown-divider"></li>
-                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
-                                <i class="bi bi-pencil"></i> Spelling Quiz
+                            <li><h6 class="dropdown-header">Activities</h6></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.activities_index') }}">
+                                <i class="bi bi-controller"></i> All Activities
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.flashcards') }}">
+                                <i class="bi bi-card-text"></i> Flashcards
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.multiple_choice') }}">
+                                <i class="bi bi-ui-radios"></i> Multiple Choice
                             </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.category_choice') }}">
                                 <i class="bi bi-grid-3x3-gap"></i> Category Choice
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.spelling_quiz') }}">
+                                <i class="bi bi-pencil"></i> Spelling Quiz
+                            </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.typing') }}">
+                                <i class="bi bi-keyboard"></i> Typing
+                            </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.sentence_completion') }}">
                                 <i class="bi bi-input-cursor-text"></i> Sentence Completion
                             </a></li>
-                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.multiple_choice') }}">
-                                <i class="bi bi-ui-radios"></i> Multiple Choice
+                            <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.verb_forms') }}">
+                                <i class="bi bi-arrow-repeat"></i> Verb Forms
                             </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('trakaido_activities.listening') }}">
                                 <i class="bi bi-headphones"></i> Listening

--- a/src/barsukas/templates/base.html
+++ b/src/barsukas/templates/base.html
@@ -37,6 +37,7 @@
                             <i class="bi bi-eye"></i> {{ STRINGS.navigation.get('view', 'View') }}
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark">
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('content', 'Content') }}</h6></li>
                             <li><a class="dropdown-item" href="{{ url_for('lemmas.list_lemmas') }}">
                                 <i class="bi bi-list"></i> {{ STRINGS.navigation.get('words', 'Words') }}
                             </a></li>
@@ -58,9 +59,8 @@
                             <li><a class="dropdown-item" href="{{ url_for('texts.list_texts_view') }}">
                                 <i class="bi bi-book"></i> {{ STRINGS.navigation.get('texts', 'Texts') }}
                             </a></li>
-                            <li><a class="dropdown-item" href="{{ url_for('pending_imports.list_pending_imports') }}">
-                                <i class="bi bi-inbox"></i> {{ STRINGS.navigation.get('pending_imports', 'Pending Imports') }}
-                            </a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('reference', 'Reference') }}</h6></li>
                             <li><a class="dropdown-item" href="{{ url_for('peleda.dictionary') }}">
                                 <i class="bi bi-journal-bookmark"></i> {{ STRINGS.navigation.get('dictionary', 'Dictionary') }}
                             </a></li>
@@ -73,6 +73,11 @@
                             <li><a class="dropdown-item" href="{{ url_for('ipa_reference') }}">
                                 <i class="bi bi-soundwave"></i> {{ STRINGS.navigation.get('ipa_reference', 'IPA Reference') }}
                             </a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('workflow', 'Workflow') }}</h6></li>
+                            <li><a class="dropdown-item" href="{{ url_for('pending_imports.list_pending_imports') }}">
+                                <i class="bi bi-inbox"></i> {{ STRINGS.navigation.get('pending_imports', 'Pending Imports') }}
+                            </a></li>
                         </ul>
                     </li>
                     <!-- Tools dropdown -->
@@ -81,13 +86,11 @@
                             <i class="bi bi-tools"></i> {{ STRINGS.navigation.get('tools', 'Tools') }}
                         </a>
                         <ul class="dropdown-menu dropdown-menu-dark">
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('quality_review', 'Quality & Review') }}</h6></li>
                             <li><a class="dropdown-item" href="{{ url_for('completeness.index') }}">
                                 <i class="bi bi-clipboard-data"></i> {{ STRINGS.navigation.get('data_completeness', 'Data Completeness') }}
                             </a></li>
                             {% if not config.get('READONLY', False) %}
-                            <li><a class="dropdown-item" href="{{ url_for('agents_launcher.list_agents') }}">
-                                <i class="bi bi-robot"></i> {{ STRINGS.navigation.get('ai_agents', 'AI Agents') }}
-                            </a></li>
                             <li><a class="dropdown-item" href="{{ url_for('bebras.index') }}">
                                 <i class="bi bi-shield-check"></i> {{ STRINGS.navigation.get('data_quality', 'Data Quality') }}
                             </a></li>
@@ -95,15 +98,26 @@
                                 <i class="bi bi-speedometer2"></i> {{ STRINGS.navigation.get('rapid_review', 'Rapid Review') }}
                             </a></li>
                             {% endif %}
-                            {% if config.get('ALLOW_OUTBOUND_CALLS', True) %}
-                            <li><a class="dropdown-item" href="{{ url_for('api_client.api_client_ui') }}">
-                                <i class="bi bi-cloud-arrow-up"></i> {{ STRINGS.navigation.get('api_client', 'API Client') }}
+                            {% if not config.get('READONLY', False) or config.get('ALLOW_OUTBOUND_CALLS', True) %}
+                            <li><hr class="dropdown-divider"></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('generation', 'Generation') }}</h6></li>
+                            {% endif %}
+                            {% if not config.get('READONLY', False) %}
+                            <li><a class="dropdown-item" href="{{ url_for('agents_launcher.list_agents') }}">
+                                <i class="bi bi-robot"></i> {{ STRINGS.navigation.get('ai_agents', 'AI Agents') }}
                             </a></li>
+                            {% endif %}
+                            {% if config.get('ALLOW_OUTBOUND_CALLS', True) %}
                             <li><a class="dropdown-item" href="{{ url_for('audio.index') }}">
                                 <i class="bi bi-music-note-beamed"></i> {{ STRINGS.navigation.get('audio', 'Audio') }}
                             </a></li>
+                            <li><a class="dropdown-item" href="{{ url_for('api_client.api_client_ui') }}">
+                                <i class="bi bi-cloud-arrow-up"></i> {{ STRINGS.navigation.get('api_client', 'API Client') }}
+                            </a></li>
                             {% endif %}
                             {% if config.get('ALLOW_EXPORTS', True) %}
+                            <li><hr class="dropdown-divider"></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('exports', 'Exports') }}</h6></li>
                             <li><a class="dropdown-item" href="{{ url_for('exports.exports_page') }}">
                                 <i class="bi bi-download"></i> {{ STRINGS.navigation.get('exports', 'Exports') }}
                             </a></li>
@@ -111,6 +125,8 @@
                                 <i class="bi bi-translate"></i> GYVATE STRINGS Export
                             </a></li>
                             {% endif %}
+                            <li><hr class="dropdown-divider"></li>
+                            <li><h6 class="dropdown-header">{{ STRINGS.navigation.get('jobs', 'Jobs') }}</h6></li>
                             <li><a class="dropdown-item" href="{{ url_for('batch_operations.list_batches') }}">
                                 <i class="bi bi-collection"></i> {{ STRINGS.navigation.get('batch_jobs', 'Batch Jobs') }}
                             </a></li>

--- a/src/barsukas/templates/batch_operations/list.html
+++ b/src/barsukas/templates/batch_operations/list.html
@@ -1,12 +1,14 @@
 {% extends "base.html" %}
 
-{% block title %}Batch Operations{% endblock %}
+{% block title %}Jobs - Batch Jobs{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
+{% set active_jobs_tab = 'batch' %}
+{% include 'shared/_jobs_nav.html' %}
+
+<div class="row mb-3">
     <div class="col">
-        <h2><i class="bi bi-collection"></i> Batch Operations</h2>
-        <p class="text-muted">OpenAI batch API jobs</p>
+        <p class="text-muted mb-0">OpenAI batch API jobs.</p>
     </div>
 </div>
 

--- a/src/barsukas/templates/exports/index.html
+++ b/src/barsukas/templates/exports/index.html
@@ -100,6 +100,36 @@
             </div>
         </div>
     </div>
+
+    <!-- GYVATE - UI STRINGS Export -->
+    <div class="col-md-6 mb-4">
+        <div class="card h-100">
+            <div class="card-header bg-info text-dark">
+                <h5 class="mb-0">
+                    <i class="bi bi-translate"></i> UI STRINGS Export
+                </h5>
+            </div>
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">GYVATE Agent</h6>
+                <p class="card-text">
+                    Translate and export UI string catalogs for application localization.
+                    Generates per-language STRINGS files from the English source catalogs.
+                </p>
+                <ul class="mb-3">
+                    <li>UI string catalog translation</li>
+                    <li>Multiple target languages</li>
+                    <li>Supports uploaded catalogs (JSON/xcstrings)</li>
+                    <li>Downloadable ZIP output</li>
+                </ul>
+                <div class="d-flex justify-content-between align-items-center">
+                    <span class="badge bg-warning text-dark">Uses LLM</span>
+                    <a href="{{ url_for('gyvate.export_page') }}" class="btn btn-info">
+                        <i class="bi bi-arrow-right-circle"></i> Export STRINGS
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="row mt-4">

--- a/src/barsukas/templates/gyvate/export.html
+++ b/src/barsukas/templates/gyvate/export.html
@@ -5,6 +5,13 @@
 {% block content %}
 <div class="row mb-4">
     <div class="col">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb mb-2">
+                <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{{ url_for('exports.exports_page') }}">Exports</a></li>
+                <li class="breadcrumb-item active">GYVATE STRINGS Export</li>
+            </ol>
+        </nav>
         <h2><i class="bi bi-translate"></i> GYVATE STRINGS Export</h2>
         <p class="text-muted">General-purpose translation catalog generation. Optional template/module scans can be enabled for Barsukas workflows.</p>
     </div>

--- a/src/barsukas/templates/lemmas/_lemma_nav.html
+++ b/src/barsukas/templates/lemmas/_lemma_nav.html
@@ -1,0 +1,64 @@
+{# Shared breadcrumb + sub-navigation for lemma pages.
+   Parameters:
+   - lemma: the Lemma object
+   - active_tab: one of 'overview', 'forms', 'audio', 'related', 'levels'
+   - nav_counts: dict with per-tab counts ('forms', 'audio', 'related', 'levels')
+#}
+<div class="row mb-2">
+    <div class="col">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb mb-2">
+                <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
+                <li class="breadcrumb-item"><a href="{{ url_for('lemmas.list_lemmas') }}">Lemmas</a></li>
+                {% if active_tab == 'overview' %}
+                <li class="breadcrumb-item active">{{ lemma.lemma_text }}</li>
+                {% else %}
+                <li class="breadcrumb-item"><a href="{{ url_for('lemmas.view_lemma', lemma_id=lemma.id) }}">{{ lemma.lemma_text }}</a></li>
+                <li class="breadcrumb-item active">
+                    {% if active_tab == 'forms' %}Forms &amp; Grammar
+                    {% elif active_tab == 'audio' %}Audio
+                    {% elif active_tab == 'related' %}Related Words
+                    {% elif active_tab == 'levels' %}Frequency &amp; Levels
+                    {% endif %}
+                </li>
+                {% endif %}
+            </ol>
+        </nav>
+        <ul class="nav nav-pills mb-3">
+            <li class="nav-item">
+                <a class="nav-link {% if active_tab == 'overview' %}active{% endif %}"
+                   href="{{ url_for('lemmas.view_lemma', lemma_id=lemma.id) }}">
+                    <i class="bi bi-book"></i> Overview
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if active_tab == 'forms' %}active{% endif %}"
+                   href="{{ url_for('lemmas.view_lemma_forms', lemma_id=lemma.id) }}">
+                    <i class="bi bi-file-text"></i> Forms &amp; Grammar
+                    {% if nav_counts.forms %}<span class="badge text-bg-light ms-1">{{ nav_counts.forms }}</span>{% endif %}
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if active_tab == 'audio' %}active{% endif %}"
+                   href="{{ url_for('lemmas.view_lemma_audio', lemma_id=lemma.id) }}">
+                    <i class="bi bi-music-note-beamed"></i> Audio
+                    {% if nav_counts.audio %}<span class="badge text-bg-light ms-1">{{ nav_counts.audio }}</span>{% endif %}
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if active_tab == 'related' %}active{% endif %}"
+                   href="{{ url_for('lemmas.view_lemma_related', lemma_id=lemma.id) }}">
+                    <i class="bi bi-shuffle"></i> Related Words
+                    {% if nav_counts.related %}<span class="badge text-bg-light ms-1">{{ nav_counts.related }}</span>{% endif %}
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if active_tab == 'levels' %}active{% endif %}"
+                   href="{{ url_for('lemmas.view_lemma_levels', lemma_id=lemma.id) }}">
+                    <i class="bi bi-bar-chart"></i> Frequency &amp; Levels
+                    {% if nav_counts.levels %}<span class="badge text-bg-light ms-1">{{ nav_counts.levels }}</span>{% endif %}
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/src/barsukas/templates/lemmas/audio.html
+++ b/src/barsukas/templates/lemmas/audio.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block title %}{{ lemma.lemma_text }} - Audio{% endblock %}
+
+{% block content %}
+{% include 'lemmas/_lemma_nav.html' %}
+
+{% include 'lemmas/sections/audio.html' %}
+
+{% endblock %}

--- a/src/barsukas/templates/lemmas/forms.html
+++ b/src/barsukas/templates/lemmas/forms.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}{{ lemma.lemma_text }} - Forms & Grammar{% endblock %}
+
+{% block content %}
+{% include 'lemmas/_lemma_nav.html' %}
+
+{% include 'lemmas/sections/forms.html' %}
+
+{% include 'lemmas/sections/grammar_facts.html' %}
+
+{% endblock %}

--- a/src/barsukas/templates/lemmas/levels.html
+++ b/src/barsukas/templates/lemmas/levels.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block title %}{{ lemma.lemma_text }} - Frequency & Levels{% endblock %}
+
+{% block content %}
+{% include 'lemmas/_lemma_nav.html' %}
+
+<!-- Base Difficulty -->
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header">
+                <i class="bi bi-speedometer"></i> Base Difficulty
+            </div>
+            <div class="card-body">
+                <p class="mb-2">
+                    <strong>Base difficulty:</strong>
+                    {% if lemma.difficulty_level is not none %}
+                        {% if lemma.difficulty_level == -1 %}
+                            <span class="badge bg-warning difficulty-badge">Excluded</span>
+                        {% else %}
+                            <span class="badge bg-info difficulty-badge">Level {{ lemma.difficulty_level }}</span>
+                        {% endif %}
+                    {% else %}
+                        <span class="text-muted">Not set</span>
+                    {% endif %}
+                    <a href="{{ url_for('lemmas.edit_lemma', lemma_id=lemma.id) }}" class="small ms-2">edit</a>
+                </p>
+                {% if difficulty_stats %}
+                <p class="mb-0 small text-muted">
+                    Level distribution for {{ lemma.pos_type }}{% if lemma.pos_subtype %} ({{ lemma.pos_subtype }}){% endif %}:
+                    {% for level in range(-1, config.MAX_DIFFICULTY_LEVEL + 1) %}
+                        {% if level in difficulty_stats %}
+                            {% if level == -1 %}
+                                <span class="badge bg-warning text-dark" title="{{ difficulty_stats[level] }} words">-1: {{ difficulty_stats[level] }}</span>
+                            {% else %}
+                                <span class="badge bg-secondary" title="{{ difficulty_stats[level] }} words">{{ level }}: {{ difficulty_stats[level] }}</span>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                </p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+{% include 'lemmas/sections/overrides.html' %}
+
+{% include 'lemmas/sections/frequency.html' %}
+
+{% endblock %}

--- a/src/barsukas/templates/lemmas/related.html
+++ b/src/barsukas/templates/lemmas/related.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block title %}{{ lemma.lemma_text }} - Related Words{% endblock %}
+
+{% block content %}
+{% include 'lemmas/_lemma_nav.html' %}
+
+{% include 'lemmas/sections/synonyms.html' %}
+
+{% include 'lemmas/sections/relations.html' %}
+
+{% include 'lemmas/sections/sentences.html' %}
+
+{% endblock %}

--- a/src/barsukas/templates/lemmas/sections/coverage.html
+++ b/src/barsukas/templates/lemmas/sections/coverage.html
@@ -1,0 +1,86 @@
+<!-- Data Coverage Summary -->
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span><i class="bi bi-clipboard-check"></i> Data Coverage</span>
+                <div>
+                    <a href="{{ url_for('lemmas.view_lemma_forms', lemma_id=lemma.id) }}" class="btn btn-sm btn-light">
+                        <i class="bi bi-file-text"></i> Forms &amp; Grammar
+                    </a>
+                    <a href="{{ url_for('lemmas.view_lemma_audio', lemma_id=lemma.id) }}" class="btn btn-sm btn-light">
+                        <i class="bi bi-music-note-beamed"></i> Audio
+                    </a>
+                </div>
+            </div>
+            <div class="card-body">
+                <p class="text-muted small mb-2">
+                    <i class="bi bi-info-circle"></i>
+                    Per-language presence of grammatical forms, pronunciations, and audio.
+                    Generation and full detail live on the
+                    <a href="{{ url_for('lemmas.view_lemma_forms', lemma_id=lemma.id) }}">Forms &amp; Grammar</a> and
+                    <a href="{{ url_for('lemmas.view_lemma_audio', lemma_id=lemma.id) }}">Audio</a> subpages.
+                </p>
+                <div class="table-responsive">
+                    <table class="table table-sm table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th>Language</th>
+                                <th>Translation</th>
+                                <th>Grammatical Forms</th>
+                                <th>Pronunciation</th>
+                                <th>Audio</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in coverage_rows %}
+                            <tr>
+                                <td><strong>{{ row.lang_name }}</strong> <small class="text-muted">({{ row.lang_code }})</small></td>
+                                <td>
+                                    {% if row.has_translation %}
+                                        <i class="bi bi-check-circle-fill text-success" title="Translation set"></i>
+                                    {% else %}
+                                        <span class="text-muted">&mdash;</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if row.forms_count %}
+                                        <a href="{{ url_for('lemmas.view_lemma_forms', lemma_id=lemma.id) }}" class="text-decoration-none">
+                                            <span class="badge bg-secondary">{{ row.forms_count }} form{{ 's' if row.forms_count != 1 else '' }}</span>
+                                        </a>
+                                    {% else %}
+                                        <span class="text-muted">&mdash;</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if row.pronunciation_count or row.has_lemma_pronunciation %}
+                                        <i class="bi bi-check-circle-fill text-success" title="Pronunciation data present"></i>
+                                        {% if row.pronunciation_count %}
+                                            <small class="text-muted">({{ row.pronunciation_count }} form{{ 's' if row.pronunciation_count != 1 else '' }})</small>
+                                        {% elif row.has_lemma_pronunciation %}
+                                            <small class="text-muted">(base only)</small>
+                                        {% endif %}
+                                    {% else %}
+                                        <span class="text-muted">&mdash;</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if row.audio_total %}
+                                        <a href="{{ url_for('lemmas.view_lemma_audio', lemma_id=lemma.id) }}" class="text-decoration-none">
+                                            <span class="badge {% if row.audio_approved == row.audio_total %}bg-success{% else %}bg-warning text-dark{% endif %}">
+                                                {{ row.audio_approved }}/{{ row.audio_total }} approved
+                                            </span>
+                                        </a>
+                                    {% else %}
+                                        <span class="text-muted">&mdash;</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/barsukas/templates/lemmas/sections/details.html
+++ b/src/barsukas/templates/lemmas/sections/details.html
@@ -88,20 +88,7 @@
                                 {% else %}
                                     <span class="text-muted">Not set</span>
                                 {% endif %}
-                                {% if difficulty_stats %}
-                                    <br><small class="text-muted">
-                                        Levels for {{ lemma.pos_type }}{% if lemma.pos_subtype %} ({{ lemma.pos_subtype }}){% endif %}:
-                                        {% for level in range(-1, config.MAX_DIFFICULTY_LEVEL + 1) %}
-                                            {% if level in difficulty_stats %}
-                                                {% if level == -1 %}
-                                                    <span class="badge bg-warning text-dark" title="{{ difficulty_stats[level] }} words" style="font-size: 0.7rem;">-1: {{ difficulty_stats[level] }}</span>
-                                                {% else %}
-                                                    <span class="badge bg-secondary" title="{{ difficulty_stats[level] }} words" style="font-size: 0.7rem;">{{ level }}: {{ difficulty_stats[level] }}</span>
-                                                {% endif %}
-                                            {% endif %}
-                                        {% endfor %}
-                                    </small>
-                                {% endif %}
+                                <a class="small ms-1" href="{{ url_for('lemmas.view_lemma_levels', lemma_id=lemma.id) }}">details</a>
                             </dd>
 
                             <dt class="col-sm-5">Confidence:</dt>
@@ -122,121 +109,6 @@
                                 <dd class="col-sm-7"><span class="badge bg-info">{{ lemma.disambiguation }}</span></dd>
                             {% endif %}
                         </dl>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Frequency and Tier Signals -->
-<div class="row mb-4">
-    <div class="col">
-        <div class="card">
-            <div class="card-header">
-                <i class="bi bi-bar-chart"></i> Frequency and Tier Signals
-            </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <strong>Combined Frequency Rank:</strong>
-                    {% if lemma.frequency_rank %}
-                        {{ lemma.frequency_rank }}
-                        <span class="text-muted">(weighted harmonic mean of corpus + tier signals; lower = more common)</span>
-                    {% else %}
-                        <span class="text-muted">— (run <code>pradzia --calc-ranks</code> to populate)</span>
-                    {% endif %}
-                </div>
-                <div class="row">
-                    <div class="col-lg-6 mb-3 mb-lg-0">
-                        <h6 class="mb-2">Tier Signals</h6>
-                        {% if lemma_tiers %}
-                            <div class="table-responsive">
-                                <table class="table table-sm table-striped">
-                                    <thead>
-                                        <tr>
-                                            <th>Source</th>
-                                            <th>Tier</th>
-                                            <th>Rank used</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for tier in lemma_tiers %}
-                                        <tr>
-                                            <td><code>{{ tier.source }}</code></td>
-                                            <td>
-                                                {{ tier_display_by_source_name.get((tier.source, tier.tier_name), tier.tier_name) }}
-                                                {% set ordinal = tier_ordinal_by_source_name.get((tier.source, tier.tier_name)) %}
-                                                {% set tier_size = tier_size_by_source.get(tier.source) %}
-                                                {% if ordinal and tier_size %}
-                                                    <span class="text-muted">({{ ordinal }} of {{ tier_size }})</span>
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% set tier_rank = tier_rank_by_source_name.get((tier.source, tier.tier_name)) %}
-                                                {% if tier_rank is not none %}
-                                                    {{ tier_rank }}
-                                                {% else %}
-                                                    <span class="text-muted">—</span>
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                            <p class="text-muted small mb-0">Rank used = synthetic rank this tier contributes to the combined frequency rank (lower = more common).</p>
-                        {% else %}
-                            <p class="text-muted mb-0">No lemma-tier assignment found yet.</p>
-                        {% endif %}
-                    </div>
-
-                    <div class="col-lg-6">
-                        <h6 class="mb-2">Corpus Frequency</h6>
-                        {% if lexeme_frequency_by_corpus %}
-                            <div class="table-responsive mb-3">
-                                <table class="table table-sm table-striped">
-                                    <thead>
-                                        <tr>
-                                            <th>Corpus</th>
-                                            <th>Freq (per M)</th>
-                                            <th>Best rank</th>
-                                            <th>Forms</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for corpus_name, rollup in lexeme_frequency_by_corpus.items() %}
-                                        <tr>
-                                            <td><code>{{ corpus_name }}</code></td>
-                                            <td>
-                                                {% if rollup %}
-                                                    {{ "%.2f"|format(rollup.total_frequency) }}
-                                                {% else %}
-                                                    <span class="text-muted">No lexeme row</span>
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% set best_rank = lexeme_rank_by_corpus.get(corpus_name) %}
-                                                {% if best_rank is not none %}
-                                                    {{ best_rank }}
-                                                {% else %}
-                                                    <span class="text-muted">—</span>
-                                                {% endif %}
-                                            </td>
-                                            <td>
-                                                {% if rollup %}
-                                                    {{ rollup.form_breakdown|length }}
-                                                {% else %}
-                                                    <span class="text-muted">—</span>
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                        {% else %}
-                            <p class="text-muted mb-0">No enabled lexeme-based corpora configured for this lemma yet.</p>
-                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/src/barsukas/templates/lemmas/sections/frequency.html
+++ b/src/barsukas/templates/lemmas/sections/frequency.html
@@ -1,0 +1,114 @@
+<!-- Frequency and Tier Signals -->
+<div class="row mb-4">
+    <div class="col">
+        <div class="card">
+            <div class="card-header">
+                <i class="bi bi-bar-chart"></i> Frequency and Tier Signals
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <strong>Combined Frequency Rank:</strong>
+                    {% if lemma.frequency_rank %}
+                        {{ lemma.frequency_rank }}
+                        <span class="text-muted">(weighted harmonic mean of corpus + tier signals; lower = more common)</span>
+                    {% else %}
+                        <span class="text-muted">— (run <code>pradzia --calc-ranks</code> to populate)</span>
+                    {% endif %}
+                </div>
+                <div class="row">
+                    <div class="col-lg-6 mb-3 mb-lg-0">
+                        <h6 class="mb-2">Tier Signals</h6>
+                        {% if lemma_tiers %}
+                            <div class="table-responsive">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Source</th>
+                                            <th>Tier</th>
+                                            <th>Rank used</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for tier in lemma_tiers %}
+                                        <tr>
+                                            <td><code>{{ tier.source }}</code></td>
+                                            <td>
+                                                {{ tier_display_by_source_name.get((tier.source, tier.tier_name), tier.tier_name) }}
+                                                {% set ordinal = tier_ordinal_by_source_name.get((tier.source, tier.tier_name)) %}
+                                                {% set tier_size = tier_size_by_source.get(tier.source) %}
+                                                {% if ordinal and tier_size %}
+                                                    <span class="text-muted">({{ ordinal }} of {{ tier_size }})</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% set tier_rank = tier_rank_by_source_name.get((tier.source, tier.tier_name)) %}
+                                                {% if tier_rank is not none %}
+                                                    {{ tier_rank }}
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                            <p class="text-muted small mb-0">Rank used = synthetic rank this tier contributes to the combined frequency rank (lower = more common).</p>
+                        {% else %}
+                            <p class="text-muted mb-0">No lemma-tier assignment found yet.</p>
+                        {% endif %}
+                    </div>
+
+                    <div class="col-lg-6">
+                        <h6 class="mb-2">Corpus Frequency</h6>
+                        {% if lexeme_frequency_by_corpus %}
+                            <div class="table-responsive mb-3">
+                                <table class="table table-sm table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Corpus</th>
+                                            <th>Freq (per M)</th>
+                                            <th>Best rank</th>
+                                            <th>Forms</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for corpus_name, rollup in lexeme_frequency_by_corpus.items() %}
+                                        <tr>
+                                            <td><code>{{ corpus_name }}</code></td>
+                                            <td>
+                                                {% if rollup %}
+                                                    {{ "%.2f"|format(rollup.total_frequency) }}
+                                                {% else %}
+                                                    <span class="text-muted">No lexeme row</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% set best_rank = lexeme_rank_by_corpus.get(corpus_name) %}
+                                                {% if best_rank is not none %}
+                                                    {{ best_rank }}
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if rollup %}
+                                                    {{ rollup.form_breakdown|length }}
+                                                {% else %}
+                                                    <span class="text-muted">—</span>
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <p class="text-muted mb-0">No enabled lexeme-based corpora configured for this lemma yet.</p>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/barsukas/templates/lemmas/view.html
+++ b/src/barsukas/templates/lemmas/view.html
@@ -3,36 +3,14 @@
 {% block title %}{{ lemma.lemma_text }}{% endblock %}
 
 {% block content %}
-<div class="row mb-4">
-    <div class="col">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a href="{{ url_for('index') }}">Home</a></li>
-                <li class="breadcrumb-item"><a href="{{ url_for('lemmas.list_lemmas') }}">Lemmas</a></li>
-                <li class="breadcrumb-item active">{{ lemma.lemma_text }}</li>
-            </ol>
-        </nav>
-    </div>
-</div>
+{% include 'lemmas/_lemma_nav.html' %}
 
 {% include 'lemmas/sections/details.html' %}
 
-{% include 'lemmas/sections/relations.html' %}
-
-{% include 'lemmas/sections/tasks.html' %}
-
-{% include 'lemmas/sections/forms.html' %}
-
-{% include 'lemmas/sections/synonyms.html' %}
-
 {% include 'lemmas/sections/translations.html' %}
 
-{% include 'lemmas/sections/grammar_facts.html' %}
+{% include 'lemmas/sections/coverage.html' %}
 
-{% include 'lemmas/sections/audio.html' %}
-
-{% include 'lemmas/sections/sentences.html' %}
-
-{% include 'lemmas/sections/overrides.html' %}
+{% include 'lemmas/sections/tasks.html' %}
 
 {% endblock %}

--- a/src/barsukas/templates/shared/_jobs_nav.html
+++ b/src/barsukas/templates/shared/_jobs_nav.html
@@ -1,0 +1,24 @@
+{# Shared header + tab navigation for the Jobs pages.
+   Parameters:
+   - active_jobs_tab: 'worker' or 'batch'
+#}
+<div class="row mb-4">
+    <div class="col">
+        <h2><i class="bi bi-list-task"></i> Jobs</h2>
+        <p class="text-muted mb-2">Background work: in-process worker tasks and OpenAI batch jobs.</p>
+        <ul class="nav nav-pills">
+            <li class="nav-item">
+                <a class="nav-link {% if active_jobs_tab == 'worker' %}active{% endif %}"
+                   href="{{ url_for('barsukas_tasks.list_tasks') }}">
+                    <i class="bi bi-list-task"></i> Worker Tasks
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if active_jobs_tab == 'batch' %}active{% endif %}"
+                   href="{{ url_for('batch_operations.list_batches') }}">
+                    <i class="bi bi-collection"></i> Batch Jobs
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/src/barsukas/templates/trakaido/lemma_search.html
+++ b/src/barsukas/templates/trakaido/lemma_search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Find a Lemma · Trakaido{% endblock %}
+{% block title %}Learner Word View · Trakaido{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/trakaido.css') }}">
@@ -9,8 +9,8 @@
 {% block content %}
 <div class="trakaido-page">
     <div class="trakaido-header">
-        <h1>Find a Lemma</h1>
-        <div class="trakaido-meta">Search by English text or by translation in the chosen languages.</div>
+        <h1>Learner Word View</h1>
+        <div class="trakaido-meta">Two-language word view. Search by English text or by translation in the chosen languages.</div>
     </div>
 
     <form class="trakaido-controls" method="get" action="{{ url_for('trakaido.lemma_search') }}">

--- a/src/tests/barsukas/test_routes_smoke.py
+++ b/src/tests/barsukas/test_routes_smoke.py
@@ -25,6 +25,9 @@ ROUTE_SMOKE_CASES: tuple[RouteSmokeCase, ...] = (
     RouteSmokeCase(name="sentences", path="/sentences/", expected_text="I eat"),
     RouteSmokeCase(name="dictionary", path="/dictionary/?letter=E", expected_text="eat"),
     RouteSmokeCase(name="sync", path="/sync/", expected_text="sync"),
+    RouteSmokeCase(name="exports", path="/exports/", expected_text="GYVATE"),
+    RouteSmokeCase(name="worker-tasks", path="/barsukas-tasks/", expected_text="Worker Tasks"),
+    RouteSmokeCase(name="batch-jobs", path="/batch-operations/", expected_text="Batch Jobs"),
 )
 
 

--- a/src/tests/barsukas/test_routes_smoke.py
+++ b/src/tests/barsukas/test_routes_smoke.py
@@ -77,9 +77,23 @@ class TestLemmaRoutes:
         html = response.data.decode()
         assert "eat" in html
 
+    @pytest.mark.parametrize("subpage", ["forms", "audio", "related", "levels"])
+    def test_view_lemma_subpages_return_200(self, client: FlaskClient, subpage: str) -> None:
+        response = client.get(f"/lemmas/1/{subpage}")
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "eat" in html
+
     def test_view_nonexistent_lemma_redirects(self, client: FlaskClient) -> None:
         response = client.get("/lemmas/9999")
         # Should redirect to the lemma list
+        assert response.status_code == 302
+
+    @pytest.mark.parametrize("subpage", ["forms", "audio", "related", "levels"])
+    def test_view_nonexistent_lemma_subpages_redirect(
+        self, client: FlaskClient, subpage: str
+    ) -> None:
+        response = client.get(f"/lemmas/9999/{subpage}")
         assert response.status_code == 302
 
     def test_view_second_lemma(self, client: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
Refactored the monolithic lemma view page into a tabbed interface with separate subpages for different content categories. This improves page load performance, user navigation, and code maintainability by splitting concerns across focused views.

## Key Changes

**Route and View Structure:**
- Extracted shared lemma page context building into `_get_lemma_page_context()` helper function that fetches and prepares all data needed by lemma subpages
- Created four new route handlers for lemma subpages:
  - `view_lemma_forms()` - Grammatical forms, pronunciations, and grammar facts
  - `view_lemma_audio()` - Audio files and audio generation interface
  - `view_lemma_related()` - Synonyms, alternative forms, related lemmas, and sentences
  - `view_lemma_levels()` - Frequency/tier signals and per-language difficulty overrides
- Simplified main `view_lemma()` to show overview with translations and per-language coverage summary
- Extracted voice option building into `_build_voice_options()` helper function

**Template Changes:**
- Created new template files for each subpage: `forms.html`, `audio.html`, `related.html`, `levels.html`
- Added shared `_lemma_nav.html` breadcrumb and tab navigation component with per-tab counts
- Extracted coverage summary into new `sections/coverage.html` template
- Extracted frequency/tier signals into new `sections/frequency.html` template
- Simplified main `view.html` to focus on overview content
- Updated `details.html` to link to levels page instead of showing full frequency data

**Navigation and UI:**
- Added shared `_jobs_nav.html` component for Jobs pages (worker tasks and batch operations)
- Updated base navigation menu with section headers and dividers
- Updated worker tasks and batch operations list pages to use shared nav component
- Updated page titles to reflect new structure (e.g., "Jobs - Worker Tasks")

**Supporting Changes:**
- Added `build_language_coverage_rows()` function to `lemma_display.py` for generating per-language coverage data
- Updated redirect URLs in `overrides.py` to point to `view_lemma_levels` instead of main view
- Removed unused import of `get_all_translations` from translation_helpers
- Added smoke tests for new routes and pages

## Implementation Details

The refactoring maintains backward compatibility by keeping the main lemma URL (`/<int:lemma_id>`) as the overview page. All data fetching is centralized in `_get_lemma_page_context()` to avoid duplication and ensure consistency across subpages. The context includes pre-computed navigation counts for each tab, allowing the shared nav component to display item counts without additional queries.

Voice options for audio generation are now built on-demand only for the audio subpage, reducing overhead for other views. The coverage summary on the overview page provides a quick visual reference to data completeness across languages, with links to detailed views for further exploration.

https://claude.ai/code/session_01DrGHAG5nw2BEKJR1cHaWC4