### PR TITLE
Sort Chinese by tone-digit pinyin instead of tone-marked pinyin

### DIFF
--- a/src/langtools/zh/pinyin_helper.py
+++ b/src/langtools/zh/pinyin_helper.py
@@ -97,6 +97,48 @@ def generate_pinyin(chinese_text: str) -> Optional[str]:
         return None
 
 
+def generate_pinyin_sort_key(chinese_text: str) -> Optional[str]:
+    """
+    Generate a pinyin sort key for Chinese dictionary ordering.
+
+    Unlike :func:`generate_pinyin`, tones are written as trailing digits rather
+    than diacritics (e.g. "dian3" instead of "diǎn").  Tone-marked vowels live
+    far above ASCII in Unicode, so a byte-ordered comparison of tone-marked
+    pinyin sorts by tone before it sorts by spelling.  Trailing digits keep the
+    letters adjacent, so a plain BINARY collation yields standard dictionary
+    order: alphabetical by syllable first, then tone 1-4 within a homophone.
+
+    Neutral tone is written as 5 so that every syllable ends in a digit, and it
+    sorts after the four marked tones as dictionaries expect.  ü is rendered
+    "v" (pypinyin's convention), which sorts just after "u".
+
+    Args:
+        chinese_text: Chinese text to convert (simplified or traditional)
+
+    Returns:
+        Lowercase pinyin with tone digits (e.g., "ni3 hao3"), or None if:
+        - pypinyin is not available
+        - text is empty
+        - text doesn't contain Chinese characters
+    """
+    if not PYPINYIN_AVAILABLE or not chinese_text:
+        return None
+
+    if not is_chinese(chinese_text):
+        return None
+
+    try:
+        # Convert to simplified Chinese first for better pinyin accuracy
+        # pypinyin handles simplified characters more reliably for polyphonic chars
+        text_for_pinyin = to_simplified(chinese_text)
+
+        pinyin_list = lazy_pinyin(text_for_pinyin, style=Style.TONE3, neutral_tone_with_five=True)
+        return " ".join(pinyin_list).lower()
+    except Exception as e:
+        logger.warning(f"Failed to generate pinyin sort key for '{chinese_text}': {e}")
+        return None
+
+
 def generate_pinyin_ruby_html(chinese_text: str) -> str:
     """
     Generate HTML with ruby annotations for Chinese text with Pinyin.

--- a/src/storage/migrations/backfill_sort_keys.py
+++ b/src/storage/migrations/backfill_sort_keys.py
@@ -6,6 +6,10 @@ Iterates over every language that ``compute_sort_key`` supports (CJK plus
 Latin, Cyrillic, Brahmic, and Thai), finds rows where ``sort_key`` is NULL,
 computes the value, and writes it back.  Safe to re-run — rows that
 already have a sort_key are skipped via the NULL filter.
+
+Pass ``--recompute`` to also rewrite rows that already have a sort_key.  This
+is needed when the key format itself changes, as it did for Chinese when tone
+marks ("diǎn") were replaced by tone digits ("dian3").
 """
 
 import sys
@@ -30,25 +34,32 @@ def _all_supported_languages() -> List[str]:
     return _CJK_LANGUAGES + sorted(SORT_KEY_LANGUAGES)
 
 
-def backfill(db_path: str, dry_run: bool = False, languages: Optional[List[str]] = None) -> None:
+def backfill(
+    db_path: str,
+    dry_run: bool = False,
+    languages: Optional[List[str]] = None,
+    recompute: bool = False,
+) -> None:
     session = create_database_session(db_path)
     target_languages = languages if languages else _all_supported_languages()
 
     try:
         for lang in target_languages:
-            rows = (
-                session.query(LemmaTranslation)
-                .filter(
-                    LemmaTranslation.language_code == lang,
-                    LemmaTranslation.sort_key.is_(None),
-                )
-                .all()
+            query = session.query(LemmaTranslation).filter(
+                LemmaTranslation.language_code == lang,
             )
+            if not recompute:
+                query = query.filter(LemmaTranslation.sort_key.is_(None))
+            rows = query.all()
             updated = 0
             skipped = 0
+            unchanged = 0
             for row in rows:
                 key = compute_sort_key(lang, row.translation)
                 if key:
+                    if key == row.sort_key:
+                        unchanged += 1
+                        continue
                     if not dry_run:
                         row.sort_key = key
                     updated += 1
@@ -59,7 +70,10 @@ def backfill(db_path: str, dry_run: bool = False, languages: Optional[List[str]]
                 session.commit()
 
             if updated or skipped:
-                print(f"{lang}: {updated} updated, {skipped} skipped (no key computed)")
+                print(
+                    f"{lang}: {updated} updated, {unchanged} unchanged, "
+                    f"{skipped} skipped (no key computed)"
+                )
 
         if dry_run:
             print("\n** DRY RUN — no changes written **")
@@ -87,12 +101,18 @@ def main() -> int:
         default=None,
         help="Restrict backfill to these language codes (default: all supported)",
     )
+    parser.add_argument(
+        "--recompute",
+        action="store_true",
+        help="Also rewrite rows that already have a sort_key (for format changes)",
+    )
     args = parser.parse_args()
 
     print(f"Database: {args.db_path}")
     print(f"Dry run: {args.dry_run}")
+    print(f"Recompute existing: {args.recompute}")
     print(f"Languages: {args.languages or 'all supported'}\n")
-    backfill(args.db_path, args.dry_run, args.languages)
+    backfill(args.db_path, args.dry_run, args.languages, args.recompute)
     return 0
 
 

--- a/src/storage/translation_helpers.py
+++ b/src/storage/translation_helpers.py
@@ -600,7 +600,9 @@ def get_all_definitions(session: Session, lemma: Lemma) -> Dict[str, Optional[st
 def compute_sort_key(lang_code: str, translation: str) -> Optional[str]:
     """Compute a sort key for dictionary ordering.
 
-    - Chinese (zh): pinyin with tone marks, e.g. "chī" for 吃
+    - Chinese (zh): pinyin with tone digits, e.g. "chi1" for 吃.  Digits rather
+      than tone marks, so that a byte-ordered comparison sorts alphabetically
+      by syllable first and only then by tone.
     - Japanese (ja): hiragana reading, e.g. "たべる" for 食べる
     - Korean (ko): decomposed jamo
     - Accented Latin languages (lt, es, de, sv, pt, fr, vi): character
@@ -618,21 +620,21 @@ def compute_sort_key(lang_code: str, translation: str) -> Optional[str]:
 
     try:
         if lang_code == "zh":
-            from langtools.zh.pinyin_helper import generate_pinyin
+            from langtools.zh.pinyin_helper import generate_pinyin_sort_key
 
-            return str(generate_pinyin(translation))
+            return generate_pinyin_sort_key(translation)
         elif lang_code == "ja":
             from langtools.ja.romaji_helper import generate_hiragana
 
-            return str(generate_hiragana(translation))
+            return generate_hiragana(translation)
         elif lang_code == "ko":
             from langtools.ko.hangul_helper import decompose_hangul
 
-            return str(decompose_hangul(translation))
+            return decompose_hangul(translation)
         elif lang_code in _COLLATION_SORT_KEY_LANGUAGES:
             from langtools.collation import generate_sort_key
 
-            return str(generate_sort_key(lang_code, translation))
+            return generate_sort_key(lang_code, translation)
     except Exception as e:
         logger.warning(f"Failed to compute sort_key for {lang_code} '{translation}': {e}")
     return None

--- a/src/tests/langtools/test_zh_pinyin_sort.py
+++ b/src/tests/langtools/test_zh_pinyin_sort.py
@@ -1,0 +1,70 @@
+"""Tests for Chinese pinyin sort keys used in dictionary ordering."""
+
+import pytest
+
+from langtools.zh.pinyin_helper import PYPINYIN_AVAILABLE, generate_pinyin_sort_key
+from storage.translation_helpers import compute_sort_key
+
+pytestmark = pytest.mark.skipif(not PYPINYIN_AVAILABLE, reason="pypinyin not installed")
+
+
+def test_sort_key_uses_tone_digits() -> None:
+    """Tones are trailing digits, not diacritics, so letters stay adjacent."""
+    assert generate_pinyin_sort_key("点") == "dian3"
+    assert generate_pinyin_sort_key("你好") == "ni3 hao3"
+
+
+def test_sort_keys_are_ascii() -> None:
+    """Tone-marked vowels would break binary collation; keys must be ASCII."""
+    for word in ["点", "掉", "对", "大", "动", "女", "绿", "散步"]:
+        key = generate_pinyin_sort_key(word)
+        assert key is not None
+        assert key.isascii(), f"non-ASCII sort key for {word!r}: {key!r}"
+
+
+def test_alphabetical_before_tonal() -> None:
+    """Spelling drives ordering; tone is only a tiebreaker among homophones."""
+    words = ["点", "掉", "对", "大", "的", "动", "但", "当", "都"]
+    ordered = sorted(words, key=lambda w: generate_pinyin_sort_key(w) or "")
+    assert ordered == ["大", "但", "当", "的", "点", "掉", "动", "都", "对"]
+
+
+def test_tone_order_within_homophones() -> None:
+    """Same syllable sorts by tone 1-4, with neutral tone (5) last."""
+    # 三 sān, 伞 sǎn, 散 sàn
+    words = ["散", "伞", "三"]
+    ordered = sorted(words, key=lambda w: generate_pinyin_sort_key(w) or "")
+    assert ordered == ["三", "伞", "散"]
+
+
+def test_neutral_tone_written_as_five() -> None:
+    """Every syllable ends in a digit so neutral tone can't sort before tone 1."""
+    assert generate_pinyin_sort_key("的") == "de5"
+
+
+def test_umlaut_u_becomes_v() -> None:
+    """ü is written 'v', sorting just after 'u' as dictionaries expect."""
+    assert generate_pinyin_sort_key("女") == "nv3"
+    assert generate_pinyin_sort_key("绿") == "lv4"
+
+
+def test_shorter_word_sorts_before_compound() -> None:
+    """A syllable sorts before compounds starting with it (space < digits)."""
+    words = ["大学", "大"]
+    ordered = sorted(words, key=lambda w: generate_pinyin_sort_key(w) or "")
+    assert ordered == ["大", "大学"]
+
+
+def test_non_chinese_returns_none() -> None:
+    assert generate_pinyin_sort_key("hello") is None
+    assert generate_pinyin_sort_key("") is None
+
+
+def test_compute_sort_key_uses_tone_digits() -> None:
+    """The storage-layer entrypoint must produce the same tone-digit keys."""
+    assert compute_sort_key("zh", "点") == "dian3"
+
+
+def test_compute_sort_key_returns_none_not_literal_none() -> None:
+    """A failed transliteration must be None, never the string 'None'."""
+    assert compute_sort_key("zh", "hello") is None


### PR DESCRIPTION
The zh sort_key stored tone-marked pinyin ("diǎn") and the dictionary ordered on it with SQLite's BINARY collation.  Tone-marked vowels sit far above ASCII in Unicode (à=U+00E0, ǎ=U+01CE, ā=U+0101), so the comparison sorted by tone before it sorted by spelling: letter D came back as dian, diao, dui, da, di, dong, dan.

Add generate_pinyin_sort_key(), which uses pypinyin's TONE3 style to write tones as trailing digits ("dian3").  That keeps the letters adjacent, so a plain BINARY collation yields standard dictionary order — alphabetical by syllable first, tone 1-4 only as a tiebreaker among homophones.  Neutral tone is written 5 so every syllable ends in a digit.  generate_pinyin() is untouched; it still returns tone marks for display.

Also drop the str() wrappers in compute_sort_key(), which turned a failed transliteration into the literal string "None" and would have sorted those rows into the N's.

backfill_sort_keys.py gains --recompute to rewrite rows that already have a key, since the NULL filter alone can't migrate a format change.  Applied to the local database: 2581 zh rows updated.