### PR TITLE
Fixes for word-addition pipeline

### DIFF
--- a/prompts/translation/definitions/context.txt
+++ b/prompts/translation/definitions/context.txt
@@ -71,10 +71,10 @@ In summary: for each definition, provide in order:
 8. At least one example sentence
 9. Any additional notes about the definition
 10. Translations in all supported languages (Lithuanian, Spanish, French, Chinese)
-11. How common this sense is: most_common, somewhat_common, uncommon, rare, or very_rare.
+11. How prominent this sense is: very_common, common, uncommon, or rare.
     Rate each sense on its own, against how often the word carries that meaning in
     general modern English. This is not a ranking within your answer: a word may have
-    two most_common senses, or none. Include uncommon and rare senses, but label them
+    two very_common senses, or none. Include uncommon and rare senses, but label them
     honestly rather than inflating them.
 12. A confidence score (0-1) - how confident you are that this definition is correct
     and well-formed. This is about your certainty, not about how common the sense is.

--- a/prompts/translation/definitions/context.txt
+++ b/prompts/translation/definitions/context.txt
@@ -44,8 +44,9 @@ For translations:
   - Include articles (la table) where appropriate, and provide verbs in the infinitive (aller)
 - For Lithuanian:
   - Use the nominative singular form for nouns and adjectives
-- For Vietnamese:
-  - Include all diacritics and tone marks
+- For Spanish:
+  - Include articles (la mesa) where appropriate, and provide verbs in the infinitive (ir)
+  - Use the masculine singular form for adjectives
 
 For phonetic spellings:
 - Provide the pronunciation for the specific definition of the word.
@@ -69,7 +70,13 @@ In summary: for each definition, provide in order:
 7. Whether this is a special case (foreign word, part of name, etc.)
 8. At least one example sentence
 9. Any additional notes about the definition
-10. Translations in all supported languages (Chinese, French, Korean, Swahili, Lithuanian, Vietnamese)
-11. A confidence score (0-1) - the most common definition should have confidence of 1, less-common or domain specific definitions should have confidence around 0.9.
+10. Translations in all supported languages (Lithuanian, Spanish, French, Chinese)
+11. How common this sense is: most_common, somewhat_common, uncommon, rare, or very_rare.
+    Rate each sense on its own, against how often the word carries that meaning in
+    general modern English. This is not a ranking within your answer: a word may have
+    two most_common senses, or none. Include uncommon and rare senses, but label them
+    honestly rather than inflating them.
+12. A confidence score (0-1) - how confident you are that this definition is correct
+    and well-formed. This is about your certainty, not about how common the sense is.
 
 Respond only with a structured JSON object following the schema provided.

--- a/prompts/translation/definitions/prompt.txt
+++ b/prompts/translation/definitions/prompt.txt
@@ -1,9 +1,9 @@
 Provide comprehensive dictionary definitions for the word '{word}'.
 
 For each definition, include:
-1. The specific grammatical form (e.g., verb/infinitive, noun/singular, verb/present_participle)
-2. Whether it's the base form (infinitive for verbs, singular for nouns, etc.)
-3. The lemma (base concept) this form represents
-4. Specific example sentences that demonstrate this exact form
+1. Whether it's the base form (infinitive for verbs, singular for nouns, etc.)
+2. The lemma (base concept) this form represents
+3. Specific example sentences that demonstrate this exact form
 
-Pay special attention to distinguishing between different grammatical forms of the same lemma (e.g., "running" as gerund vs present participle).
+Give every distinct sense of the word, including less common ones, and rate how
+common each sense is.

--- a/src/agents/dramblys/staging.py
+++ b/src/agents/dramblys/staging.py
@@ -24,6 +24,7 @@ from storage.backend.config import DataSourceConfig
 from storage.models.imports import PendingImport, PendingImportSynonymCandidate, WordExclusion
 from storage.translation_helpers import LANG_CODE_TO_LLM_FIELD
 from wordfreq.translation.client import LinguisticClient
+from wordfreq.translation.definitions import select_senses_to_add
 
 logger = get_logger(__name__)
 
@@ -500,8 +501,22 @@ def stage_missing_words_for_import(
                     time.sleep(throttle)
                 continue
 
-            # For each definition/sense, create a pending import entry
-            definitions = word_data.get("definitions", [])
+            # Create a pending import per sense worth adding. The LLM returns
+            # every sense it can think of, including marginal ones, so keep the
+            # prominent handful rather than all of them.
+            all_definitions = word_data.get("definitions", [])
+            definitions = select_senses_to_add(all_definitions)
+            if len(definitions) < len(all_definitions):
+                kept_ids = {id(d) for d in definitions}
+                dropped = [
+                    f"{d.get('definition', '')[:40]} ({d.get('sense_prominence', 'unrated')})"
+                    for d in all_definitions
+                    if id(d) not in kept_ids
+                ]
+                logger.info(
+                    f"'{word}': keeping {len(definitions)} of {len(all_definitions)} senses; "
+                    f"skipped {'; '.join(dropped)}"
+                )
             for definition_data in definitions:
                 definition_text = definition_data.get("definition", "")
                 # The schema uses "pos" not "pos_type"

--- a/src/agents/dramblys/staging.py
+++ b/src/agents/dramblys/staging.py
@@ -22,6 +22,7 @@ from util.logging_config import get_logger
 from agents.dramblys.synonym_screening import has_active_strong_synonym_candidate
 from storage.backend.config import DataSourceConfig
 from storage.models.imports import PendingImport, PendingImportSynonymCandidate, WordExclusion
+from storage.translation_helpers import LANG_CODE_TO_LLM_FIELD
 from wordfreq.translation.client import LinguisticClient
 
 logger = get_logger(__name__)
@@ -507,9 +508,13 @@ def stage_missing_words_for_import(
                 pos_type = definition_data.get("pos", None)
                 pos_subtype = definition_data.get("pos_subtype", None)
 
-                # Get translation for disambiguation
-                # The schema uses {language}_translation fields, not a translations dict
-                translation_key = f"{target_language}_translation"
+                # Get translation for disambiguation. The schema keys are LLM
+                # field names ("lithuanian_translation"), not language codes, so
+                # map through LANG_CODE_TO_LLM_FIELD rather than building
+                # f"{target_language}_translation" -- that produced
+                # "lt_translation", which never matched, so the disambiguation
+                # translation was always empty.
+                translation_key = LANG_CODE_TO_LLM_FIELD[target_language]
                 translation = definition_data.get(translation_key, "")
 
                 if not definition_text:

--- a/src/agents/povas.py
+++ b/src/agents/povas.py
@@ -40,7 +40,9 @@ from storage.models.schema import DerivativeForm, Lemma, WordToken
 from storage.translation_helpers import get_translation
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/agents/pradzia/agent.py
+++ b/src/agents/pradzia/agent.py
@@ -45,6 +45,7 @@ from storage.database import (
     initialize_corpora,
 )
 from storage.models.schema import Corpus  # Ensure Corpus model is imported
+from storage.translation_helpers import has_translation_clause
 from agents.pradzia import json_to_database
 
 # Configure logging
@@ -473,9 +474,7 @@ class PradziaAgent:
 
             # Count lemmas with Lithuanian translations
             existing_lithuanian_count = (
-                session.query(Lemma)
-                .filter(Lemma.lithuanian_translation != None, Lemma.lithuanian_translation != "")
-                .count()
+                session.query(Lemma).filter(has_translation_clause("lt")).count()
             )
 
             if existing_lithuanian_count > 0:

--- a/src/agents/pradzia/json_to_database.py
+++ b/src/agents/pradzia/json_to_database.py
@@ -61,6 +61,7 @@ from storage.database import (
     update_lemma_translation,
 )
 from storage.models.schema import DerivativeForm, Lemma, WordToken
+from storage.translation_helpers import has_translation_clause
 
 english_alternative_map = {
     "bicycle": ["bike"],
@@ -313,7 +314,7 @@ def find_or_create_lemma(
     existing_lemma = (
         session.query(Lemma)
         .filter(Lemma.lemma_text == clean_english)
-        .filter(Lemma.lithuanian_translation == lithuanian_word)
+        .filter(has_translation_clause("lt", lithuanian_word))
         .first()
     )
 
@@ -582,9 +583,7 @@ Examples:
         print(f"\nDatabase statistics after migration:")
         lemmas_with_subtypes = session.query(Lemma).filter(Lemma.pos_subtype != None).count()
         lemmas_with_guids = session.query(Lemma).filter(Lemma.guid != None).count()
-        lemmas_with_lithuanian = (
-            session.query(Lemma).filter(Lemma.lithuanian_translation != None).count()
-        )
+        lemmas_with_lithuanian = session.query(Lemma).filter(has_translation_clause("lt")).count()
         lemmas_with_difficulty = session.query(Lemma).filter(Lemma.difficulty_level != None).count()
         english_derivative_forms = (
             session.query(DerivativeForm).filter(DerivativeForm.language_code == "en").count()

--- a/src/audioshoe/coqui/coqui_tts.py
+++ b/src/audioshoe/coqui/coqui_tts.py
@@ -23,7 +23,9 @@ from audioshoe.coqui.types import CoquiVoice
 from clients.audio.types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/audioshoe/espeak/espeak_tts.py
+++ b/src/audioshoe/espeak/espeak_tts.py
@@ -22,7 +22,9 @@ from audioshoe.espeak.types import EspeakVoice
 from clients.audio.types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/audioshoe/piper/piper_tts.py
+++ b/src/audioshoe/piper/piper_tts.py
@@ -23,7 +23,9 @@ from audioshoe.piper.types import PiperVoice
 from clients.audio.types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/audioshoe/qwen/qwen_tts.py
+++ b/src/audioshoe/qwen/qwen_tts.py
@@ -29,7 +29,9 @@ from audioshoe.qwen.types import QWEN_LANGUAGE_NAMES, QwenVoice
 from clients.audio.types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/barsukas/helpers/audio_helpers.py
+++ b/src/barsukas/helpers/audio_helpers.py
@@ -36,35 +36,18 @@ def link_audio_to_lemma(
     if lemma:
         return cast(int, lemma.id)
 
-    # Fallback to text matching based on language
-    # Map language codes to column names
-    language_column_map = {
-        "zh": "chinese_translation",
-        "ko": "korean_translation",
-        "fr": "french_translation",
-        "sw": "swahili_translation",
-        "lt": "lithuanian_translation",
-        "vi": "vietnamese_translation",
-    }
+    # Fallback to text matching. Every language lives in LemmaTranslation now;
+    # the per-language Lemma columns this used to consult for zh/ko/fr/sw/lt/vi
+    # are gone.
+    from storage.models.schema import LemmaTranslation
 
-    # For table-based translations (es, de, pt), query LemmaTranslation
-    if language_code in ["es", "de", "pt"]:
-        from storage.models.schema import LemmaTranslation
-
-        translation = (
-            session.query(LemmaTranslation)
-            .filter_by(language_code=language_code, translation=expected_text)
-            .first()
-        )
-        if translation:
-            return cast(int, translation.lemma_id)
-
-    # For column-based translations
-    elif language_code in language_column_map:
-        column_name = language_column_map[language_code]
-        lemma = session.query(Lemma).filter(getattr(Lemma, column_name) == expected_text).first()
-        if lemma:
-            return cast(int, lemma.id)
+    translation = (
+        session.query(LemmaTranslation)
+        .filter_by(language_code=language_code, translation=expected_text)
+        .first()
+    )
+    if translation:
+        return cast(int, translation.lemma_id)
 
     return None
 
@@ -89,16 +72,6 @@ def validate_audio_translation(
             "lemma_found": bool
         }
     """
-    # Map language codes to column names
-    language_column_map = {
-        "zh": "chinese_translation",
-        "ko": "korean_translation",
-        "fr": "french_translation",
-        "sw": "swahili_translation",
-        "lt": "lithuanian_translation",
-        "vi": "vietnamese_translation",
-    }
-
     # Try to find lemma by GUID
     lemma = session.query(Lemma).filter_by(guid=guid).first()
 
@@ -110,25 +83,18 @@ def validate_audio_translation(
             "lemma_found": False,
         }
 
-    # Get current translation from database
+    # Get current translation from database. All languages live in
+    # LemmaTranslation; the per-language Lemma columns are gone.
+    from storage.models.schema import LemmaTranslation
+
     current_translation = None
-
-    # For table-based translations (es, de, pt)
-    if language_code in ["es", "de", "pt"]:
-        from storage.models.schema import LemmaTranslation
-
-        translation = (
-            session.query(LemmaTranslation)
-            .filter_by(lemma_id=lemma.id, language_code=language_code)
-            .first()
-        )
-        if translation:
-            current_translation = translation.translation
-
-    # For column-based translations
-    elif language_code in language_column_map:
-        column_name = language_column_map[language_code]
-        current_translation = getattr(lemma, column_name, None)
+    translation = (
+        session.query(LemmaTranslation)
+        .filter_by(lemma_id=lemma.id, language_code=language_code)
+        .first()
+    )
+    if translation:
+        current_translation = translation.translation
 
     # Check if they match
     if current_translation is None:

--- a/src/benchmarks/datastore/common.py
+++ b/src/benchmarks/datastore/common.py
@@ -99,12 +99,14 @@ def _migrate_postgres_schema(conn) -> None:
     existing_columns = {
         (row[0], row[1])
         for row in conn.execute(
-            text("""
+            text(
+                """
                 SELECT table_name, column_name
                 FROM information_schema.columns
                 WHERE table_schema = :schema
                   AND table_name IN ('benchmark', 'model', 'run_detail', 'question')
-                """),
+                """
+            ),
             {"schema": schema},
         )
     }

--- a/src/benchmarks/lib/advanced_queries.py
+++ b/src/benchmarks/lib/advanced_queries.py
@@ -11,7 +11,9 @@ from clients import unified_client
 from util.telemetry import LLMUsage
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "gemma2:9b"

--- a/src/benchmarks/lib/exemplars/base.py
+++ b/src/benchmarks/lib/exemplars/base.py
@@ -21,7 +21,9 @@ from clients import unified_client
 from clients.types import Response, Schema
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 
@@ -434,7 +436,8 @@ class ExemplarReportGenerator:
         # Generate simple HTML report
         report_path = os.path.join(self.output_dir, f"{exemplar_id}.html")
         with open(report_path, "w", encoding="utf-8") as f:
-            f.write(f"""<!DOCTYPE html>
+            f.write(
+                f"""<!DOCTYPE html>
 <html>
 <head>
     <title>Exemplar Report: {exemplar.name}</title>
@@ -458,7 +461,8 @@ class ExemplarReportGenerator:
     {self._generate_model_sections(results)}
 </body>
 </html>
-""")
+"""
+            )
 
         logger.info(f"Generated report at {report_path}")
         return report_path
@@ -483,7 +487,8 @@ class ExemplarReportGenerator:
             model_size = model_sizes.get(model_name, "Unknown")
 
             # Create section for this model
-            sections.append(f"""
+            sections.append(
+                f"""
     <div class="model-response">
         <h2>Model: {model_name} ({model_size} MB)</h2>
         <div class="metadata">
@@ -493,7 +498,8 @@ class ExemplarReportGenerator:
         <h3>Response:</h3>
         <pre>{response}</pre>
     </div>
-""")
+"""
+            )
 
         return "\n".join(sections)
 
@@ -529,7 +535,8 @@ class ExemplarReportGenerator:
         # Generate HTML table of exemplars
         rows = []
         for exemplar in exemplars:
-            rows.append(f"""
+            rows.append(
+                f"""
     <tr>
         <td>{exemplar.name}</td>
         <td>{exemplar.id}</td>
@@ -537,12 +544,14 @@ class ExemplarReportGenerator:
         <td>{exemplar.description or ""}</td>
         <td><a href="{exemplar.id}.html">View Report</a></td>
     </tr>
-""")
+"""
+            )
 
         # Write index report
         index_path = os.path.join(self.output_dir, "index.html")
         with open(index_path, "w") as f:
-            f.write(f"""<!DOCTYPE html>
+            f.write(
+                f"""<!DOCTYPE html>
 <html>
 <head>
     <title>Exemplar Reports</title>
@@ -568,7 +577,8 @@ class ExemplarReportGenerator:
     </table>
 </body>
 </html>
-""")
+"""
+            )
 
         logger.info(f"Generated index report at {index_path}")
         return index_path

--- a/src/benchmarks/lib/generators/book_author_match_generator.py
+++ b/src/benchmarks/lib/generators/book_author_match_generator.py
@@ -38,7 +38,12 @@ class BookAuthorMatchGenerator(BenchmarkGenerator):
         schema = {
             "type": "object",
             "properties": {
-                "decoys": {"type": "array", "items": {"type": "string"}, "minItems": 3, "maxItems": 3}
+                "decoys": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 3,
+                    "maxItems": 3,
+                }
             },
             "required": ["decoys"],
         }

--- a/src/benchmarks/lib/runners/spell_check_runner.py
+++ b/src/benchmarks/lib/runners/spell_check_runner.py
@@ -10,7 +10,9 @@ from benchmarks.lib.utils.data_models import BenchmarkMetadata
 from benchmarks.lib.utils.factory import runner
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Define benchmark code

--- a/src/benchmarks/lib/runners/test_verb_forms_scoring.py
+++ b/src/benchmarks/lib/runners/test_verb_forms_scoring.py
@@ -245,7 +245,6 @@ class TestVerbFormsScoring(unittest.TestCase):
         score = self.runner.score_response(question_data, response)
         self.assertEqual(score, 100)
 
-
     def test_spanish_pronoun_stripping_scores_100(self):
         question_data = {
             "correct_answer": {
@@ -257,9 +256,30 @@ class TestVerbFormsScoring(unittest.TestCase):
                     "participle": "hablado",
                 },
                 "forms": {
-                    "present": {"1s": "hablo", "2s": "hablas", "3s": "habla", "1p": "hablamos", "2p": "habláis", "3p": "hablan"},
-                    "past": {"1s": "hablé", "2s": "hablaste", "3s": "habló", "1p": "hablamos", "2p": "hablasteis", "3p": "hablaron"},
-                    "future": {"1s": "hablaré", "2s": "hablarás", "3s": "hablará", "1p": "hablaremos", "2p": "hablaréis", "3p": "hablarán"},
+                    "present": {
+                        "1s": "hablo",
+                        "2s": "hablas",
+                        "3s": "habla",
+                        "1p": "hablamos",
+                        "2p": "habláis",
+                        "3p": "hablan",
+                    },
+                    "past": {
+                        "1s": "hablé",
+                        "2s": "hablaste",
+                        "3s": "habló",
+                        "1p": "hablamos",
+                        "2p": "hablasteis",
+                        "3p": "hablaron",
+                    },
+                    "future": {
+                        "1s": "hablaré",
+                        "2s": "hablarás",
+                        "3s": "hablará",
+                        "1p": "hablaremos",
+                        "2p": "hablaréis",
+                        "3p": "hablarán",
+                    },
                 },
             }
         }
@@ -269,9 +289,30 @@ class TestVerbFormsScoring(unittest.TestCase):
             "lemma": "hablar",
             "extra_forms": {"gerund": "hablando", "participle": "hablado"},
             "forms": {
-                "present": {"1s": "yo hablo", "2s": "tú hablas", "3s": "ella habla", "1p": "nosotros hablamos", "2p": "vosotros habláis", "3p": "ellos hablan"},
-                "past": {"1s": "yo hablé", "2s": "tú hablaste", "3s": "ella habló", "1p": "nosotros hablamos", "2p": "vosotros hablasteis", "3p": "ellos hablaron"},
-                "future": {"1s": "yo hablaré", "2s": "tú hablarás", "3s": "ella hablará", "1p": "nosotros hablaremos", "2p": "vosotros hablaréis", "3p": "ellos hablarán"},
+                "present": {
+                    "1s": "yo hablo",
+                    "2s": "tú hablas",
+                    "3s": "ella habla",
+                    "1p": "nosotros hablamos",
+                    "2p": "vosotros habláis",
+                    "3p": "ellos hablan",
+                },
+                "past": {
+                    "1s": "yo hablé",
+                    "2s": "tú hablaste",
+                    "3s": "ella habló",
+                    "1p": "nosotros hablamos",
+                    "2p": "vosotros hablasteis",
+                    "3p": "ellos hablaron",
+                },
+                "future": {
+                    "1s": "yo hablaré",
+                    "2s": "tú hablarás",
+                    "3s": "ella hablará",
+                    "1p": "nosotros hablaremos",
+                    "2p": "vosotros hablaréis",
+                    "3p": "ellos hablarán",
+                },
             },
         }
 

--- a/src/benchmarks/scripts/export_translations.py
+++ b/src/benchmarks/scripts/export_translations.py
@@ -28,7 +28,9 @@ from storage.translation_helpers import LANGUAGE_NAMES, get_all_translations
 from storage.utils.session import create_database_session
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Default output location alongside the wordlist data

--- a/src/benchmarks/scripts/generate_0062_data.py
+++ b/src/benchmarks/scripts/generate_0062_data.py
@@ -211,21 +211,7 @@ def get_sentences_with_full_sentenceword_data(
                     # Get translations for this lemma
                     lemma_translations: Dict[str, str] = {}
 
-                    # Check legacy columns first
-                    if sw.lemma.chinese_translation:
-                        lemma_translations["zh"] = sw.lemma.chinese_translation
-                    if sw.lemma.french_translation:
-                        lemma_translations["fr"] = sw.lemma.french_translation
-                    if sw.lemma.korean_translation:
-                        lemma_translations["ko"] = sw.lemma.korean_translation
-                    if sw.lemma.swahili_translation:
-                        lemma_translations["sw"] = sw.lemma.swahili_translation
-                    if sw.lemma.lithuanian_translation:
-                        lemma_translations["lt"] = sw.lemma.lithuanian_translation
-                    if sw.lemma.vietnamese_translation:
-                        lemma_translations["vi"] = sw.lemma.vietnamese_translation
-
-                    # Add from lemma_translations table
+                    # From the lemma_translations table
                     for lt in sw.lemma.translations:
                         if lt.language_code not in lemma_translations:
                             lemma_translations[lt.language_code] = lt.translation

--- a/src/benchmarks/scripts/run_all_quals.py
+++ b/src/benchmarks/scripts/run_all_quals.py
@@ -11,7 +11,9 @@ from benchmarks.datastore import quals as datastore_quals
 from lib import run_quals
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/benchmarks/server/benchmark_worker.py
+++ b/src/benchmarks/server/benchmark_worker.py
@@ -66,7 +66,9 @@ class BenchmarkRunWorker:
         self._interactive_local_ttl_seconds = 120.0
 
         self._state_lock = threading.Lock()
-        self._thread = threading.Thread(target=self._run_forever, daemon=True, name="benchmark-run-worker")
+        self._thread = threading.Thread(
+            target=self._run_forever, daemon=True, name="benchmark-run-worker"
+        )
         self._thread.start()
 
     def enqueue(self, benchmark_name: str, model_name: str) -> int:
@@ -86,7 +88,9 @@ class BenchmarkRunWorker:
             self._tasks[task_id] = task
             self._cleanup_expired_outputs_locked()
 
-        request = BenchmarkRunRequest(benchmark_name=benchmark_name, model_name=model_name, task_id=task_id)
+        request = BenchmarkRunRequest(
+            benchmark_name=benchmark_name, model_name=model_name, task_id=task_id
+        )
         self._queue.put(request)
         return self._queue.qsize()
 
@@ -131,13 +135,15 @@ class BenchmarkRunWorker:
                 and task.enqueued_at >= now_utc - self._history_window
             ]
         return {
-            "active": None
-            if current is None
-            else {
-                "task_id": current.task_id,
-                "benchmark_name": current.benchmark_name,
-                "model_name": current.model_name,
-            },
+            "active": (
+                None
+                if current is None
+                else {
+                    "task_id": current.task_id,
+                    "benchmark_name": current.benchmark_name,
+                    "model_name": current.model_name,
+                }
+            ),
             "queued": len(queued_tasks),
             "queued_tasks": queued_tasks,
             "recent_tasks": recent_tasks,
@@ -231,8 +237,12 @@ class BenchmarkRunWorker:
 
         logger.info("Running benchmark via worker: %s", " ".join(cmd))
         task = self._tasks.get(request.task_id)
-        stdout_path = task.stdout_path if task else self._output_dir / f"task-{request.task_id}.stdout.log"
-        stderr_path = task.stderr_path if task else self._output_dir / f"task-{request.task_id}.stderr.log"
+        stdout_path = (
+            task.stdout_path if task else self._output_dir / f"task-{request.task_id}.stdout.log"
+        )
+        stderr_path = (
+            task.stderr_path if task else self._output_dir / f"task-{request.task_id}.stderr.log"
+        )
 
         with (
             stdout_path.open("w", encoding="utf-8") as stdout_file,

--- a/src/clients/audio/audio_acceptance.py
+++ b/src/clients/audio/audio_acceptance.py
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
 from clients.audio.s3_uploader import S3AudioUploader
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/clients/audio/azure_tts.py
+++ b/src/clients/audio/azure_tts.py
@@ -17,7 +17,9 @@ import requests
 from .types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Default configuration

--- a/src/clients/audio/google_tts.py
+++ b/src/clients/audio/google_tts.py
@@ -19,7 +19,9 @@ from clients.keys import load_key
 from .types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Default configuration

--- a/src/clients/audio/polly_tts.py
+++ b/src/clients/audio/polly_tts.py
@@ -19,7 +19,9 @@ from clients.keys import load_key
 from .types import AudioFormat, AudioGenerationResult
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Default configuration

--- a/src/clients/lib.py
+++ b/src/clients/lib.py
@@ -11,9 +11,13 @@ converted to the appropriate format for different LLM clients:
 """
 
 import copy
+import json
+import logging
 from typing import Any, Dict, List
 
 from clients.types import Schema, SchemaProperty
+
+logger = logging.getLogger(__name__)
 
 # A single chat message in the provider-neutral "dialect": a role of "user" or
 # "assistant" and string content. Clients translate these into their own request
@@ -23,6 +27,69 @@ ChatMessage = Dict[str, str]
 # Filler used when a synthetic assistant turn must be inserted to keep roles
 # alternating for providers that require it (Anthropic, Gemini).
 ALTERNATION_ACK: str = "Understood."
+
+# Maximum size of a serialized JSON schema, in tokens. A schema is sent with
+# every request that uses it, so a large one is a recurring cost on every call.
+# The usual cause is embedding a full enum: listing every GrammaticalForm value
+# (1238 of them, ~7100 tokens) to ask about a single English word cost more than
+# the instructions and the query combined. If a schema trips this, narrow the
+# enum to the values that are actually possible, or describe the format in the
+# prompt and drop the enum.
+MAX_SCHEMA_TOKENS = 2048
+
+
+class SchemaTooLargeError(ValueError):
+    """Raised when a serialized schema exceeds MAX_SCHEMA_TOKENS."""
+
+
+def count_schema_tokens(schema_dict: Dict[str, Any]) -> int:
+    """Count tokens in a serialized schema, for size enforcement."""
+    import tiktoken
+
+    encoder = tiktoken.get_encoding("cl100k_base")
+    return len(encoder.encode(json.dumps(schema_dict)))
+
+
+def _check_schema_size(schema_dict: Dict[str, Any], schema_name: str, provider: str) -> None:
+    """Raise if the serialized schema is too large to send on every request.
+
+    Args:
+        schema_dict: The provider-format schema about to be returned
+        schema_name: Schema.name, for the error message
+        provider: Provider name, for the error message
+
+    Raises:
+        SchemaTooLargeError: If the schema exceeds MAX_SCHEMA_TOKENS
+    """
+    token_count = count_schema_tokens(schema_dict)
+    if token_count > MAX_SCHEMA_TOKENS:
+        largest = _largest_enums(schema_dict)
+        detail = ""
+        if largest:
+            detail = " Largest enums: " + ", ".join(
+                f"{path} ({count} values)" for path, count in largest
+            )
+        raise SchemaTooLargeError(
+            f"{provider} schema {schema_name!r} is {token_count} tokens, over the "
+            f"{MAX_SCHEMA_TOKENS} limit. A schema is sent on every request that uses "
+            f"it, so this is a per-call cost.{detail}"
+        )
+
+
+def _largest_enums(schema_dict: Any, path: str = "", found: Any = None) -> List[Any]:
+    """Find the largest enum lists in a schema, to point at the likely cause."""
+    if found is None:
+        found = []
+    if isinstance(schema_dict, dict):
+        for key, value in schema_dict.items():
+            if key == "enum" and isinstance(value, list):
+                found.append((path or "<root>", len(value)))
+            elif isinstance(value, (dict, list)):
+                _largest_enums(value, f"{path}.{key}" if path else key, found)
+    elif isinstance(schema_dict, list):
+        for index, item in enumerate(schema_dict):
+            _largest_enums(item, f"{path}[{index}]", found)
+    return sorted(found, key=lambda pair: pair[1], reverse=True)[:3]
 
 
 def normalize_alternating_messages(
@@ -203,6 +270,7 @@ def to_openai_schema(schema: Schema) -> Dict[str, Any]:
     _recursive_clean_for_openai(result)
     # Ensure all nested objects have additionalProperties set (required by OpenAI)
     _ensure_additional_properties(result)
+    _check_schema_size(result, schema.name, "OpenAI")
     return result
 
 
@@ -294,6 +362,7 @@ def to_anthropic_schema(schema: Schema) -> Dict[str, Any]:
 
         result["properties"][name] = property_schema
 
+    _check_schema_size(result, schema.name, "Anthropic")
     return result
 
 
@@ -395,6 +464,7 @@ def to_gemini_schema(schema: Schema) -> Dict[str, Any]:
     # Add propertyOrdering required by Gemini
     result["propertyOrdering"] = list(schema.properties.keys())
 
+    _check_schema_size(result, schema.name, "Gemini")
     return result
 
 
@@ -487,6 +557,7 @@ def to_ollama_schema(schema: Schema) -> Dict[str, Any]:
 
         result["properties"][name] = property_schema
 
+    _check_schema_size(result, schema.name, "Ollama")
     return result
 
 

--- a/src/clients/ollama_client.py
+++ b/src/clients/ollama_client.py
@@ -16,7 +16,9 @@ from clients.types import Response
 from util.telemetry import LLMUsage
 
 # Configure logging with DEBUG level option
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 SERVER = "100.123.16.86"

--- a/src/clients/openai/batch_client.py
+++ b/src/clients/openai/batch_client.py
@@ -14,7 +14,9 @@ import constants
 from clients.keys import load_key
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 API_BASE = "https://api.openai.com/v1"

--- a/src/clients/translategemma_client.py
+++ b/src/clients/translategemma_client.py
@@ -17,11 +17,13 @@ import requests
 from requests.exceptions import RequestException
 
 from clients.types import Response
-from storage.translation_helpers import LANGUAGE_NAMES
+from storage.translation_helpers import LANGUAGE_NAME_TO_CODE, LANGUAGE_NAMES
 from util.telemetry import LLMUsage
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Backend configuration
@@ -282,17 +284,14 @@ class TranslateGemmaClient:
         Returns:
             Tuple of (source_code, target_code) or None if not found
         """
-        # Build reverse lookup: name -> code
-        name_to_code = {name.lower(): code for code, name in LANGUAGE_NAMES.items()}
-
         # Pattern: "from <lang> to <lang>"
         match = re.search(r"from\s+(\w+)\s+to\s+(\w+)", context, re.IGNORECASE)
         if match:
             source_str = match.group(1).lower()
             target_str = match.group(2).lower()
 
-            source_code = name_to_code.get(source_str, source_str)
-            target_code = name_to_code.get(target_str, target_str)
+            source_code = LANGUAGE_NAME_TO_CODE.get(source_str, source_str)
+            target_code = LANGUAGE_NAME_TO_CODE.get(target_str, target_str)
 
             if source_code in LANGUAGE_NAMES and target_code in LANGUAGE_NAMES:
                 return source_code, target_code

--- a/src/langtools/bn/utils.py
+++ b/src/langtools/bn/utils.py
@@ -80,6 +80,7 @@ def is_bengali_script(text: str) -> bool:
             return True
     return False
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a Bengali subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_bengali_text(text.strip().lower())
@@ -89,11 +90,10 @@ def strip_subject_pronoun(text: str) -> str:
     combined_pronouns = ["সে/তিনি ", "তিনি/সে ", "সে / তিনি ", "তিনি / সে "]
     for pronoun in combined_pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
 
     pronouns = ["আমি ", "তুমি ", "আপনি ", "সে ", "তিনি ", "আমরা ", "তোমরা ", "আপনারা ", "তারা "]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/langtools/de/generated_conjugations.py
+++ b/src/langtools/de/generated_conjugations.py
@@ -1,2915 +1,2773 @@
 """Auto-generated verb conjugation consensus data from Šeškas agent."""
 
 DE_VERB_CONJUGATION_CONSENSUS = {
-  "backen": {
-    "extra_forms": {
-      "partizip_ii": "gebacken"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden backen",
-        "1s": "werde backen",
-        "2p": "werdet backen",
-        "2s": "wirst backen",
-        "3p": "werden backen",
-        "3s": "wird backen"
-      },
-      "perfect": {
-        "1p": "haben gebacken",
-        "1s": "habe gebacken",
-        "2p": "habt gebacken",
-        "2s": "hast gebacken",
-        "3p": "haben gebacken",
-        "3s": "hat gebacken"
-      },
-      "present": {
-        "1p": "backen",
-        "1s": "backe",
-        "2p": "backt",
-        "2s": "backst",
-        "3p": "backen",
-        "3s": "backt"
-      },
-      "preterite": {
-        "1p": "buken",
-        "1s": "buk",
-        "2p": "bukt",
-        "2s": "bukst",
-        "3p": "buken",
-        "3s": "buk"
-      }
-    },
-    "language_code": "de",
-    "lemma": "backen"
-  },
-  "beginnen": {
-    "extra_forms": {
-      "partizip_ii": "begonnen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden beginnen",
-        "1s": "werde beginnen",
-        "2p": "werdet beginnen",
-        "2s": "wirst beginnen",
-        "3p": "werden beginnen",
-        "3s": "wird beginnen"
-      },
-      "perfect": {
-        "1p": "haben begonnen",
-        "1s": "habe begonnen",
-        "2p": "habt begonnen",
-        "2s": "hast begonnen",
-        "3p": "haben begonnen",
-        "3s": "hat begonnen"
-      },
-      "present": {
-        "1p": "beginnen",
-        "1s": "beginne",
-        "2p": "beginnt",
-        "2s": "beginnst",
-        "3p": "beginnen",
-        "3s": "beginnt"
-      },
-      "preterite": {
-        "1p": "begannen",
-        "1s": "begann",
-        "2p": "begannt",
-        "2s": "begannst",
-        "3p": "begannen",
-        "3s": "begann"
-      }
-    },
-    "language_code": "de",
-    "lemma": "beginnen"
-  },
-  "bieten": {
-    "extra_forms": {
-      "partizip_ii": "geboten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden bieten",
-        "1s": "werde bieten",
-        "2p": "werdet bieten",
-        "2s": "wirst bieten",
-        "3p": "werden bieten",
-        "3s": "wird bieten"
-      },
-      "perfect": {
-        "1p": "haben geboten",
-        "1s": "habe geboten",
-        "2p": "habt geboten",
-        "2s": "hast geboten",
-        "3p": "haben geboten",
-        "3s": "hat geboten"
-      },
-      "present": {
-        "1p": "bieten",
-        "1s": "biete",
-        "2p": "bietet",
-        "2s": "bietest",
-        "3p": "bieten",
-        "3s": "bietet"
-      },
-      "preterite": {
-        "1p": "boten",
-        "1s": "bot",
-        "2p": "botet",
-        "2s": "botst",
-        "3p": "boten",
-        "3s": "bot"
-      }
-    },
-    "language_code": "de",
-    "lemma": "bieten"
-  },
-  "bleiben": {
-    "extra_forms": {
-      "partizip_ii": "geblieben"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden bleiben",
-        "1s": "werde bleiben",
-        "2p": "werdet bleiben",
-        "2s": "wirst bleiben",
-        "3p": "werden bleiben",
-        "3s": "wird bleiben"
-      },
-      "perfect": {
-        "1p": "sind geblieben",
-        "1s": "bin geblieben",
-        "2p": "seid geblieben",
-        "2s": "bist geblieben",
-        "3p": "sind geblieben",
-        "3s": "ist geblieben"
-      },
-      "present": {
-        "1p": "bleiben",
-        "1s": "bleibe",
-        "2p": "bleibt",
-        "2s": "bleibst",
-        "3p": "bleiben",
-        "3s": "bleibt"
-      },
-      "preterite": {
-        "1p": "blieben",
-        "1s": "blieb",
-        "2p": "bliebt",
-        "2s": "bliebst",
-        "3p": "blieben",
-        "3s": "blieb"
-      }
-    },
-    "language_code": "de",
-    "lemma": "bleiben"
-  },
-  "brechen": {
-    "extra_forms": {
-      "partizip_ii": "gebrochen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden brechen",
-        "1s": "werde brechen",
-        "2p": "werdet brechen",
-        "2s": "wirst brechen",
-        "3p": "werden brechen",
-        "3s": "wird brechen"
-      },
-      "perfect": {
-        "1p": "haben gebrochen",
-        "1s": "habe gebrochen",
-        "2p": "habt gebrochen",
-        "2s": "hast gebrochen",
-        "3p": "haben gebrochen",
-        "3s": "hat gebrochen"
-      },
-      "present": {
-        "1p": "brechen",
-        "1s": "breche",
-        "2p": "brecht",
-        "2s": "brichst",
-        "3p": "brechen",
-        "3s": "bricht"
-      },
-      "preterite": {
-        "1p": "brachen",
-        "1s": "brach",
-        "2p": "bracht",
-        "2s": "brachst",
-        "3p": "brachen",
-        "3s": "brach"
-      }
-    },
-    "language_code": "de",
-    "lemma": "brechen"
-  },
-  "brennen": {
-    "extra_forms": {
-      "partizip_ii": "gebrannt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden brennen",
-        "1s": "werde brennen",
-        "2p": "werdet brennen",
-        "2s": "wirst brennen",
-        "3p": "werden brennen",
-        "3s": "wird brennen"
-      },
-      "perfect": {
-        "1p": "haben gebrannt",
-        "1s": "habe gebrannt",
-        "2p": "habt gebrannt",
-        "2s": "hast gebrannt",
-        "3p": "haben gebrannt",
-        "3s": "hat gebrannt"
-      },
-      "present": {
-        "1p": "brennen",
-        "1s": "brenne",
-        "2p": "brennt",
-        "2s": "brennst",
-        "3p": "brennen",
-        "3s": "brennt"
-      },
-      "preterite": {
-        "1p": "brannten",
-        "1s": "brannte",
-        "2p": "branntet",
-        "2s": "branntest",
-        "3p": "brannten",
-        "3s": "brannte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "brennen"
-  },
-  "bringen": {
-    "extra_forms": {
-      "partizip_ii": "gebracht"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden bringen",
-        "1s": "werde bringen",
-        "2p": "werdet bringen",
-        "2s": "wirst bringen",
-        "3p": "werden bringen",
-        "3s": "wird bringen"
-      },
-      "perfect": {
-        "1p": "haben gebracht",
-        "1s": "habe gebracht",
-        "2p": "habt gebracht",
-        "2s": "hast gebracht",
-        "3p": "haben gebracht",
-        "3s": "hat gebracht"
-      },
-      "present": {
-        "1p": "bringen",
-        "1s": "bringe",
-        "2p": "bringt",
-        "2s": "bringst",
-        "3p": "bringen",
-        "3s": "bringt"
-      },
-      "preterite": {
-        "1p": "brachten",
-        "1s": "brachte",
-        "2p": "brachtet",
-        "2s": "brachtest",
-        "3p": "brachten",
-        "3s": "brachte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "bringen"
-  },
-  "denken": {
-    "extra_forms": {
-      "partizip_ii": "gedacht"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden denken",
-        "1s": "werde denken",
-        "2p": "werdet denken",
-        "2s": "wirst denken",
-        "3p": "werden denken",
-        "3s": "wird denken"
-      },
-      "perfect": {
-        "1p": "haben gedacht",
-        "1s": "habe gedacht",
-        "2p": "habt gedacht",
-        "2s": "hast gedacht",
-        "3p": "haben gedacht",
-        "3s": "hat gedacht"
-      },
-      "present": {
-        "1p": "denken",
-        "1s": "denke",
-        "2p": "denkt",
-        "2s": "denkst",
-        "3p": "denken",
-        "3s": "denkt"
-      },
-      "preterite": {
-        "1p": "dachten",
-        "1s": "dachte",
-        "2p": "dachtet",
-        "2s": "dachtest",
-        "3p": "dachten",
-        "3s": "dachte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "denken"
-  },
-  "dürfen": {
-    "extra_forms": {
-      "partizip_ii": "gedurft"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden dürfen",
-        "1s": "werde dürfen",
-        "2p": "werdet dürfen",
-        "2s": "wirst dürfen",
-        "3p": "werden dürfen",
-        "3s": "wird dürfen"
-      },
-      "perfect": {
-        "1p": "haben gedurft",
-        "1s": "habe gedurft",
-        "2p": "habt gedurft",
-        "2s": "hast gedurft",
-        "3p": "haben gedurft",
-        "3s": "hat gedurft"
-      },
-      "present": {
-        "1p": "dürfen",
-        "1s": "darf",
-        "2p": "dürft",
-        "2s": "darfst",
-        "3p": "dürfen",
-        "3s": "darf"
-      },
-      "preterite": {
-        "1p": "durften",
-        "1s": "durfte",
-        "2p": "durftet",
-        "2s": "durftest",
-        "3p": "durften",
-        "3s": "durfte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "dürfen"
-  },
-  "empfehlen": {
-    "extra_forms": {
-      "partizip_ii": "empfohlen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden empfehlen",
-        "1s": "werde empfehlen",
-        "2p": "werdet empfehlen",
-        "2s": "wirst empfehlen",
-        "3p": "werden empfehlen",
-        "3s": "wird empfehlen"
-      },
-      "perfect": {
-        "1p": "haben empfohlen",
-        "1s": "habe empfohlen",
-        "2p": "habt empfohlen",
-        "2s": "hast empfohlen",
-        "3p": "haben empfohlen",
-        "3s": "hat empfohlen"
-      },
-      "present": {
-        "1p": "empfehlen",
-        "1s": "empfehle",
-        "2p": "empfehlt",
-        "2s": "empfiehlst",
-        "3p": "empfehlen",
-        "3s": "empfiehlt"
-      },
-      "preterite": {
-        "1p": "empfahlen",
-        "1s": "empfahl",
-        "2p": "empfahlt",
-        "2s": "empfahlst",
-        "3p": "empfahlen",
-        "3s": "empfahl"
-      }
-    },
-    "language_code": "de",
-    "lemma": "empfehlen"
-  },
-  "erschrecken": {
-    "extra_forms": {
-      "partizip_ii": "erschrocken / erschreckt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden erschrecken",
-        "1s": "werde erschrecken",
-        "2p": "werdet erschrecken",
-        "2s": "wirst erschrecken",
-        "3p": "werden erschrecken",
-        "3s": "wird erschrecken"
-      },
-      "perfect": {
-        "1p": "sind erschrocken / haben erschreckt",
-        "1s": "bin erschrocken / habe erschreckt",
-        "2p": "seid erschrocken / habt erschreckt",
-        "2s": "bist erschrocken / hast erschreckt",
-        "3p": "sind erschrocken / haben erschreckt",
-        "3s": "ist erschrocken / hat erschreckt"
-      },
-      "present": {
-        "1p": "erschrecken",
-        "1s": "erschrecke",
-        "2p": "erschreckt",
-        "2s": "erschrickst",
-        "3p": "erschrecken",
-        "3s": "erschrickt"
-      },
-      "preterite": {
-        "1p": "erschraken / erschreckten",
-        "1s": "erschrak / erschreckte",
-        "2p": "erschrakt / erschrecktet",
-        "2s": "erschrakst / erschrecktest",
-        "3p": "erschraken / erschreckten",
-        "3s": "erschrak / erschreckte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "erschrecken"
-  },
-  "essen": {
-    "extra_forms": {
-      "partizip_ii": "gegessen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden essen",
-        "1s": "werde essen",
-        "2p": "werdet essen",
-        "2s": "wirst essen",
-        "3p": "werden essen",
-        "3s": "wird essen"
-      },
-      "perfect": {
-        "1p": "haben gegessen",
-        "1s": "habe gegessen",
-        "2p": "habt gegessen",
-        "2s": "hast gegessen",
-        "3p": "haben gegessen",
-        "3s": "hat gegessen"
-      },
-      "present": {
-        "1p": "essen",
-        "1s": "esse",
-        "2p": "esset",
-        "2s": "isst",
-        "3p": "essen",
-        "3s": "isst"
-      },
-      "preterite": {
-        "1p": "aßen",
-        "1s": "aß",
-        "2p": "aßt",
-        "2s": "aßest",
-        "3p": "aßen",
-        "3s": "aß"
-      }
-    },
-    "language_code": "de",
-    "lemma": "essen"
-  },
-  "fahren": {
-    "extra_forms": {
-      "partizip_ii": "gefahren"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden fahren",
-        "1s": "werde fahren",
-        "2p": "werdet fahren",
-        "2s": "wirst fahren",
-        "3p": "werden fahren",
-        "3s": "wird fahren"
-      },
-      "perfect": {
-        "1p": "sind gefahren",
-        "1s": "bin gefahren",
-        "2p": "seid gefahren",
-        "2s": "bist gefahren",
-        "3p": "sind gefahren",
-        "3s": "ist gefahren"
-      },
-      "present": {
-        "1p": "fahren",
-        "1s": "fahre",
-        "2p": "fahrt",
-        "2s": "fährst",
-        "3p": "fahren",
-        "3s": "fährt"
-      },
-      "preterite": {
-        "1p": "fuhren",
-        "1s": "fuhr",
-        "2p": "fuhrt",
-        "2s": "fuhrst",
-        "3p": "fuhren",
-        "3s": "fuhr"
-      }
-    },
-    "language_code": "de",
-    "lemma": "fahren"
-  },
-  "fallen": {
-    "extra_forms": {
-      "partizip_ii": "gefallen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden fallen",
-        "1s": "werde fallen",
-        "2p": "werdet fallen",
-        "2s": "wirst fallen",
-        "3p": "werden fallen",
-        "3s": "wird fallen"
-      },
-      "perfect": {
-        "1p": "sind gefallen",
-        "1s": "bin gefallen",
-        "2p": "seid gefallen",
-        "2s": "bist gefallen",
-        "3p": "sind gefallen",
-        "3s": "ist gefallen"
-      },
-      "present": {
-        "1p": "fallen",
-        "1s": "falle",
-        "2p": "fallt",
-        "2s": "fällst",
-        "3p": "fallen",
-        "3s": "fällt"
-      },
-      "preterite": {
-        "1p": "fielen",
-        "1s": "fiel",
-        "2p": "fielt",
-        "2s": "fielst",
-        "3p": "fielen",
-        "3s": "fiel"
-      }
-    },
-    "language_code": "de",
-    "lemma": "fallen"
-  },
-  "finden": {
-    "extra_forms": {
-      "partizip_ii": "gefunden"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden finden",
-        "1s": "werde finden",
-        "2p": "werdet finden",
-        "2s": "wirst finden",
-        "3p": "werden finden",
-        "3s": "wird finden"
-      },
-      "perfect": {
-        "1p": "haben gefunden",
-        "1s": "habe gefunden",
-        "2p": "habt gefunden",
-        "2s": "hast gefunden",
-        "3p": "haben gefunden",
-        "3s": "hat gefunden"
-      },
-      "present": {
-        "1p": "finden",
-        "1s": "finde",
-        "2p": "findet",
-        "2s": "findest",
-        "3p": "finden",
-        "3s": "findet"
-      },
-      "preterite": {
-        "1p": "fanden",
-        "1s": "fand",
-        "2p": "fandet",
-        "2s": "fandest",
-        "3p": "fanden",
-        "3s": "fand"
-      }
-    },
-    "language_code": "de",
-    "lemma": "finden"
-  },
-  "fliegen": {
-    "extra_forms": {
-      "partizip_ii": "geflogen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden fliegen",
-        "1s": "werde fliegen",
-        "2p": "werdet fliegen",
-        "2s": "wirst fliegen",
-        "3p": "werden fliegen",
-        "3s": "wird fliegen"
-      },
-      "perfect": {
-        "1p": "sind geflogen",
-        "1s": "bin geflogen",
-        "2p": "seid geflogen",
-        "2s": "bist geflogen",
-        "3p": "sind geflogen",
-        "3s": "ist geflogen"
-      },
-      "present": {
-        "1p": "fliegen",
-        "1s": "fliege",
-        "2p": "fliegt",
-        "2s": "fliegst",
-        "3p": "fliegen",
-        "3s": "fliegt"
-      },
-      "preterite": {
-        "1p": "flogen",
-        "1s": "flog",
-        "2p": "flogt",
-        "2s": "flogst",
-        "3p": "flogen",
-        "3s": "flog"
-      }
-    },
-    "language_code": "de",
-    "lemma": "fliegen"
-  },
-  "geben": {
-    "extra_forms": {
-      "partizip_ii": "gegeben"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden geben",
-        "1s": "werde geben",
-        "2p": "werdet geben",
-        "2s": "wirst geben",
-        "3p": "werden geben",
-        "3s": "wird geben"
-      },
-      "perfect": {
-        "1p": "haben gegeben",
-        "1s": "habe gegeben",
-        "2p": "habt gegeben",
-        "2s": "hast gegeben",
-        "3p": "haben gegeben",
-        "3s": "hat gegeben"
-      },
-      "present": {
-        "1p": "geben",
-        "1s": "gebe",
-        "2p": "gebt",
-        "2s": "gibst",
-        "3p": "geben",
-        "3s": "gibt"
-      },
-      "preterite": {
-        "1p": "gaben",
-        "1s": "gab",
-        "2p": "gabt",
-        "2s": "gabst",
-        "3p": "gaben",
-        "3s": "gab"
-      }
-    },
-    "language_code": "de",
-    "lemma": "geben"
-  },
-  "gehen": {
-    "extra_forms": {
-      "partizip_ii": "gegangen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden gehen",
-        "1s": "werde gehen",
-        "2p": "werdet gehen",
-        "2s": "wirst gehen",
-        "3p": "werden gehen",
-        "3s": "wird gehen"
-      },
-      "perfect": {
-        "1p": "sind gegangen",
-        "1s": "bin gegangen",
-        "2p": "seid gegangen",
-        "2s": "bist gegangen",
-        "3p": "sind gegangen",
-        "3s": "ist gegangen"
-      },
-      "present": {
-        "1p": "gehen",
-        "1s": "gehe",
-        "2p": "geht",
-        "2s": "gehst",
-        "3p": "gehen",
-        "3s": "geht"
-      },
-      "preterite": {
-        "1p": "gingen",
-        "1s": "ging",
-        "2p": "gingt",
-        "2s": "gingst",
-        "3p": "gingen",
-        "3s": "ging"
-      }
-    },
-    "language_code": "de",
-    "lemma": "gehen"
-  },
-  "gelten": {
-    "extra_forms": {
-      "partizip_ii": "gegolten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden gelten",
-        "1s": "werde gelten",
-        "2p": "werdet gelten",
-        "2s": "wirst gelten",
-        "3p": "werden gelten",
-        "3s": "wird gelten"
-      },
-      "perfect": {
-        "1p": "haben gegolten",
-        "1s": "habe gegolten",
-        "2p": "habt gegolten",
-        "2s": "hast gegolten",
-        "3p": "haben gegolten",
-        "3s": "hat gegolten"
-      },
-      "present": {
-        "1p": "gelten",
-        "1s": "gelte",
-        "2p": "geltet",
-        "2s": "giltst",
-        "3p": "gelten",
-        "3s": "gilt"
-      },
-      "preterite": {
-        "1p": "galten",
-        "1s": "galt",
-        "2p": "galtet",
-        "2s": "galtst",
-        "3p": "galten",
-        "3s": "galt"
-      }
-    },
-    "language_code": "de",
-    "lemma": "gelten"
-  },
-  "gewinnen": {
-    "extra_forms": {
-      "partizip_ii": "gewonnen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden gewinnen",
-        "1s": "werde gewinnen",
-        "2p": "werdet gewinnen",
-        "2s": "wirst gewinnen",
-        "3p": "werden gewinnen",
-        "3s": "wird gewinnen"
-      },
-      "perfect": {
-        "1p": "haben gewonnen",
-        "1s": "habe gewonnen",
-        "2p": "habt gewonnen",
-        "2s": "hast gewonnen",
-        "3p": "haben gewonnen",
-        "3s": "hat gewonnen"
-      },
-      "present": {
-        "1p": "gewinnen",
-        "1s": "gewinne",
-        "2p": "gewinnt",
-        "2s": "gewinnst",
-        "3p": "gewinnen",
-        "3s": "gewinnt"
-      },
-      "preterite": {
-        "1p": "gewannen",
-        "1s": "gewann",
-        "2p": "gewannt",
-        "2s": "gewannst",
-        "3p": "gewannen",
-        "3s": "gewann"
-      }
-    },
-    "language_code": "de",
-    "lemma": "gewinnen"
-  },
-  "haben": {
-    "extra_forms": {
-      "partizip_ii": "gehabt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden haben",
-        "1s": "werde haben",
-        "2p": "werdet haben",
-        "2s": "wirst haben",
-        "3p": "werden haben",
-        "3s": "wird haben"
-      },
-      "perfect": {
-        "1p": "haben gehabt",
-        "1s": "habe gehabt",
-        "2p": "habt gehabt",
-        "2s": "hast gehabt",
-        "3p": "haben gehabt",
-        "3s": "hat gehabt"
-      },
-      "present": {
-        "1p": "haben",
-        "1s": "habe",
-        "2p": "habt",
-        "2s": "hast",
-        "3p": "haben",
-        "3s": "hat"
-      },
-      "preterite": {
-        "1p": "hatten",
-        "1s": "hatte",
-        "2p": "hattet",
-        "2s": "hattest",
-        "3p": "hatten",
-        "3s": "hatte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "haben"
-  },
-  "halten": {
-    "extra_forms": {
-      "partizip_ii": "gehalten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden halten",
-        "1s": "werde halten",
-        "2p": "werdet halten",
-        "2s": "wirst halten",
-        "3p": "werden halten",
-        "3s": "wird halten"
-      },
-      "perfect": {
-        "1p": "haben gehalten",
-        "1s": "habe gehalten",
-        "2p": "habt gehalten",
-        "2s": "hast gehalten",
-        "3p": "haben gehalten",
-        "3s": "hat gehalten"
-      },
-      "present": {
-        "1p": "halten",
-        "1s": "halte",
-        "2p": "haltet",
-        "2s": "hältst",
-        "3p": "halten",
-        "3s": "hält"
-      },
-      "preterite": {
-        "1p": "hielten",
-        "1s": "hielt",
-        "2p": "hieltet",
-        "2s": "hieltest",
-        "3p": "hielten",
-        "3s": "hielt"
-      }
-    },
-    "language_code": "de",
-    "lemma": "halten"
-  },
-  "helfen": {
-    "extra_forms": {
-      "partizip_ii": "geholfen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden helfen",
-        "1s": "werde helfen",
-        "2p": "werdet helfen",
-        "2s": "wirst helfen",
-        "3p": "werden helfen",
-        "3s": "wird helfen"
-      },
-      "perfect": {
-        "1p": "haben geholfen",
-        "1s": "habe geholfen",
-        "2p": "habt geholfen",
-        "2s": "hast geholfen",
-        "3p": "haben geholfen",
-        "3s": "hat geholfen"
-      },
-      "present": {
-        "1p": "helfen",
-        "1s": "helfe",
-        "2p": "helft",
-        "2s": "hilfst",
-        "3p": "helfen",
-        "3s": "hilft"
-      },
-      "preterite": {
-        "1p": "halfen",
-        "1s": "half",
-        "2p": "halft",
-        "2s": "halfst",
-        "3p": "halfen",
-        "3s": "half"
-      }
-    },
-    "language_code": "de",
-    "lemma": "helfen"
-  },
-  "kennen": {
-    "extra_forms": {
-      "partizip_ii": "gekannt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden kennen",
-        "1s": "werde kennen",
-        "2p": "werdet kennen",
-        "2s": "wirst kennen",
-        "3p": "werden kennen",
-        "3s": "wird kennen"
-      },
-      "perfect": {
-        "1p": "haben gekannt",
-        "1s": "habe gekannt",
-        "2p": "habt gekannt",
-        "2s": "hast gekannt",
-        "3p": "haben gekannt",
-        "3s": "hat gekannt"
-      },
-      "present": {
-        "1p": "kennen",
-        "1s": "kenne",
-        "2p": "kennt",
-        "2s": "kennst",
-        "3p": "kennen",
-        "3s": "kennt"
-      },
-      "preterite": {
-        "1p": "kannten",
-        "1s": "kannte",
-        "2p": "kanntet",
-        "2s": "kanntest",
-        "3p": "kannten",
-        "3s": "kannte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "kennen"
-  },
-  "kommen": {
-    "extra_forms": {
-      "partizip_ii": "gekommen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden kommen",
-        "1s": "werde kommen",
-        "2p": "werdet kommen",
-        "2s": "wirst kommen",
-        "3p": "werden kommen",
-        "3s": "wird kommen"
-      },
-      "perfect": {
-        "1p": "sind gekommen",
-        "1s": "bin gekommen",
-        "2p": "seid gekommen",
-        "2s": "bist gekommen",
-        "3p": "sind gekommen",
-        "3s": "ist gekommen"
-      },
-      "present": {
-        "1p": "kommen",
-        "1s": "komme",
-        "2p": "kommt",
-        "2s": "kommst",
-        "3p": "kommen",
-        "3s": "kommt"
-      },
-      "preterite": {
-        "1p": "kamen",
-        "1s": "kam",
-        "2p": "kamt",
-        "2s": "kamst",
-        "3p": "kamen",
-        "3s": "kam"
-      }
-    },
-    "language_code": "de",
-    "lemma": "kommen"
-  },
-  "können": {
-    "extra_forms": {
-      "partizip_ii": "gekonnt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden können",
-        "1s": "werde können",
-        "2p": "werdet können",
-        "2s": "wirst können",
-        "3p": "werden können",
-        "3s": "wird können"
-      },
-      "perfect": {
-        "1p": "haben gekonnt",
-        "1s": "habe gekonnt",
-        "2p": "habt gekonnt",
-        "2s": "hast gekonnt",
-        "3p": "haben gekonnt",
-        "3s": "hat gekonnt"
-      },
-      "present": {
-        "1p": "können",
-        "1s": "kann",
-        "2p": "könnt",
-        "2s": "kannst",
-        "3p": "können",
-        "3s": "kann"
-      },
-      "preterite": {
-        "1p": "konnten",
-        "1s": "konnte",
-        "2p": "konntet",
-        "2s": "konntest",
-        "3p": "konnten",
-        "3s": "konnte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "können"
-  },
-  "laden": {
-    "extra_forms": {
-      "partizip_ii": "geladen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden laden",
-        "1s": "werde laden",
-        "2p": "werdet laden",
-        "2s": "wirst laden",
-        "3p": "werden laden",
-        "3s": "wird laden"
-      },
-      "perfect": {
-        "1p": "haben geladen",
-        "1s": "habe geladen",
-        "2p": "habt geladen",
-        "2s": "hast geladen",
-        "3p": "haben geladen",
-        "3s": "hat geladen"
-      },
-      "present": {
-        "1p": "laden",
-        "1s": "lade",
-        "2p": "ladet",
-        "2s": "lädst",
-        "3p": "laden",
-        "3s": "lädt"
-      },
-      "preterite": {
-        "1p": "luden",
-        "1s": "lud",
-        "2p": "ludet",
-        "2s": " ludst",
-        "3p": "luden",
-        "3s": "lud"
-      }
-    },
-    "language_code": "de",
-    "lemma": "laden"
-  },
-  "lassen": {
-    "extra_forms": {
-      "partizip_ii": "gelassen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden lassen",
-        "1s": "werde lassen",
-        "2p": "werdet lassen",
-        "2s": "wirst lassen",
-        "3p": "werden lassen",
-        "3s": "wird lassen"
-      },
-      "perfect": {
-        "1p": "haben gelassen",
-        "1s": "habe gelassen",
-        "2p": "habt gelassen",
-        "2s": "hast gelassen",
-        "3p": "haben gelassen",
-        "3s": "hat gelassen"
-      },
-      "present": {
-        "1p": "lassen",
-        "1s": "lasse",
-        "2p": "lasst",
-        "2s": "lässt",
-        "3p": "lassen",
-        "3s": "lässt"
-      },
-      "preterite": {
-        "1p": "ließen",
-        "1s": "ließ",
-        "2p": "ließt",
-        "2s": "ließest",
-        "3p": "ließen",
-        "3s": "ließ"
-      }
-    },
-    "language_code": "de",
-    "lemma": "lassen"
-  },
-  "laufen": {
-    "extra_forms": {
-      "partizip_ii": "gelaufen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden laufen",
-        "1s": "werde laufen",
-        "2p": "werdet laufen",
-        "2s": "wirst laufen",
-        "3p": "werden laufen",
-        "3s": "wird laufen"
-      },
-      "perfect": {
-        "1p": "sind gelaufen",
-        "1s": "bin gelaufen",
-        "2p": "seid gelaufen",
-        "2s": "bist gelaufen",
-        "3p": "sind gelaufen",
-        "3s": "ist gelaufen"
-      },
-      "present": {
-        "1p": "laufen",
-        "1s": "laufe",
-        "2p": "lauft",
-        "2s": "läufst",
-        "3p": "laufen",
-        "3s": "läuft"
-      },
-      "preterite": {
-        "1p": "liefen",
-        "1s": "lief",
-        "2p": "lieft",
-        "2s": "liefst",
-        "3p": "liefen",
-        "3s": "lief"
-      }
-    },
-    "language_code": "de",
-    "lemma": "laufen"
-  },
-  "lesen": {
-    "extra_forms": {
-      "partizip_ii": "gelesen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden lesen",
-        "1s": "werde lesen",
-        "2p": "werdet lesen",
-        "2s": "wirst lesen",
-        "3p": "werden lesen",
-        "3s": "wird lesen"
-      },
-      "perfect": {
-        "1p": "haben gelesen",
-        "1s": "habe gelesen",
-        "2p": "habt gelesen",
-        "2s": "hast gelesen",
-        "3p": "haben gelesen",
-        "3s": "hat gelesen"
-      },
-      "present": {
-        "1p": "lesen",
-        "1s": "lese",
-        "2p": "lest",
-        "2s": "liest",
-        "3p": "lesen",
-        "3s": "liest"
-      },
-      "preterite": {
-        "1p": "lasen",
-        "1s": "las",
-        "2p": "last",
-        "2s": "last",
-        "3p": "lasen",
-        "3s": "las"
-      }
-    },
-    "language_code": "de",
-    "lemma": "lesen"
-  },
-  "liegen": {
-    "extra_forms": {
-      "partizip_ii": "gelegen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden liegen",
-        "1s": "werde liegen",
-        "2p": "werdet liegen",
-        "2s": "wirst liegen",
-        "3p": "werden liegen",
-        "3s": "wird liegen"
-      },
-      "perfect": {
-        "1p": "haben gelegen",
-        "1s": "habe gelegen",
-        "2p": "habt gelegen",
-        "2s": "hast gelegen",
-        "3p": "haben gelegen",
-        "3s": "hat gelegen"
-      },
-      "present": {
-        "1p": "liegen",
-        "1s": "liege",
-        "2p": "liegt",
-        "2s": "liegst",
-        "3p": "liegen",
-        "3s": "liegt"
-      },
-      "preterite": {
-        "1p": "lagen",
-        "1s": "lag",
-        "2p": "lagt",
-        "2s": "lagst",
-        "3p": "lagen",
-        "3s": "lag"
-      }
-    },
-    "language_code": "de",
-    "lemma": "liegen"
-  },
-  "mögen": {
-    "extra_forms": {
-      "partizip_ii": "gemocht"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden mögen",
-        "1s": "werde mögen",
-        "2p": "werdet mögen",
-        "2s": "wirst mögen",
-        "3p": "werden mögen",
-        "3s": "wird mögen"
-      },
-      "perfect": {
-        "1p": "haben gemocht",
-        "1s": "habe gemocht",
-        "2p": "habt gemocht",
-        "2s": "hast gemocht",
-        "3p": "haben gemocht",
-        "3s": "hat gemocht"
-      },
-      "present": {
-        "1p": "mögen",
-        "1s": "mag",
-        "2p": "mögt",
-        "2s": "magst",
-        "3p": "mögen",
-        "3s": "mag"
-      },
-      "preterite": {
-        "1p": "mochten",
-        "1s": "mochte",
-        "2p": "mochtet",
-        "2s": "mochtest",
-        "3p": "mochten",
-        "3s": "mochte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "mögen"
-  },
-  "müssen": {
-    "extra_forms": {
-      "partizip_ii": "gemusst"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden müssen",
-        "1s": "werde müssen",
-        "2p": "werdet müssen",
-        "2s": "wirst müssen",
-        "3p": "werden müssen",
-        "3s": "wird müssen"
-      },
-      "perfect": {
-        "1p": "haben gemusst",
-        "1s": "habe gemusst",
-        "2p": "habt gemusst",
-        "2s": "hast gemusst",
-        "3p": "haben gemusst",
-        "3s": "hat gemusst"
-      },
-      "present": {
-        "1p": "müssen",
-        "1s": "muss",
-        "2p": "müsst",
-        "2s": "musst",
-        "3p": "müssen",
-        "3s": "muss"
-      },
-      "preterite": {
-        "1p": "mussten",
-        "1s": "musste",
-        "2p": "musstet",
-        "2s": "musstest",
-        "3p": "mussten",
-        "3s": "musste"
-      }
-    },
-    "language_code": "de",
-    "lemma": "müssen"
-  },
-  "nehmen": {
-    "extra_forms": {
-      "partizip_ii": "genommen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden nehmen",
-        "1s": "werde nehmen",
-        "2p": "werdet nehmen",
-        "2s": "wirst nehmen",
-        "3p": "werden nehmen",
-        "3s": "wird nehmen"
-      },
-      "perfect": {
-        "1p": "haben genommen",
-        "1s": "habe genommen",
-        "2p": "habt genommen",
-        "2s": "hast genommen",
-        "3p": "haben genommen",
-        "3s": "hat genommen"
-      },
-      "present": {
-        "1p": "nehmen",
-        "1s": "nehme",
-        "2p": "nehmt",
-        "2s": "nimmst",
-        "3p": "nehmen",
-        "3s": "nimmt"
-      },
-      "preterite": {
-        "1p": "nahmen",
-        "1s": "nahm",
-        "2p": "nahmt",
-        "2s": "nahmst",
-        "3p": "nahmen",
-        "3s": "nahm"
-      }
-    },
-    "language_code": "de",
-    "lemma": "nehmen"
-  },
-  "nennen": {
-    "extra_forms": {
-      "partizip_ii": "genannt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden nennen",
-        "1s": "werde nennen",
-        "2p": "werdet nennen",
-        "2s": "wirst nennen",
-        "3p": "werden nennen",
-        "3s": "wird nennen"
-      },
-      "perfect": {
-        "1p": "haben genannt",
-        "1s": "habe genannt",
-        "2p": "habt genannt",
-        "2s": "hast genannt",
-        "3p": "haben genannt",
-        "3s": "hat genannt"
-      },
-      "present": {
-        "1p": "nennen",
-        "1s": "nenne",
-        "2p": "nennt",
-        "2s": "nennst",
-        "3p": "nennen",
-        "3s": "nennt"
-      },
-      "preterite": {
-        "1p": "nannten",
-        "1s": "nannte",
-        "2p": "nanntet",
-        "2s": "nanntest",
-        "3p": "nannten",
-        "3s": "nannte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "nennen"
-  },
-  "raten": {
-    "extra_forms": {
-      "partizip_ii": "geraten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden raten",
-        "1s": "werde raten",
-        "2p": "werdet raten",
-        "2s": "wirst raten",
-        "3p": "werden raten",
-        "3s": "wird raten"
-      },
-      "perfect": {
-        "1p": "haben geraten",
-        "1s": "habe geraten",
-        "2p": "habt geraten",
-        "2s": "hast geraten",
-        "3p": "haben geraten",
-        "3s": "hat geraten"
-      },
-      "present": {
-        "1p": "raten",
-        "1s": "rate",
-        "2p": "ratet",
-        "2s": "rätst",
-        "3p": "raten",
-        "3s": "rät"
-      },
-      "preterite": {
-        "1p": "rieten",
-        "1s": "riet",
-        "2p": "rietet",
-        "2s": "rietest",
-        "3p": "rieten",
-        "3s": "riet"
-      }
-    },
-    "language_code": "de",
-    "lemma": "raten"
-  },
-  "reiten": {
-    "extra_forms": {
-      "partizip_ii": "geritten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden reiten",
-        "1s": "werde reiten",
-        "2p": "werdet reiten",
-        "2s": "wirst reiten",
-        "3p": "werden reiten",
-        "3s": "wird reiten"
-      },
-      "perfect": {
-        "1p": "haben geritten",
-        "1s": "habe geritten",
-        "2p": "habt geritten",
-        "2s": "hast geritten",
-        "3p": "haben geritten",
-        "3s": "hat geritten"
-      },
-      "present": {
-        "1p": "reiten",
-        "1s": "reite",
-        "2p": "reitet",
-        "2s": "reitest",
-        "3p": "reiten",
-        "3s": "reitet"
-      },
-      "preterite": {
-        "1p": "ritten",
-        "1s": "ritt",
-        "2p": "rittet",
-        "2s": "rittest",
-        "3p": "ritten",
-        "3s": "ritt"
-      }
-    },
-    "language_code": "de",
-    "lemma": "reiten"
-  },
-  "rennen": {
-    "extra_forms": {
-      "partizip_ii": "gerannt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden rennen",
-        "1s": "werde rennen",
-        "2p": "werdet rennen",
-        "2s": "wirst rennen",
-        "3p": "werden rennen",
-        "3s": "wird rennen"
-      },
-      "perfect": {
-        "1p": "sind gerannt",
-        "1s": "bin gerannt",
-        "2p": "seid gerannt",
-        "2s": "bist gerannt",
-        "3p": "sind gerannt",
-        "3s": "ist gerannt"
-      },
-      "present": {
-        "1p": "rennen",
-        "1s": "renne",
-        "2p": "rennt",
-        "2s": "rennst",
-        "3p": "rennen",
-        "3s": "rennt"
-      },
-      "preterite": {
-        "1p": "rannten",
-        "1s": "rannte",
-        "2p": "ranntet",
-        "2s": "ranntest",
-        "3p": "rannten",
-        "3s": "rannte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "rennen"
-  },
-  "rufen": {
-    "extra_forms": {
-      "partizip_ii": "gerufen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden rufen",
-        "1s": "werde rufen",
-        "2p": "werdet rufen",
-        "2s": "wirst rufen",
-        "3p": "werden rufen",
-        "3s": "wird rufen"
-      },
-      "perfect": {
-        "1p": "haben gerufen",
-        "1s": "habe gerufen",
-        "2p": "habt gerufen",
-        "2s": "hast gerufen",
-        "3p": "haben gerufen",
-        "3s": "hat gerufen"
-      },
-      "present": {
-        "1p": "rufen",
-        "1s": "rufe",
-        "2p": "ruft",
-        "2s": "rufst",
-        "3p": "rufen",
-        "3s": "ruft"
-      },
-      "preterite": {
-        "1p": "riefen",
-        "1s": "rief",
-        "2p": "rieft",
-        "2s": "riefst",
-        "3p": "riefen",
-        "3s": "rief"
-      }
-    },
-    "language_code": "de",
-    "lemma": "rufen"
-  },
-  "scheinen": {
-    "extra_forms": {
-      "partizip_ii": "geschienen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden scheinen",
-        "1s": "werde scheinen",
-        "2p": "werdet scheinen",
-        "2s": "wirst scheinen",
-        "3p": "werden scheinen",
-        "3s": "wird scheinen"
-      },
-      "perfect": {
-        "1p": "haben geschienen",
-        "1s": "habe geschienen",
-        "2p": "habt geschienen",
-        "2s": "hast geschienen",
-        "3p": "haben geschienen",
-        "3s": "hat geschienen"
-      },
-      "present": {
-        "1p": "scheinen",
-        "1s": "scheine",
-        "2p": "scheint",
-        "2s": "scheinst",
-        "3p": "scheinen",
-        "3s": "scheint"
-      },
-      "preterite": {
-        "1p": "schienen",
-        "1s": "schien",
-        "2p": "schient",
-        "2s": "schienst",
-        "3p": "schienen",
-        "3s": "schien"
-      }
-    },
-    "language_code": "de",
-    "lemma": "scheinen"
-  },
-  "schlafen": {
-    "extra_forms": {
-      "partizip_ii": "geschlafen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schlafen",
-        "1s": "werde schlafen",
-        "2p": "werdet schlafen",
-        "2s": "wirst schlafen",
-        "3p": "werden schlafen",
-        "3s": "wird schlafen"
-      },
-      "perfect": {
-        "1p": "haben geschlafen",
-        "1s": "habe geschlafen",
-        "2p": "habt geschlafen",
-        "2s": "hast geschlafen",
-        "3p": "haben geschlafen",
-        "3s": "hat geschlafen"
-      },
-      "present": {
-        "1p": "schlafen",
-        "1s": "schlafe",
-        "2p": "schlaft",
-        "2s": "schläfst",
-        "3p": "schlafen",
-        "3s": "schläft"
-      },
-      "preterite": {
-        "1p": "schliefen",
-        "1s": "schlief",
-        "2p": "schlieft",
-        "2s": "schliefst",
-        "3p": "schliefen",
-        "3s": "schlief"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schlafen"
-  },
-  "schlagen": {
-    "extra_forms": {
-      "partizip_ii": "geschlagen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schlagen",
-        "1s": "werde schlagen",
-        "2p": "werdet schlagen",
-        "2s": "wirst schlagen",
-        "3p": "werden schlagen",
-        "3s": "wird schlagen"
-      },
-      "perfect": {
-        "1p": "haben geschlagen",
-        "1s": "habe geschlagen",
-        "2p": "habt geschlagen",
-        "2s": "hast geschlagen",
-        "3p": "haben geschlagen",
-        "3s": "hat geschlagen"
-      },
-      "present": {
-        "1p": "schlagen",
-        "1s": "schlage",
-        "2p": "schlagt",
-        "2s": "schlägst",
-        "3p": "schlagen",
-        "3s": "schlägt"
-      },
-      "preterite": {
-        "1p": "schlugen",
-        "1s": "schlug",
-        "2p": "schlugt",
-        "2s": "schlugst",
-        "3p": "schlugen",
-        "3s": "schlug"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schlagen"
-  },
-  "schließen": {
-    "extra_forms": {
-      "partizip_ii": "geschlossen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schließen",
-        "1s": "werde schließen",
-        "2p": "werdet schließen",
-        "2s": "wirst schließen",
-        "3p": "werden schließen",
-        "3s": "wird schließen"
-      },
-      "perfect": {
-        "1p": "haben geschlossen",
-        "1s": "habe geschlossen",
-        "2p": "habt geschlossen",
-        "2s": "hast geschlossen",
-        "3p": "haben geschlossen",
-        "3s": "hat geschlossen"
-      },
-      "present": {
-        "1p": "schließen",
-        "1s": "schließe",
-        "2p": "schließt",
-        "2s": "schließt",
-        "3p": "schließen",
-        "3s": "schließt"
-      },
-      "preterite": {
-        "1p": "schlossen",
-        "1s": "schloss",
-        "2p": "schlosst",
-        "2s": "schlossest",
-        "3p": "schlossen",
-        "3s": "schloss"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schließen"
-  },
-  "schneiden": {
-    "extra_forms": {
-      "partizip_ii": "geschnitten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schneiden",
-        "1s": "werde schneiden",
-        "2p": "werdet schneiden",
-        "2s": "wirst schneiden",
-        "3p": "werden schneiden",
-        "3s": "wird schneiden"
-      },
-      "perfect": {
-        "1p": "haben geschnitten",
-        "1s": "habe geschnitten",
-        "2p": "habt geschnitten",
-        "2s": "hast geschnitten",
-        "3p": "haben geschnitten",
-        "3s": "hat geschnitten"
-      },
-      "present": {
-        "1p": "schneiden",
-        "1s": "schneide",
-        "2p": "schneidet",
-        "2s": "schneidest",
-        "3p": "schneiden",
-        "3s": "schneidet"
-      },
-      "preterite": {
-        "1p": "schnitten",
-        "1s": "schnitt",
-        "2p": "schnittet",
-        "2s": "schnittest",
-        "3p": "schnitten",
-        "3s": "schnitt"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schneiden"
-  },
-  "schreiben": {
-    "extra_forms": {
-      "partizip_ii": "geschrieben"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schreiben",
-        "1s": "werde schreiben",
-        "2p": "werdet schreiben",
-        "2s": "wirst schreiben",
-        "3p": "werden schreiben",
-        "3s": "wird schreiben"
-      },
-      "perfect": {
-        "1p": "haben geschrieben",
-        "1s": "habe geschrieben",
-        "2p": "habt geschrieben",
-        "2s": "hast geschrieben",
-        "3p": "haben geschrieben",
-        "3s": "hat geschrieben"
-      },
-      "present": {
-        "1p": "schreiben",
-        "1s": "schreibe",
-        "2p": "schreibt",
-        "2s": "schreibst",
-        "3p": "schreiben",
-        "3s": "schreibt"
-      },
-      "preterite": {
-        "1p": "schreiben",
-        "1s": "schrieb",
-        "2p": "schriebt",
-        "2s": "schriebst",
-        "3p": "schrieben",
-        "3s": "schrieb"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schreiben"
-  },
-  "schwimmen": {
-    "extra_forms": {
-      "partizip_ii": "geschwommen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden schwimmen",
-        "1s": "werde schwimmen",
-        "2p": "werdet schwimmen",
-        "2s": "wirst schwimmen",
-        "3p": "werden schwimmen",
-        "3s": "wird schwimmen"
-      },
-      "perfect": {
-        "1p": "haben geschwommen",
-        "1s": "habe geschwommen",
-        "2p": "habt geschwommen",
-        "2s": "hast geschwommen",
-        "3p": "haben geschwommen",
-        "3s": "hat geschwommen"
-      },
-      "present": {
-        "1p": "schwimmen",
-        "1s": "schwimme",
-        "2p": "schwimmt",
-        "2s": "schwimmst",
-        "3p": "schwimmen",
-        "3s": "schwimmt"
-      },
-      "preterite": {
-        "1p": "schwammen",
-        "1s": "schwamm",
-        "2p": "schwammt",
-        "2s": "schwammst",
-        "3p": "schwammen",
-        "3s": "schwamm"
-      }
-    },
-    "language_code": "de",
-    "lemma": "schwimmen"
-  },
-  "sehen": {
-    "extra_forms": {
-      "partizip_ii": "gesehen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sehen",
-        "1s": "werde sehen",
-        "2p": "werdet sehen",
-        "2s": "wirst sehen",
-        "3p": "werden sehen",
-        "3s": "wird sehen"
-      },
-      "perfect": {
-        "1p": "haben gesehen",
-        "1s": "habe gesehen",
-        "2p": "habt gesehen",
-        "2s": "hast gesehen",
-        "3p": "haben gesehen",
-        "3s": "hat gesehen"
-      },
-      "present": {
-        "1p": "sehen",
-        "1s": "sehe",
-        "2p": "seht",
-        "2s": "siehst",
-        "3p": "sehen",
-        "3s": "sieht"
-      },
-      "preterite": {
-        "1p": "sahen",
-        "1s": "sah",
-        "2p": "saht",
-        "2s": "sahst",
-        "3p": "sahen",
-        "3s": "sah"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sehen"
-  },
-  "sein": {
-    "extra_forms": {
-      "partizip_ii": "gewesen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sein",
-        "1s": "werde sein",
-        "2p": "werdet sein",
-        "2s": "wirst sein",
-        "3p": "werden sein",
-        "3s": "wird sein"
-      },
-      "perfect": {
-        "1p": "sind gewesen",
-        "1s": "bin gewesen",
-        "2p": "seid gewesen",
-        "2s": "bist gewesen",
-        "3p": "sind gewesen",
-        "3s": "ist gewesen"
-      },
-      "present": {
-        "1p": "sind",
-        "1s": "bin",
-        "2p": "seid",
-        "2s": "bist",
-        "3p": "sind",
-        "3s": "ist"
-      },
-      "preterite": {
-        "1p": "waren",
-        "1s": "war",
-        "2p": "wart",
-        "2s": "warst",
-        "3p": "waren",
-        "3s": "war"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sein"
-  },
-  "singen": {
-    "extra_forms": {
-      "partizip_ii": "gesungen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden singen",
-        "1s": "werde singen",
-        "2p": "werdet singen",
-        "2s": "wirst singen",
-        "3p": "werden singen",
-        "3s": "wird singen"
-      },
-      "perfect": {
-        "1p": "haben gesungen",
-        "1s": "habe gesungen",
-        "2p": "habt gesungen",
-        "2s": "hast gesungen",
-        "3p": "haben gesungen",
-        "3s": "hat gesungen"
-      },
-      "present": {
-        "1p": "singen",
-        "1s": "singe",
-        "2p": "singt",
-        "2s": "singst",
-        "3p": "singen",
-        "3s": "singt"
-      },
-      "preterite": {
-        "1p": "sangen",
-        "1s": "sang",
-        "2p": "sangt",
-        "2s": "sangst",
-        "3p": "sangen",
-        "3s": "sang"
-      }
-    },
-    "language_code": "de",
-    "lemma": "singen"
-  },
-  "sitzen": {
-    "extra_forms": {
-      "partizip_ii": "gesessen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sitzen",
-        "1s": "werde sitzen",
-        "2p": "werdet sitzen",
-        "2s": "wirst sitzen",
-        "3p": "werden sitzen",
-        "3s": "wird sitzen"
-      },
-      "perfect": {
-        "1p": "haben gesessen",
-        "1s": "habe gesessen",
-        "2p": "habt gesessen",
-        "2s": "hast gesessen",
-        "3p": "haben gesessen",
-        "3s": "hat gesessen"
-      },
-      "present": {
-        "1p": "sitzen",
-        "1s": "sitze",
-        "2p": "sitzt",
-        "2s": "sitzt",
-        "3p": "sitzen",
-        "3s": "sitzt"
-      },
-      "preterite": {
-        "1p": "saßen",
-        "1s": "saß",
-        "2p": "saßt",
-        "2s": "saßest",
-        "3p": "saßen",
-        "3s": "saß"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sitzen"
-  },
-  "sollen": {
-    "extra_forms": {
-      "partizip_ii": "gesollt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sollen",
-        "1s": "werde sollen",
-        "2p": "werdet sollen",
-        "2s": "wirst sollen",
-        "3p": "werden sollen",
-        "3s": "wird sollen"
-      },
-      "perfect": {
-        "1p": "haben gesollt",
-        "1s": "habe gesollt",
-        "2p": "habt gesollt",
-        "2s": "hast gesollt",
-        "3p": "haben gesollt",
-        "3s": "hat gesollt"
-      },
-      "present": {
-        "1p": "sollen",
-        "1s": "soll",
-        "2p": "sollt",
-        "2s": "sollst",
-        "3p": "sollen",
-        "3s": "soll"
-      },
-      "preterite": {
-        "1p": "sollten",
-        "1s": "sollte",
-        "2p": "solltet",
-        "2s": "solltest",
-        "3p": "sollten",
-        "3s": "sollte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sollen"
-  },
-  "sprechen": {
-    "extra_forms": {
-      "partizip_ii": "gesprochen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sprechen",
-        "1s": "werde sprechen",
-        "2p": "werdet sprechen",
-        "2s": "wirst sprechen",
-        "3p": "werden sprechen",
-        "3s": "wird sprechen"
-      },
-      "perfect": {
-        "1p": "haben gesprochen",
-        "1s": "habe gesprochen",
-        "2p": "habt gesprochen",
-        "2s": "hast gesprochen",
-        "3p": "haben gesprochen",
-        "3s": "hat gesprochen"
-      },
-      "present": {
-        "1p": "sprechen",
-        "1s": "spreche",
-        "2p": "sprecht",
-        "2s": "sprichst",
-        "3p": "sprechen",
-        "3s": "spricht"
-      },
-      "preterite": {
-        "1p": "sprachen",
-        "1s": "sprach",
-        "2p": "spracht",
-        "2s": "sprachst",
-        "3p": "sprachen",
-        "3s": "sprach"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sprechen"
-  },
-  "springen": {
-    "extra_forms": {
-      "partizip_ii": "gesprungen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden springen",
-        "1s": "werde springen",
-        "2p": "werdet springen",
-        "2s": "wirst springen",
-        "3p": "werden springen",
-        "3s": "wird springen"
-      },
-      "perfect": {
-        "1p": "sind gesprungen",
-        "1s": "bin gesprungen",
-        "2p": "seid gesprungen",
-        "2s": "bist gesprungen",
-        "3p": "sind gesprungen",
-        "3s": "ist gesprungen"
-      },
-      "present": {
-        "1p": "springen",
-        "1s": "springe",
-        "2p": "springt",
-        "2s": "springst",
-        "3p": "springen",
-        "3s": "springt"
-      },
-      "preterite": {
-        "1p": "sprangen",
-        "1s": "sprang",
-        "2p": "sprangt",
-        "2s": "sprangst",
-        "3p": "sprangen",
-        "3s": "sprang"
-      }
-    },
-    "language_code": "de",
-    "lemma": "springen"
-  },
-  "stehen": {
-    "extra_forms": {
-      "partizip_ii": "gestanden"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden stehen",
-        "1s": "werde stehen",
-        "2p": "werdet stehen",
-        "2s": "wirst stehen",
-        "3p": "werden stehen",
-        "3s": "wird stehen"
-      },
-      "perfect": {
-        "1p": "haben gestanden",
-        "1s": "habe gestanden",
-        "2p": "habt gestanden",
-        "2s": "hast gestanden",
-        "3p": "haben gestanden",
-        "3s": "hat gestanden"
-      },
-      "present": {
-        "1p": "stehen",
-        "1s": "stehe",
-        "2p": "steht",
-        "2s": "stehst",
-        "3p": "stehen",
-        "3s": "steht"
-      },
-      "preterite": {
-        "1p": "standen",
-        "1s": "stand",
-        "2p": "standet",
-        "2s": "standest",
-        "3p": "standen",
-        "3s": "stand"
-      }
-    },
-    "language_code": "de",
-    "lemma": "stehen"
-  },
-  "steigen": {
-    "extra_forms": {
-      "partizip_ii": "gestiegen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden steigen",
-        "1s": "werde steigen",
-        "2p": "werdet steigen",
-        "2s": "wirst steigen",
-        "3p": "werden steigen",
-        "3s": "wird steigen"
-      },
-      "perfect": {
-        "1p": "sind gestiegen",
-        "1s": "bin gestiegen",
-        "2p": "seid gestiegen",
-        "2s": "bist gestiegen",
-        "3p": "sind gestiegen",
-        "3s": "ist gestiegen"
-      },
-      "present": {
-        "1p": "steigen",
-        "1s": "steige",
-        "2p": "steigt",
-        "2s": "steigst",
-        "3p": "steigen",
-        "3s": "steigt"
-      },
-      "preterite": {
-        "1p": "stiegen",
-        "1s": "stieg",
-        "2p": "stiegt",
-        "2s": "stiegst",
-        "3p": "stiegen",
-        "3s": "stieg"
-      }
-    },
-    "language_code": "de",
-    "lemma": "steigen"
-  },
-  "sterben": {
-    "extra_forms": {
-      "partizip_ii": "gestorben"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden sterben",
-        "1s": "werde sterben",
-        "2p": "werdet sterben",
-        "2s": "wirst sterben",
-        "3p": "werden sterben",
-        "3s": "wird sterben"
-      },
-      "perfect": {
-        "1p": "sind gestorben",
-        "1s": "bin gestorben",
-        "2p": "seid gestorben",
-        "2s": "bist gestorben",
-        "3p": "sind gestorben",
-        "3s": "ist gestorben"
-      },
-      "present": {
-        "1p": "sterben",
-        "1s": "sterbe",
-        "2p": "sterbt",
-        "2s": "stirbst",
-        "3p": "sterben",
-        "3s": "stirbt"
-      },
-      "preterite": {
-        "1p": "starben",
-        "1s": "starb",
-        "2p": "starbt",
-        "2s": "starbst",
-        "3p": "starben",
-        "3s": "starb"
-      }
-    },
-    "language_code": "de",
-    "lemma": "sterben"
-  },
-  "stoßen": {
-    "extra_forms": {
-      "partizip_ii": "gestoßen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden stoßen",
-        "1s": "werde stoßen",
-        "2p": "werdet stoßen",
-        "2s": "wirst stoßen",
-        "3p": "werden stoßen",
-        "3s": "wird stoßen"
-      },
-      "perfect": {
-        "1p": "haben gestoßen",
-        "1s": "habe gestoßen",
-        "2p": "habt gestoßen",
-        "2s": "hast gestoßen",
-        "3p": "haben gestoßen",
-        "3s": "hat gestoßen"
-      },
-      "present": {
-        "1p": "stoßen",
-        "1s": "stoße",
-        "2p": "stoßt",
-        "2s": "stößt",
-        "3p": "stoßen",
-        "3s": "stößt"
-      },
-      "preterite": {
-        "1p": "stießen",
-        "1s": "stieß",
-        "2p": "stießt",
-        "2s": "stießest",
-        "3p": "stießen",
-        "3s": "stieß"
-      }
-    },
-    "language_code": "de",
-    "lemma": "stoßen"
-  },
-  "streiten": {
-    "extra_forms": {
-      "partizip_ii": "gestritten"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden streiten",
-        "1s": "werde streiten",
-        "2p": "werdet streiten",
-        "2s": "wirst streiten",
-        "3p": "werden streiten",
-        "3s": "wird streiten"
-      },
-      "perfect": {
-        "1p": "haben gestritten",
-        "1s": "habe gestritten",
-        "2p": "habt gestritten",
-        "2s": "hast gestritten",
-        "3p": "haben gestritten",
-        "3s": "hat gestritten"
-      },
-      "present": {
-        "1p": "streiten",
-        "1s": "streite",
-        "2p": "streitet",
-        "2s": "streitest",
-        "3p": "streiten",
-        "3s": "streitet"
-      },
-      "preterite": {
-        "1p": "stritten",
-        "1s": "stritt",
-        "2p": "strittet",
-        "2s": "strittest",
-        "3p": "stritten",
-        "3s": "stritt"
-      }
-    },
-    "language_code": "de",
-    "lemma": "streiten"
-  },
-  "tragen": {
-    "extra_forms": {
-      "partizip_ii": "getragen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden tragen",
-        "1s": "werde tragen",
-        "2p": "werdet tragen",
-        "2s": "wirst tragen",
-        "3p": "werden tragen",
-        "3s": "wird tragen"
-      },
-      "perfect": {
-        "1p": "haben getragen",
-        "1s": "habe getragen",
-        "2p": "habt getragen",
-        "2s": "hast getragen",
-        "3p": "haben getragen",
-        "3s": "hat getragen"
-      },
-      "present": {
-        "1p": "tragen",
-        "1s": "trage",
-        "2p": "tragt",
-        "2s": "trägst",
-        "3p": "tragen",
-        "3s": "trägt"
-      },
-      "preterite": {
-        "1p": "trugen",
-        "1s": "trug",
-        "2p": "trugt",
-        "2s": "trugst",
-        "3p": "trugen",
-        "3s": "trug"
-      }
-    },
-    "language_code": "de",
-    "lemma": "tragen"
-  },
-  "treffen": {
-    "extra_forms": {
-      "partizip_ii": "getroffen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden treffen",
-        "1s": "werde treffen",
-        "2p": "werdet treffen",
-        "2s": "wirst treffen",
-        "3p": "werden treffen",
-        "3s": "wird treffen"
-      },
-      "perfect": {
-        "1p": "haben getroffen",
-        "1s": "habe getroffen",
-        "2p": "habt getroffen",
-        "2s": "hast getroffen",
-        "3p": "haben getroffen",
-        "3s": "hat getroffen"
-      },
-      "present": {
-        "1p": "treffen",
-        "1s": "treffe",
-        "2p": "trefft",
-        "2s": "triffst",
-        "3p": "treffen",
-        "3s": "trifft"
-      },
-      "preterite": {
-        "1p": "trafen",
-        "1s": "traf",
-        "2p": "traft",
-        "2s": "trafst",
-        "3p": "trafen",
-        "3s": "traf"
-      }
-    },
-    "language_code": "de",
-    "lemma": "treffen"
-  },
-  "treiben": {
-    "extra_forms": {
-      "partizip_ii": "getrieben"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden treiben",
-        "1s": "werde treiben",
-        "2p": "werdet treiben",
-        "2s": "wirst treiben",
-        "3p": "werden treiben",
-        "3s": "wird treiben"
-      },
-      "perfect": {
-        "1p": "haben getrieben",
-        "1s": "habe getrieben",
-        "2p": "habt getrieben",
-        "2s": "hast getrieben",
-        "3p": "haben getrieben",
-        "3s": "hat getrieben"
-      },
-      "present": {
-        "1p": "treiben",
-        "1s": "treibe",
-        "2p": "treibt",
-        "2s": "treibst",
-        "3p": "treiben",
-        "3s": "treibt"
-      },
-      "preterite": {
-        "1p": "trieben",
-        "1s": "trieb",
-        "2p": "triebt",
-        "2s": "triebst",
-        "3p": "trieben",
-        "3s": "trieb"
-      }
-    },
-    "language_code": "de",
-    "lemma": "treiben"
-  },
-  "trinken": {
-    "extra_forms": {
-      "partizip_ii": "getrunken"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden trinken",
-        "1s": "werde trinken",
-        "2p": "werdet trinken",
-        "2s": "wirst trinken",
-        "3p": "werden trinken",
-        "3s": "wird trinken"
-      },
-      "perfect": {
-        "1p": "haben getrunken",
-        "1s": "habe getrunken",
-        "2p": "habt getrunken",
-        "2s": "hast getrunken",
-        "3p": "haben getrunken",
-        "3s": "hat getrunken"
-      },
-      "present": {
-        "1p": "trinken",
-        "1s": "trinke",
-        "2p": "trinkt",
-        "2s": "trinkst",
-        "3p": "trinken",
-        "3s": "trinkt"
-      },
-      "preterite": {
-        "1p": "tranken",
-        "1s": "trank",
-        "2p": "trankt",
-        "2s": "trankst",
-        "3p": "tranken",
-        "3s": "trank"
-      }
-    },
-    "language_code": "de",
-    "lemma": "trinken"
-  },
-  "tun": {
-    "extra_forms": {
-      "partizip_ii": "getan"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden tun",
-        "1s": "werde tun",
-        "2p": "werdet tun",
-        "2s": "wirst tun",
-        "3p": "werden tun",
-        "3s": "wird tun"
-      },
-      "perfect": {
-        "1p": "haben getan",
-        "1s": "habe getan",
-        "2p": "habt getan",
-        "2s": "hast getan",
-        "3p": "haben getan",
-        "3s": "hat getan"
-      },
-      "present": {
-        "1p": "tun",
-        "1s": "tue",
-        "2p": "tut",
-        "2s": "tust",
-        "3p": "tun",
-        "3s": "tut"
-      },
-      "preterite": {
-        "1p": "taten",
-        "1s": "tat",
-        "2p": "tatet",
-        "2s": "tatst",
-        "3p": "taten",
-        "3s": "tat"
-      }
-    },
-    "language_code": "de",
-    "lemma": "tun"
-  },
-  "vergessen": {
-    "extra_forms": {
-      "partizip_ii": "vergessen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden vergessen",
-        "1s": "werde vergessen",
-        "2p": "werdet vergessen",
-        "2s": "wirst vergessen",
-        "3p": "werden vergessen",
-        "3s": "wird vergessen"
-      },
-      "perfect": {
-        "1p": "haben vergessen",
-        "1s": "habe vergessen",
-        "2p": "habt vergessen",
-        "2s": "hast vergessen",
-        "3p": "haben vergessen",
-        "3s": "hat vergessen"
-      },
-      "present": {
-        "1p": "vergessen",
-        "1s": "vergesse",
-        "2p": "vergesst",
-        "2s": "vergisst",
-        "3p": "vergessen",
-        "3s": "vergisst"
-      },
-      "preterite": {
-        "1p": "vergaßen",
-        "1s": "vergaß",
-        "2p": "vergaßt",
-        "2s": "vergaßt",
-        "3p": "vergaßen",
-        "3s": "vergaß"
-      }
-    },
-    "language_code": "de",
-    "lemma": "vergessen"
-  },
-  "wachsen": {
-    "extra_forms": {
-      "partizip_ii": "gewachsen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden wachsen",
-        "1s": "werde wachsen",
-        "2p": "werdet wachsen",
-        "2s": "wirst wachsen",
-        "3p": "werden wachsen",
-        "3s": "wird wachsen"
-      },
-      "perfect": {
-        "1p": "sind gewachsen",
-        "1s": "bin gewachsen",
-        "2p": "seid gewachsen",
-        "2s": "bist gewachsen",
-        "3p": "sind gewachsen",
-        "3s": "ist gewachsen"
-      },
-      "present": {
-        "1p": "wachsen",
-        "1s": "wachse",
-        "2p": "wächst",
-        "2s": "wächst",
-        "3p": "wachsen",
-        "3s": "wächst"
-      },
-      "preterite": {
-        "1p": "wuchsen",
-        "1s": "wuchs",
-        "2p": "wuchst",
-        "2s": "wuchs(e)st",
-        "3p": "wuchsen",
-        "3s": "wuchs"
-      }
-    },
-    "language_code": "de",
-    "lemma": "wachsen"
-  },
-  "waschen": {
-    "extra_forms": {
-      "partizip_ii": "gewaschen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden waschen",
-        "1s": "werde waschen",
-        "2p": "werdet waschen",
-        "2s": "wirst waschen",
-        "3p": "werden waschen",
-        "3s": "wird waschen"
-      },
-      "perfect": {
-        "1p": "haben gewaschen",
-        "1s": "habe gewaschen",
-        "2p": "habt gewaschen",
-        "2s": "hast gewaschen",
-        "3p": "haben gewaschen",
-        "3s": "hat gewaschen"
-      },
-      "present": {
-        "1p": "waschen",
-        "1s": "wasche",
-        "2p": "wascht",
-        "2s": "wäschst",
-        "3p": "waschen",
-        "3s": "wäscht"
-      },
-      "preterite": {
-        "1p": "wuschen",
-        "1s": "wusch",
-        "2p": "wuscht",
-        "2s": "wuschest",
-        "3p": "wuschen",
-        "3s": "wusch"
-      }
-    },
-    "language_code": "de",
-    "lemma": "waschen"
-  },
-  "werden": {
-    "extra_forms": {
-      "partizip_ii": "geworden"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden werden",
-        "1s": "werde werden",
-        "2p": "werdet werden",
-        "2s": "wirst werden",
-        "3p": "werden werden",
-        "3s": "wird werden"
-      },
-      "perfect": {
-        "1p": "sind geworden",
-        "1s": "bin geworden",
-        "2p": "seid geworden",
-        "2s": "bist geworden",
-        "3p": "sind geworden",
-        "3s": "ist geworden"
-      },
-      "present": {
-        "1p": "werden",
-        "1s": "werde",
-        "2p": "werdet",
-        "2s": "wirst",
-        "3p": "werden",
-        "3s": "wird"
-      },
-      "preterite": {
-        "1p": "wurden",
-        "1s": "wurde",
-        "2p": "wurdet",
-        "2s": "wurdest",
-        "3p": "wurden",
-        "3s": "wurde"
-      }
-    },
-    "language_code": "de",
-    "lemma": "werden"
-  },
-  "werfen": {
-    "extra_forms": {
-      "partizip_ii": "geworfen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden werfen",
-        "1s": "werde werfen",
-        "2p": "werdet werfen",
-        "2s": "wirst werfen",
-        "3p": "werden werfen",
-        "3s": "wird werfen"
-      },
-      "perfect": {
-        "1p": "haben geworfen",
-        "1s": "habe geworfen",
-        "2p": "habt geworfen",
-        "2s": "hast geworfen",
-        "3p": "haben geworfen",
-        "3s": "hat geworfen"
-      },
-      "present": {
-        "1p": "werfen",
-        "1s": "werfe",
-        "2p": "werft",
-        "2s": "wirfst",
-        "3p": "werfen",
-        "3s": "wirft"
-      },
-      "preterite": {
-        "1p": "warfen",
-        "1s": "warf",
-        "2p": "warft",
-        "2s": "warfst",
-        "3p": "warfen",
-        "3s": "warf"
-      }
-    },
-    "language_code": "de",
-    "lemma": "werfen"
-  },
-  "wissen": {
-    "extra_forms": {
-      "partizip_ii": "gewusst"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden wissen",
-        "1s": "werde wissen",
-        "2p": "werdet wissen",
-        "2s": "wirst wissen",
-        "3p": "werden wissen",
-        "3s": "wird wissen"
-      },
-      "perfect": {
-        "1p": "haben gewusst",
-        "1s": "habe gewusst",
-        "2p": "habt gewusst",
-        "2s": "hast gewusst",
-        "3p": "haben gewusst",
-        "3s": "hat gewusst"
-      },
-      "present": {
-        "1p": "wissen",
-        "1s": "weiß",
-        "2p": "wisst",
-        "2s": "weißt",
-        "3p": "wissen",
-        "3s": "weiß"
-      },
-      "preterite": {
-        "1p": "wussten",
-        "1s": "wusste",
-        "2p": "wusstet",
-        "2s": "wusstest",
-        "3p": "wussten",
-        "3s": "wusste"
-      }
-    },
-    "language_code": "de",
-    "lemma": "wissen"
-  },
-  "wollen": {
-    "extra_forms": {
-      "partizip_ii": "gewollt"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden wollen",
-        "1s": "werde wollen",
-        "2p": "werdet wollen",
-        "2s": "wirst wollen",
-        "3p": "werden wollen",
-        "3s": "wird wollen"
-      },
-      "perfect": {
-        "1p": "haben gewollt",
-        "1s": "habe gewollt",
-        "2p": "habt gewollt",
-        "2s": "hast gewollt",
-        "3p": "haben gewollt",
-        "3s": "hat gewollt"
-      },
-      "present": {
-        "1p": "wollen",
-        "1s": "will",
-        "2p": "wollt",
-        "2s": "willst",
-        "3p": "wollen",
-        "3s": "will"
-      },
-      "preterite": {
-        "1p": "wollten",
-        "1s": "wollte",
-        "2p": "wolltet",
-        "2s": "wolltest",
-        "3p": "wollten",
-        "3s": "wollte"
-      }
-    },
-    "language_code": "de",
-    "lemma": "wollen"
-  },
-  "ziehen": {
-    "extra_forms": {
-      "partizip_ii": "gezogen"
-    },
-    "forms": {
-      "future_i": {
-        "1p": "werden ziehen",
-        "1s": "werde ziehen",
-        "2p": "werdet ziehen",
-        "2s": "wirst ziehen",
-        "3p": "werden ziehen",
-        "3s": "wird ziehen"
-      },
-      "perfect": {
-        "1p": "haben gezogen",
-        "1s": "habe gezogen",
-        "2p": "habt gezogen",
-        "2s": "hast gezogen",
-        "3p": "haben gezogen",
-        "3s": "hat gezogen"
-      },
-      "present": {
-        "1p": "ziehen",
-        "1s": "ziehe",
-        "2p": "zieht",
-        "2s": "ziehst",
-        "3p": "ziehen",
-        "3s": "zieht"
-      },
-      "preterite": {
-        "1p": "zogen",
-        "1s": "zog",
-        "2p": "zogen",
-        "2s": "zogst",
-        "3p": "zogen",
-        "3s": "zog"
-      }
-    },
-    "language_code": "de",
-    "lemma": "ziehen"
-  }
+    "backen": {
+        "extra_forms": {"partizip_ii": "gebacken"},
+        "forms": {
+            "future_i": {
+                "1p": "werden backen",
+                "1s": "werde backen",
+                "2p": "werdet backen",
+                "2s": "wirst backen",
+                "3p": "werden backen",
+                "3s": "wird backen",
+            },
+            "perfect": {
+                "1p": "haben gebacken",
+                "1s": "habe gebacken",
+                "2p": "habt gebacken",
+                "2s": "hast gebacken",
+                "3p": "haben gebacken",
+                "3s": "hat gebacken",
+            },
+            "present": {
+                "1p": "backen",
+                "1s": "backe",
+                "2p": "backt",
+                "2s": "backst",
+                "3p": "backen",
+                "3s": "backt",
+            },
+            "preterite": {
+                "1p": "buken",
+                "1s": "buk",
+                "2p": "bukt",
+                "2s": "bukst",
+                "3p": "buken",
+                "3s": "buk",
+            },
+        },
+        "language_code": "de",
+        "lemma": "backen",
+    },
+    "beginnen": {
+        "extra_forms": {"partizip_ii": "begonnen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden beginnen",
+                "1s": "werde beginnen",
+                "2p": "werdet beginnen",
+                "2s": "wirst beginnen",
+                "3p": "werden beginnen",
+                "3s": "wird beginnen",
+            },
+            "perfect": {
+                "1p": "haben begonnen",
+                "1s": "habe begonnen",
+                "2p": "habt begonnen",
+                "2s": "hast begonnen",
+                "3p": "haben begonnen",
+                "3s": "hat begonnen",
+            },
+            "present": {
+                "1p": "beginnen",
+                "1s": "beginne",
+                "2p": "beginnt",
+                "2s": "beginnst",
+                "3p": "beginnen",
+                "3s": "beginnt",
+            },
+            "preterite": {
+                "1p": "begannen",
+                "1s": "begann",
+                "2p": "begannt",
+                "2s": "begannst",
+                "3p": "begannen",
+                "3s": "begann",
+            },
+        },
+        "language_code": "de",
+        "lemma": "beginnen",
+    },
+    "bieten": {
+        "extra_forms": {"partizip_ii": "geboten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden bieten",
+                "1s": "werde bieten",
+                "2p": "werdet bieten",
+                "2s": "wirst bieten",
+                "3p": "werden bieten",
+                "3s": "wird bieten",
+            },
+            "perfect": {
+                "1p": "haben geboten",
+                "1s": "habe geboten",
+                "2p": "habt geboten",
+                "2s": "hast geboten",
+                "3p": "haben geboten",
+                "3s": "hat geboten",
+            },
+            "present": {
+                "1p": "bieten",
+                "1s": "biete",
+                "2p": "bietet",
+                "2s": "bietest",
+                "3p": "bieten",
+                "3s": "bietet",
+            },
+            "preterite": {
+                "1p": "boten",
+                "1s": "bot",
+                "2p": "botet",
+                "2s": "botst",
+                "3p": "boten",
+                "3s": "bot",
+            },
+        },
+        "language_code": "de",
+        "lemma": "bieten",
+    },
+    "bleiben": {
+        "extra_forms": {"partizip_ii": "geblieben"},
+        "forms": {
+            "future_i": {
+                "1p": "werden bleiben",
+                "1s": "werde bleiben",
+                "2p": "werdet bleiben",
+                "2s": "wirst bleiben",
+                "3p": "werden bleiben",
+                "3s": "wird bleiben",
+            },
+            "perfect": {
+                "1p": "sind geblieben",
+                "1s": "bin geblieben",
+                "2p": "seid geblieben",
+                "2s": "bist geblieben",
+                "3p": "sind geblieben",
+                "3s": "ist geblieben",
+            },
+            "present": {
+                "1p": "bleiben",
+                "1s": "bleibe",
+                "2p": "bleibt",
+                "2s": "bleibst",
+                "3p": "bleiben",
+                "3s": "bleibt",
+            },
+            "preterite": {
+                "1p": "blieben",
+                "1s": "blieb",
+                "2p": "bliebt",
+                "2s": "bliebst",
+                "3p": "blieben",
+                "3s": "blieb",
+            },
+        },
+        "language_code": "de",
+        "lemma": "bleiben",
+    },
+    "brechen": {
+        "extra_forms": {"partizip_ii": "gebrochen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden brechen",
+                "1s": "werde brechen",
+                "2p": "werdet brechen",
+                "2s": "wirst brechen",
+                "3p": "werden brechen",
+                "3s": "wird brechen",
+            },
+            "perfect": {
+                "1p": "haben gebrochen",
+                "1s": "habe gebrochen",
+                "2p": "habt gebrochen",
+                "2s": "hast gebrochen",
+                "3p": "haben gebrochen",
+                "3s": "hat gebrochen",
+            },
+            "present": {
+                "1p": "brechen",
+                "1s": "breche",
+                "2p": "brecht",
+                "2s": "brichst",
+                "3p": "brechen",
+                "3s": "bricht",
+            },
+            "preterite": {
+                "1p": "brachen",
+                "1s": "brach",
+                "2p": "bracht",
+                "2s": "brachst",
+                "3p": "brachen",
+                "3s": "brach",
+            },
+        },
+        "language_code": "de",
+        "lemma": "brechen",
+    },
+    "brennen": {
+        "extra_forms": {"partizip_ii": "gebrannt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden brennen",
+                "1s": "werde brennen",
+                "2p": "werdet brennen",
+                "2s": "wirst brennen",
+                "3p": "werden brennen",
+                "3s": "wird brennen",
+            },
+            "perfect": {
+                "1p": "haben gebrannt",
+                "1s": "habe gebrannt",
+                "2p": "habt gebrannt",
+                "2s": "hast gebrannt",
+                "3p": "haben gebrannt",
+                "3s": "hat gebrannt",
+            },
+            "present": {
+                "1p": "brennen",
+                "1s": "brenne",
+                "2p": "brennt",
+                "2s": "brennst",
+                "3p": "brennen",
+                "3s": "brennt",
+            },
+            "preterite": {
+                "1p": "brannten",
+                "1s": "brannte",
+                "2p": "branntet",
+                "2s": "branntest",
+                "3p": "brannten",
+                "3s": "brannte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "brennen",
+    },
+    "bringen": {
+        "extra_forms": {"partizip_ii": "gebracht"},
+        "forms": {
+            "future_i": {
+                "1p": "werden bringen",
+                "1s": "werde bringen",
+                "2p": "werdet bringen",
+                "2s": "wirst bringen",
+                "3p": "werden bringen",
+                "3s": "wird bringen",
+            },
+            "perfect": {
+                "1p": "haben gebracht",
+                "1s": "habe gebracht",
+                "2p": "habt gebracht",
+                "2s": "hast gebracht",
+                "3p": "haben gebracht",
+                "3s": "hat gebracht",
+            },
+            "present": {
+                "1p": "bringen",
+                "1s": "bringe",
+                "2p": "bringt",
+                "2s": "bringst",
+                "3p": "bringen",
+                "3s": "bringt",
+            },
+            "preterite": {
+                "1p": "brachten",
+                "1s": "brachte",
+                "2p": "brachtet",
+                "2s": "brachtest",
+                "3p": "brachten",
+                "3s": "brachte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "bringen",
+    },
+    "denken": {
+        "extra_forms": {"partizip_ii": "gedacht"},
+        "forms": {
+            "future_i": {
+                "1p": "werden denken",
+                "1s": "werde denken",
+                "2p": "werdet denken",
+                "2s": "wirst denken",
+                "3p": "werden denken",
+                "3s": "wird denken",
+            },
+            "perfect": {
+                "1p": "haben gedacht",
+                "1s": "habe gedacht",
+                "2p": "habt gedacht",
+                "2s": "hast gedacht",
+                "3p": "haben gedacht",
+                "3s": "hat gedacht",
+            },
+            "present": {
+                "1p": "denken",
+                "1s": "denke",
+                "2p": "denkt",
+                "2s": "denkst",
+                "3p": "denken",
+                "3s": "denkt",
+            },
+            "preterite": {
+                "1p": "dachten",
+                "1s": "dachte",
+                "2p": "dachtet",
+                "2s": "dachtest",
+                "3p": "dachten",
+                "3s": "dachte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "denken",
+    },
+    "dürfen": {
+        "extra_forms": {"partizip_ii": "gedurft"},
+        "forms": {
+            "future_i": {
+                "1p": "werden dürfen",
+                "1s": "werde dürfen",
+                "2p": "werdet dürfen",
+                "2s": "wirst dürfen",
+                "3p": "werden dürfen",
+                "3s": "wird dürfen",
+            },
+            "perfect": {
+                "1p": "haben gedurft",
+                "1s": "habe gedurft",
+                "2p": "habt gedurft",
+                "2s": "hast gedurft",
+                "3p": "haben gedurft",
+                "3s": "hat gedurft",
+            },
+            "present": {
+                "1p": "dürfen",
+                "1s": "darf",
+                "2p": "dürft",
+                "2s": "darfst",
+                "3p": "dürfen",
+                "3s": "darf",
+            },
+            "preterite": {
+                "1p": "durften",
+                "1s": "durfte",
+                "2p": "durftet",
+                "2s": "durftest",
+                "3p": "durften",
+                "3s": "durfte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "dürfen",
+    },
+    "empfehlen": {
+        "extra_forms": {"partizip_ii": "empfohlen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden empfehlen",
+                "1s": "werde empfehlen",
+                "2p": "werdet empfehlen",
+                "2s": "wirst empfehlen",
+                "3p": "werden empfehlen",
+                "3s": "wird empfehlen",
+            },
+            "perfect": {
+                "1p": "haben empfohlen",
+                "1s": "habe empfohlen",
+                "2p": "habt empfohlen",
+                "2s": "hast empfohlen",
+                "3p": "haben empfohlen",
+                "3s": "hat empfohlen",
+            },
+            "present": {
+                "1p": "empfehlen",
+                "1s": "empfehle",
+                "2p": "empfehlt",
+                "2s": "empfiehlst",
+                "3p": "empfehlen",
+                "3s": "empfiehlt",
+            },
+            "preterite": {
+                "1p": "empfahlen",
+                "1s": "empfahl",
+                "2p": "empfahlt",
+                "2s": "empfahlst",
+                "3p": "empfahlen",
+                "3s": "empfahl",
+            },
+        },
+        "language_code": "de",
+        "lemma": "empfehlen",
+    },
+    "erschrecken": {
+        "extra_forms": {"partizip_ii": "erschrocken / erschreckt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden erschrecken",
+                "1s": "werde erschrecken",
+                "2p": "werdet erschrecken",
+                "2s": "wirst erschrecken",
+                "3p": "werden erschrecken",
+                "3s": "wird erschrecken",
+            },
+            "perfect": {
+                "1p": "sind erschrocken / haben erschreckt",
+                "1s": "bin erschrocken / habe erschreckt",
+                "2p": "seid erschrocken / habt erschreckt",
+                "2s": "bist erschrocken / hast erschreckt",
+                "3p": "sind erschrocken / haben erschreckt",
+                "3s": "ist erschrocken / hat erschreckt",
+            },
+            "present": {
+                "1p": "erschrecken",
+                "1s": "erschrecke",
+                "2p": "erschreckt",
+                "2s": "erschrickst",
+                "3p": "erschrecken",
+                "3s": "erschrickt",
+            },
+            "preterite": {
+                "1p": "erschraken / erschreckten",
+                "1s": "erschrak / erschreckte",
+                "2p": "erschrakt / erschrecktet",
+                "2s": "erschrakst / erschrecktest",
+                "3p": "erschraken / erschreckten",
+                "3s": "erschrak / erschreckte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "erschrecken",
+    },
+    "essen": {
+        "extra_forms": {"partizip_ii": "gegessen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden essen",
+                "1s": "werde essen",
+                "2p": "werdet essen",
+                "2s": "wirst essen",
+                "3p": "werden essen",
+                "3s": "wird essen",
+            },
+            "perfect": {
+                "1p": "haben gegessen",
+                "1s": "habe gegessen",
+                "2p": "habt gegessen",
+                "2s": "hast gegessen",
+                "3p": "haben gegessen",
+                "3s": "hat gegessen",
+            },
+            "present": {
+                "1p": "essen",
+                "1s": "esse",
+                "2p": "esset",
+                "2s": "isst",
+                "3p": "essen",
+                "3s": "isst",
+            },
+            "preterite": {
+                "1p": "aßen",
+                "1s": "aß",
+                "2p": "aßt",
+                "2s": "aßest",
+                "3p": "aßen",
+                "3s": "aß",
+            },
+        },
+        "language_code": "de",
+        "lemma": "essen",
+    },
+    "fahren": {
+        "extra_forms": {"partizip_ii": "gefahren"},
+        "forms": {
+            "future_i": {
+                "1p": "werden fahren",
+                "1s": "werde fahren",
+                "2p": "werdet fahren",
+                "2s": "wirst fahren",
+                "3p": "werden fahren",
+                "3s": "wird fahren",
+            },
+            "perfect": {
+                "1p": "sind gefahren",
+                "1s": "bin gefahren",
+                "2p": "seid gefahren",
+                "2s": "bist gefahren",
+                "3p": "sind gefahren",
+                "3s": "ist gefahren",
+            },
+            "present": {
+                "1p": "fahren",
+                "1s": "fahre",
+                "2p": "fahrt",
+                "2s": "fährst",
+                "3p": "fahren",
+                "3s": "fährt",
+            },
+            "preterite": {
+                "1p": "fuhren",
+                "1s": "fuhr",
+                "2p": "fuhrt",
+                "2s": "fuhrst",
+                "3p": "fuhren",
+                "3s": "fuhr",
+            },
+        },
+        "language_code": "de",
+        "lemma": "fahren",
+    },
+    "fallen": {
+        "extra_forms": {"partizip_ii": "gefallen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden fallen",
+                "1s": "werde fallen",
+                "2p": "werdet fallen",
+                "2s": "wirst fallen",
+                "3p": "werden fallen",
+                "3s": "wird fallen",
+            },
+            "perfect": {
+                "1p": "sind gefallen",
+                "1s": "bin gefallen",
+                "2p": "seid gefallen",
+                "2s": "bist gefallen",
+                "3p": "sind gefallen",
+                "3s": "ist gefallen",
+            },
+            "present": {
+                "1p": "fallen",
+                "1s": "falle",
+                "2p": "fallt",
+                "2s": "fällst",
+                "3p": "fallen",
+                "3s": "fällt",
+            },
+            "preterite": {
+                "1p": "fielen",
+                "1s": "fiel",
+                "2p": "fielt",
+                "2s": "fielst",
+                "3p": "fielen",
+                "3s": "fiel",
+            },
+        },
+        "language_code": "de",
+        "lemma": "fallen",
+    },
+    "finden": {
+        "extra_forms": {"partizip_ii": "gefunden"},
+        "forms": {
+            "future_i": {
+                "1p": "werden finden",
+                "1s": "werde finden",
+                "2p": "werdet finden",
+                "2s": "wirst finden",
+                "3p": "werden finden",
+                "3s": "wird finden",
+            },
+            "perfect": {
+                "1p": "haben gefunden",
+                "1s": "habe gefunden",
+                "2p": "habt gefunden",
+                "2s": "hast gefunden",
+                "3p": "haben gefunden",
+                "3s": "hat gefunden",
+            },
+            "present": {
+                "1p": "finden",
+                "1s": "finde",
+                "2p": "findet",
+                "2s": "findest",
+                "3p": "finden",
+                "3s": "findet",
+            },
+            "preterite": {
+                "1p": "fanden",
+                "1s": "fand",
+                "2p": "fandet",
+                "2s": "fandest",
+                "3p": "fanden",
+                "3s": "fand",
+            },
+        },
+        "language_code": "de",
+        "lemma": "finden",
+    },
+    "fliegen": {
+        "extra_forms": {"partizip_ii": "geflogen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden fliegen",
+                "1s": "werde fliegen",
+                "2p": "werdet fliegen",
+                "2s": "wirst fliegen",
+                "3p": "werden fliegen",
+                "3s": "wird fliegen",
+            },
+            "perfect": {
+                "1p": "sind geflogen",
+                "1s": "bin geflogen",
+                "2p": "seid geflogen",
+                "2s": "bist geflogen",
+                "3p": "sind geflogen",
+                "3s": "ist geflogen",
+            },
+            "present": {
+                "1p": "fliegen",
+                "1s": "fliege",
+                "2p": "fliegt",
+                "2s": "fliegst",
+                "3p": "fliegen",
+                "3s": "fliegt",
+            },
+            "preterite": {
+                "1p": "flogen",
+                "1s": "flog",
+                "2p": "flogt",
+                "2s": "flogst",
+                "3p": "flogen",
+                "3s": "flog",
+            },
+        },
+        "language_code": "de",
+        "lemma": "fliegen",
+    },
+    "geben": {
+        "extra_forms": {"partizip_ii": "gegeben"},
+        "forms": {
+            "future_i": {
+                "1p": "werden geben",
+                "1s": "werde geben",
+                "2p": "werdet geben",
+                "2s": "wirst geben",
+                "3p": "werden geben",
+                "3s": "wird geben",
+            },
+            "perfect": {
+                "1p": "haben gegeben",
+                "1s": "habe gegeben",
+                "2p": "habt gegeben",
+                "2s": "hast gegeben",
+                "3p": "haben gegeben",
+                "3s": "hat gegeben",
+            },
+            "present": {
+                "1p": "geben",
+                "1s": "gebe",
+                "2p": "gebt",
+                "2s": "gibst",
+                "3p": "geben",
+                "3s": "gibt",
+            },
+            "preterite": {
+                "1p": "gaben",
+                "1s": "gab",
+                "2p": "gabt",
+                "2s": "gabst",
+                "3p": "gaben",
+                "3s": "gab",
+            },
+        },
+        "language_code": "de",
+        "lemma": "geben",
+    },
+    "gehen": {
+        "extra_forms": {"partizip_ii": "gegangen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden gehen",
+                "1s": "werde gehen",
+                "2p": "werdet gehen",
+                "2s": "wirst gehen",
+                "3p": "werden gehen",
+                "3s": "wird gehen",
+            },
+            "perfect": {
+                "1p": "sind gegangen",
+                "1s": "bin gegangen",
+                "2p": "seid gegangen",
+                "2s": "bist gegangen",
+                "3p": "sind gegangen",
+                "3s": "ist gegangen",
+            },
+            "present": {
+                "1p": "gehen",
+                "1s": "gehe",
+                "2p": "geht",
+                "2s": "gehst",
+                "3p": "gehen",
+                "3s": "geht",
+            },
+            "preterite": {
+                "1p": "gingen",
+                "1s": "ging",
+                "2p": "gingt",
+                "2s": "gingst",
+                "3p": "gingen",
+                "3s": "ging",
+            },
+        },
+        "language_code": "de",
+        "lemma": "gehen",
+    },
+    "gelten": {
+        "extra_forms": {"partizip_ii": "gegolten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden gelten",
+                "1s": "werde gelten",
+                "2p": "werdet gelten",
+                "2s": "wirst gelten",
+                "3p": "werden gelten",
+                "3s": "wird gelten",
+            },
+            "perfect": {
+                "1p": "haben gegolten",
+                "1s": "habe gegolten",
+                "2p": "habt gegolten",
+                "2s": "hast gegolten",
+                "3p": "haben gegolten",
+                "3s": "hat gegolten",
+            },
+            "present": {
+                "1p": "gelten",
+                "1s": "gelte",
+                "2p": "geltet",
+                "2s": "giltst",
+                "3p": "gelten",
+                "3s": "gilt",
+            },
+            "preterite": {
+                "1p": "galten",
+                "1s": "galt",
+                "2p": "galtet",
+                "2s": "galtst",
+                "3p": "galten",
+                "3s": "galt",
+            },
+        },
+        "language_code": "de",
+        "lemma": "gelten",
+    },
+    "gewinnen": {
+        "extra_forms": {"partizip_ii": "gewonnen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden gewinnen",
+                "1s": "werde gewinnen",
+                "2p": "werdet gewinnen",
+                "2s": "wirst gewinnen",
+                "3p": "werden gewinnen",
+                "3s": "wird gewinnen",
+            },
+            "perfect": {
+                "1p": "haben gewonnen",
+                "1s": "habe gewonnen",
+                "2p": "habt gewonnen",
+                "2s": "hast gewonnen",
+                "3p": "haben gewonnen",
+                "3s": "hat gewonnen",
+            },
+            "present": {
+                "1p": "gewinnen",
+                "1s": "gewinne",
+                "2p": "gewinnt",
+                "2s": "gewinnst",
+                "3p": "gewinnen",
+                "3s": "gewinnt",
+            },
+            "preterite": {
+                "1p": "gewannen",
+                "1s": "gewann",
+                "2p": "gewannt",
+                "2s": "gewannst",
+                "3p": "gewannen",
+                "3s": "gewann",
+            },
+        },
+        "language_code": "de",
+        "lemma": "gewinnen",
+    },
+    "haben": {
+        "extra_forms": {"partizip_ii": "gehabt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden haben",
+                "1s": "werde haben",
+                "2p": "werdet haben",
+                "2s": "wirst haben",
+                "3p": "werden haben",
+                "3s": "wird haben",
+            },
+            "perfect": {
+                "1p": "haben gehabt",
+                "1s": "habe gehabt",
+                "2p": "habt gehabt",
+                "2s": "hast gehabt",
+                "3p": "haben gehabt",
+                "3s": "hat gehabt",
+            },
+            "present": {
+                "1p": "haben",
+                "1s": "habe",
+                "2p": "habt",
+                "2s": "hast",
+                "3p": "haben",
+                "3s": "hat",
+            },
+            "preterite": {
+                "1p": "hatten",
+                "1s": "hatte",
+                "2p": "hattet",
+                "2s": "hattest",
+                "3p": "hatten",
+                "3s": "hatte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "haben",
+    },
+    "halten": {
+        "extra_forms": {"partizip_ii": "gehalten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden halten",
+                "1s": "werde halten",
+                "2p": "werdet halten",
+                "2s": "wirst halten",
+                "3p": "werden halten",
+                "3s": "wird halten",
+            },
+            "perfect": {
+                "1p": "haben gehalten",
+                "1s": "habe gehalten",
+                "2p": "habt gehalten",
+                "2s": "hast gehalten",
+                "3p": "haben gehalten",
+                "3s": "hat gehalten",
+            },
+            "present": {
+                "1p": "halten",
+                "1s": "halte",
+                "2p": "haltet",
+                "2s": "hältst",
+                "3p": "halten",
+                "3s": "hält",
+            },
+            "preterite": {
+                "1p": "hielten",
+                "1s": "hielt",
+                "2p": "hieltet",
+                "2s": "hieltest",
+                "3p": "hielten",
+                "3s": "hielt",
+            },
+        },
+        "language_code": "de",
+        "lemma": "halten",
+    },
+    "helfen": {
+        "extra_forms": {"partizip_ii": "geholfen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden helfen",
+                "1s": "werde helfen",
+                "2p": "werdet helfen",
+                "2s": "wirst helfen",
+                "3p": "werden helfen",
+                "3s": "wird helfen",
+            },
+            "perfect": {
+                "1p": "haben geholfen",
+                "1s": "habe geholfen",
+                "2p": "habt geholfen",
+                "2s": "hast geholfen",
+                "3p": "haben geholfen",
+                "3s": "hat geholfen",
+            },
+            "present": {
+                "1p": "helfen",
+                "1s": "helfe",
+                "2p": "helft",
+                "2s": "hilfst",
+                "3p": "helfen",
+                "3s": "hilft",
+            },
+            "preterite": {
+                "1p": "halfen",
+                "1s": "half",
+                "2p": "halft",
+                "2s": "halfst",
+                "3p": "halfen",
+                "3s": "half",
+            },
+        },
+        "language_code": "de",
+        "lemma": "helfen",
+    },
+    "kennen": {
+        "extra_forms": {"partizip_ii": "gekannt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden kennen",
+                "1s": "werde kennen",
+                "2p": "werdet kennen",
+                "2s": "wirst kennen",
+                "3p": "werden kennen",
+                "3s": "wird kennen",
+            },
+            "perfect": {
+                "1p": "haben gekannt",
+                "1s": "habe gekannt",
+                "2p": "habt gekannt",
+                "2s": "hast gekannt",
+                "3p": "haben gekannt",
+                "3s": "hat gekannt",
+            },
+            "present": {
+                "1p": "kennen",
+                "1s": "kenne",
+                "2p": "kennt",
+                "2s": "kennst",
+                "3p": "kennen",
+                "3s": "kennt",
+            },
+            "preterite": {
+                "1p": "kannten",
+                "1s": "kannte",
+                "2p": "kanntet",
+                "2s": "kanntest",
+                "3p": "kannten",
+                "3s": "kannte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "kennen",
+    },
+    "kommen": {
+        "extra_forms": {"partizip_ii": "gekommen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden kommen",
+                "1s": "werde kommen",
+                "2p": "werdet kommen",
+                "2s": "wirst kommen",
+                "3p": "werden kommen",
+                "3s": "wird kommen",
+            },
+            "perfect": {
+                "1p": "sind gekommen",
+                "1s": "bin gekommen",
+                "2p": "seid gekommen",
+                "2s": "bist gekommen",
+                "3p": "sind gekommen",
+                "3s": "ist gekommen",
+            },
+            "present": {
+                "1p": "kommen",
+                "1s": "komme",
+                "2p": "kommt",
+                "2s": "kommst",
+                "3p": "kommen",
+                "3s": "kommt",
+            },
+            "preterite": {
+                "1p": "kamen",
+                "1s": "kam",
+                "2p": "kamt",
+                "2s": "kamst",
+                "3p": "kamen",
+                "3s": "kam",
+            },
+        },
+        "language_code": "de",
+        "lemma": "kommen",
+    },
+    "können": {
+        "extra_forms": {"partizip_ii": "gekonnt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden können",
+                "1s": "werde können",
+                "2p": "werdet können",
+                "2s": "wirst können",
+                "3p": "werden können",
+                "3s": "wird können",
+            },
+            "perfect": {
+                "1p": "haben gekonnt",
+                "1s": "habe gekonnt",
+                "2p": "habt gekonnt",
+                "2s": "hast gekonnt",
+                "3p": "haben gekonnt",
+                "3s": "hat gekonnt",
+            },
+            "present": {
+                "1p": "können",
+                "1s": "kann",
+                "2p": "könnt",
+                "2s": "kannst",
+                "3p": "können",
+                "3s": "kann",
+            },
+            "preterite": {
+                "1p": "konnten",
+                "1s": "konnte",
+                "2p": "konntet",
+                "2s": "konntest",
+                "3p": "konnten",
+                "3s": "konnte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "können",
+    },
+    "laden": {
+        "extra_forms": {"partizip_ii": "geladen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden laden",
+                "1s": "werde laden",
+                "2p": "werdet laden",
+                "2s": "wirst laden",
+                "3p": "werden laden",
+                "3s": "wird laden",
+            },
+            "perfect": {
+                "1p": "haben geladen",
+                "1s": "habe geladen",
+                "2p": "habt geladen",
+                "2s": "hast geladen",
+                "3p": "haben geladen",
+                "3s": "hat geladen",
+            },
+            "present": {
+                "1p": "laden",
+                "1s": "lade",
+                "2p": "ladet",
+                "2s": "lädst",
+                "3p": "laden",
+                "3s": "lädt",
+            },
+            "preterite": {
+                "1p": "luden",
+                "1s": "lud",
+                "2p": "ludet",
+                "2s": " ludst",
+                "3p": "luden",
+                "3s": "lud",
+            },
+        },
+        "language_code": "de",
+        "lemma": "laden",
+    },
+    "lassen": {
+        "extra_forms": {"partizip_ii": "gelassen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden lassen",
+                "1s": "werde lassen",
+                "2p": "werdet lassen",
+                "2s": "wirst lassen",
+                "3p": "werden lassen",
+                "3s": "wird lassen",
+            },
+            "perfect": {
+                "1p": "haben gelassen",
+                "1s": "habe gelassen",
+                "2p": "habt gelassen",
+                "2s": "hast gelassen",
+                "3p": "haben gelassen",
+                "3s": "hat gelassen",
+            },
+            "present": {
+                "1p": "lassen",
+                "1s": "lasse",
+                "2p": "lasst",
+                "2s": "lässt",
+                "3p": "lassen",
+                "3s": "lässt",
+            },
+            "preterite": {
+                "1p": "ließen",
+                "1s": "ließ",
+                "2p": "ließt",
+                "2s": "ließest",
+                "3p": "ließen",
+                "3s": "ließ",
+            },
+        },
+        "language_code": "de",
+        "lemma": "lassen",
+    },
+    "laufen": {
+        "extra_forms": {"partizip_ii": "gelaufen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden laufen",
+                "1s": "werde laufen",
+                "2p": "werdet laufen",
+                "2s": "wirst laufen",
+                "3p": "werden laufen",
+                "3s": "wird laufen",
+            },
+            "perfect": {
+                "1p": "sind gelaufen",
+                "1s": "bin gelaufen",
+                "2p": "seid gelaufen",
+                "2s": "bist gelaufen",
+                "3p": "sind gelaufen",
+                "3s": "ist gelaufen",
+            },
+            "present": {
+                "1p": "laufen",
+                "1s": "laufe",
+                "2p": "lauft",
+                "2s": "läufst",
+                "3p": "laufen",
+                "3s": "läuft",
+            },
+            "preterite": {
+                "1p": "liefen",
+                "1s": "lief",
+                "2p": "lieft",
+                "2s": "liefst",
+                "3p": "liefen",
+                "3s": "lief",
+            },
+        },
+        "language_code": "de",
+        "lemma": "laufen",
+    },
+    "lesen": {
+        "extra_forms": {"partizip_ii": "gelesen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden lesen",
+                "1s": "werde lesen",
+                "2p": "werdet lesen",
+                "2s": "wirst lesen",
+                "3p": "werden lesen",
+                "3s": "wird lesen",
+            },
+            "perfect": {
+                "1p": "haben gelesen",
+                "1s": "habe gelesen",
+                "2p": "habt gelesen",
+                "2s": "hast gelesen",
+                "3p": "haben gelesen",
+                "3s": "hat gelesen",
+            },
+            "present": {
+                "1p": "lesen",
+                "1s": "lese",
+                "2p": "lest",
+                "2s": "liest",
+                "3p": "lesen",
+                "3s": "liest",
+            },
+            "preterite": {
+                "1p": "lasen",
+                "1s": "las",
+                "2p": "last",
+                "2s": "last",
+                "3p": "lasen",
+                "3s": "las",
+            },
+        },
+        "language_code": "de",
+        "lemma": "lesen",
+    },
+    "liegen": {
+        "extra_forms": {"partizip_ii": "gelegen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden liegen",
+                "1s": "werde liegen",
+                "2p": "werdet liegen",
+                "2s": "wirst liegen",
+                "3p": "werden liegen",
+                "3s": "wird liegen",
+            },
+            "perfect": {
+                "1p": "haben gelegen",
+                "1s": "habe gelegen",
+                "2p": "habt gelegen",
+                "2s": "hast gelegen",
+                "3p": "haben gelegen",
+                "3s": "hat gelegen",
+            },
+            "present": {
+                "1p": "liegen",
+                "1s": "liege",
+                "2p": "liegt",
+                "2s": "liegst",
+                "3p": "liegen",
+                "3s": "liegt",
+            },
+            "preterite": {
+                "1p": "lagen",
+                "1s": "lag",
+                "2p": "lagt",
+                "2s": "lagst",
+                "3p": "lagen",
+                "3s": "lag",
+            },
+        },
+        "language_code": "de",
+        "lemma": "liegen",
+    },
+    "mögen": {
+        "extra_forms": {"partizip_ii": "gemocht"},
+        "forms": {
+            "future_i": {
+                "1p": "werden mögen",
+                "1s": "werde mögen",
+                "2p": "werdet mögen",
+                "2s": "wirst mögen",
+                "3p": "werden mögen",
+                "3s": "wird mögen",
+            },
+            "perfect": {
+                "1p": "haben gemocht",
+                "1s": "habe gemocht",
+                "2p": "habt gemocht",
+                "2s": "hast gemocht",
+                "3p": "haben gemocht",
+                "3s": "hat gemocht",
+            },
+            "present": {
+                "1p": "mögen",
+                "1s": "mag",
+                "2p": "mögt",
+                "2s": "magst",
+                "3p": "mögen",
+                "3s": "mag",
+            },
+            "preterite": {
+                "1p": "mochten",
+                "1s": "mochte",
+                "2p": "mochtet",
+                "2s": "mochtest",
+                "3p": "mochten",
+                "3s": "mochte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "mögen",
+    },
+    "müssen": {
+        "extra_forms": {"partizip_ii": "gemusst"},
+        "forms": {
+            "future_i": {
+                "1p": "werden müssen",
+                "1s": "werde müssen",
+                "2p": "werdet müssen",
+                "2s": "wirst müssen",
+                "3p": "werden müssen",
+                "3s": "wird müssen",
+            },
+            "perfect": {
+                "1p": "haben gemusst",
+                "1s": "habe gemusst",
+                "2p": "habt gemusst",
+                "2s": "hast gemusst",
+                "3p": "haben gemusst",
+                "3s": "hat gemusst",
+            },
+            "present": {
+                "1p": "müssen",
+                "1s": "muss",
+                "2p": "müsst",
+                "2s": "musst",
+                "3p": "müssen",
+                "3s": "muss",
+            },
+            "preterite": {
+                "1p": "mussten",
+                "1s": "musste",
+                "2p": "musstet",
+                "2s": "musstest",
+                "3p": "mussten",
+                "3s": "musste",
+            },
+        },
+        "language_code": "de",
+        "lemma": "müssen",
+    },
+    "nehmen": {
+        "extra_forms": {"partizip_ii": "genommen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden nehmen",
+                "1s": "werde nehmen",
+                "2p": "werdet nehmen",
+                "2s": "wirst nehmen",
+                "3p": "werden nehmen",
+                "3s": "wird nehmen",
+            },
+            "perfect": {
+                "1p": "haben genommen",
+                "1s": "habe genommen",
+                "2p": "habt genommen",
+                "2s": "hast genommen",
+                "3p": "haben genommen",
+                "3s": "hat genommen",
+            },
+            "present": {
+                "1p": "nehmen",
+                "1s": "nehme",
+                "2p": "nehmt",
+                "2s": "nimmst",
+                "3p": "nehmen",
+                "3s": "nimmt",
+            },
+            "preterite": {
+                "1p": "nahmen",
+                "1s": "nahm",
+                "2p": "nahmt",
+                "2s": "nahmst",
+                "3p": "nahmen",
+                "3s": "nahm",
+            },
+        },
+        "language_code": "de",
+        "lemma": "nehmen",
+    },
+    "nennen": {
+        "extra_forms": {"partizip_ii": "genannt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden nennen",
+                "1s": "werde nennen",
+                "2p": "werdet nennen",
+                "2s": "wirst nennen",
+                "3p": "werden nennen",
+                "3s": "wird nennen",
+            },
+            "perfect": {
+                "1p": "haben genannt",
+                "1s": "habe genannt",
+                "2p": "habt genannt",
+                "2s": "hast genannt",
+                "3p": "haben genannt",
+                "3s": "hat genannt",
+            },
+            "present": {
+                "1p": "nennen",
+                "1s": "nenne",
+                "2p": "nennt",
+                "2s": "nennst",
+                "3p": "nennen",
+                "3s": "nennt",
+            },
+            "preterite": {
+                "1p": "nannten",
+                "1s": "nannte",
+                "2p": "nanntet",
+                "2s": "nanntest",
+                "3p": "nannten",
+                "3s": "nannte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "nennen",
+    },
+    "raten": {
+        "extra_forms": {"partizip_ii": "geraten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden raten",
+                "1s": "werde raten",
+                "2p": "werdet raten",
+                "2s": "wirst raten",
+                "3p": "werden raten",
+                "3s": "wird raten",
+            },
+            "perfect": {
+                "1p": "haben geraten",
+                "1s": "habe geraten",
+                "2p": "habt geraten",
+                "2s": "hast geraten",
+                "3p": "haben geraten",
+                "3s": "hat geraten",
+            },
+            "present": {
+                "1p": "raten",
+                "1s": "rate",
+                "2p": "ratet",
+                "2s": "rätst",
+                "3p": "raten",
+                "3s": "rät",
+            },
+            "preterite": {
+                "1p": "rieten",
+                "1s": "riet",
+                "2p": "rietet",
+                "2s": "rietest",
+                "3p": "rieten",
+                "3s": "riet",
+            },
+        },
+        "language_code": "de",
+        "lemma": "raten",
+    },
+    "reiten": {
+        "extra_forms": {"partizip_ii": "geritten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden reiten",
+                "1s": "werde reiten",
+                "2p": "werdet reiten",
+                "2s": "wirst reiten",
+                "3p": "werden reiten",
+                "3s": "wird reiten",
+            },
+            "perfect": {
+                "1p": "haben geritten",
+                "1s": "habe geritten",
+                "2p": "habt geritten",
+                "2s": "hast geritten",
+                "3p": "haben geritten",
+                "3s": "hat geritten",
+            },
+            "present": {
+                "1p": "reiten",
+                "1s": "reite",
+                "2p": "reitet",
+                "2s": "reitest",
+                "3p": "reiten",
+                "3s": "reitet",
+            },
+            "preterite": {
+                "1p": "ritten",
+                "1s": "ritt",
+                "2p": "rittet",
+                "2s": "rittest",
+                "3p": "ritten",
+                "3s": "ritt",
+            },
+        },
+        "language_code": "de",
+        "lemma": "reiten",
+    },
+    "rennen": {
+        "extra_forms": {"partizip_ii": "gerannt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden rennen",
+                "1s": "werde rennen",
+                "2p": "werdet rennen",
+                "2s": "wirst rennen",
+                "3p": "werden rennen",
+                "3s": "wird rennen",
+            },
+            "perfect": {
+                "1p": "sind gerannt",
+                "1s": "bin gerannt",
+                "2p": "seid gerannt",
+                "2s": "bist gerannt",
+                "3p": "sind gerannt",
+                "3s": "ist gerannt",
+            },
+            "present": {
+                "1p": "rennen",
+                "1s": "renne",
+                "2p": "rennt",
+                "2s": "rennst",
+                "3p": "rennen",
+                "3s": "rennt",
+            },
+            "preterite": {
+                "1p": "rannten",
+                "1s": "rannte",
+                "2p": "ranntet",
+                "2s": "ranntest",
+                "3p": "rannten",
+                "3s": "rannte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "rennen",
+    },
+    "rufen": {
+        "extra_forms": {"partizip_ii": "gerufen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden rufen",
+                "1s": "werde rufen",
+                "2p": "werdet rufen",
+                "2s": "wirst rufen",
+                "3p": "werden rufen",
+                "3s": "wird rufen",
+            },
+            "perfect": {
+                "1p": "haben gerufen",
+                "1s": "habe gerufen",
+                "2p": "habt gerufen",
+                "2s": "hast gerufen",
+                "3p": "haben gerufen",
+                "3s": "hat gerufen",
+            },
+            "present": {
+                "1p": "rufen",
+                "1s": "rufe",
+                "2p": "ruft",
+                "2s": "rufst",
+                "3p": "rufen",
+                "3s": "ruft",
+            },
+            "preterite": {
+                "1p": "riefen",
+                "1s": "rief",
+                "2p": "rieft",
+                "2s": "riefst",
+                "3p": "riefen",
+                "3s": "rief",
+            },
+        },
+        "language_code": "de",
+        "lemma": "rufen",
+    },
+    "scheinen": {
+        "extra_forms": {"partizip_ii": "geschienen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden scheinen",
+                "1s": "werde scheinen",
+                "2p": "werdet scheinen",
+                "2s": "wirst scheinen",
+                "3p": "werden scheinen",
+                "3s": "wird scheinen",
+            },
+            "perfect": {
+                "1p": "haben geschienen",
+                "1s": "habe geschienen",
+                "2p": "habt geschienen",
+                "2s": "hast geschienen",
+                "3p": "haben geschienen",
+                "3s": "hat geschienen",
+            },
+            "present": {
+                "1p": "scheinen",
+                "1s": "scheine",
+                "2p": "scheint",
+                "2s": "scheinst",
+                "3p": "scheinen",
+                "3s": "scheint",
+            },
+            "preterite": {
+                "1p": "schienen",
+                "1s": "schien",
+                "2p": "schient",
+                "2s": "schienst",
+                "3p": "schienen",
+                "3s": "schien",
+            },
+        },
+        "language_code": "de",
+        "lemma": "scheinen",
+    },
+    "schlafen": {
+        "extra_forms": {"partizip_ii": "geschlafen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schlafen",
+                "1s": "werde schlafen",
+                "2p": "werdet schlafen",
+                "2s": "wirst schlafen",
+                "3p": "werden schlafen",
+                "3s": "wird schlafen",
+            },
+            "perfect": {
+                "1p": "haben geschlafen",
+                "1s": "habe geschlafen",
+                "2p": "habt geschlafen",
+                "2s": "hast geschlafen",
+                "3p": "haben geschlafen",
+                "3s": "hat geschlafen",
+            },
+            "present": {
+                "1p": "schlafen",
+                "1s": "schlafe",
+                "2p": "schlaft",
+                "2s": "schläfst",
+                "3p": "schlafen",
+                "3s": "schläft",
+            },
+            "preterite": {
+                "1p": "schliefen",
+                "1s": "schlief",
+                "2p": "schlieft",
+                "2s": "schliefst",
+                "3p": "schliefen",
+                "3s": "schlief",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schlafen",
+    },
+    "schlagen": {
+        "extra_forms": {"partizip_ii": "geschlagen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schlagen",
+                "1s": "werde schlagen",
+                "2p": "werdet schlagen",
+                "2s": "wirst schlagen",
+                "3p": "werden schlagen",
+                "3s": "wird schlagen",
+            },
+            "perfect": {
+                "1p": "haben geschlagen",
+                "1s": "habe geschlagen",
+                "2p": "habt geschlagen",
+                "2s": "hast geschlagen",
+                "3p": "haben geschlagen",
+                "3s": "hat geschlagen",
+            },
+            "present": {
+                "1p": "schlagen",
+                "1s": "schlage",
+                "2p": "schlagt",
+                "2s": "schlägst",
+                "3p": "schlagen",
+                "3s": "schlägt",
+            },
+            "preterite": {
+                "1p": "schlugen",
+                "1s": "schlug",
+                "2p": "schlugt",
+                "2s": "schlugst",
+                "3p": "schlugen",
+                "3s": "schlug",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schlagen",
+    },
+    "schließen": {
+        "extra_forms": {"partizip_ii": "geschlossen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schließen",
+                "1s": "werde schließen",
+                "2p": "werdet schließen",
+                "2s": "wirst schließen",
+                "3p": "werden schließen",
+                "3s": "wird schließen",
+            },
+            "perfect": {
+                "1p": "haben geschlossen",
+                "1s": "habe geschlossen",
+                "2p": "habt geschlossen",
+                "2s": "hast geschlossen",
+                "3p": "haben geschlossen",
+                "3s": "hat geschlossen",
+            },
+            "present": {
+                "1p": "schließen",
+                "1s": "schließe",
+                "2p": "schließt",
+                "2s": "schließt",
+                "3p": "schließen",
+                "3s": "schließt",
+            },
+            "preterite": {
+                "1p": "schlossen",
+                "1s": "schloss",
+                "2p": "schlosst",
+                "2s": "schlossest",
+                "3p": "schlossen",
+                "3s": "schloss",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schließen",
+    },
+    "schneiden": {
+        "extra_forms": {"partizip_ii": "geschnitten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schneiden",
+                "1s": "werde schneiden",
+                "2p": "werdet schneiden",
+                "2s": "wirst schneiden",
+                "3p": "werden schneiden",
+                "3s": "wird schneiden",
+            },
+            "perfect": {
+                "1p": "haben geschnitten",
+                "1s": "habe geschnitten",
+                "2p": "habt geschnitten",
+                "2s": "hast geschnitten",
+                "3p": "haben geschnitten",
+                "3s": "hat geschnitten",
+            },
+            "present": {
+                "1p": "schneiden",
+                "1s": "schneide",
+                "2p": "schneidet",
+                "2s": "schneidest",
+                "3p": "schneiden",
+                "3s": "schneidet",
+            },
+            "preterite": {
+                "1p": "schnitten",
+                "1s": "schnitt",
+                "2p": "schnittet",
+                "2s": "schnittest",
+                "3p": "schnitten",
+                "3s": "schnitt",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schneiden",
+    },
+    "schreiben": {
+        "extra_forms": {"partizip_ii": "geschrieben"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schreiben",
+                "1s": "werde schreiben",
+                "2p": "werdet schreiben",
+                "2s": "wirst schreiben",
+                "3p": "werden schreiben",
+                "3s": "wird schreiben",
+            },
+            "perfect": {
+                "1p": "haben geschrieben",
+                "1s": "habe geschrieben",
+                "2p": "habt geschrieben",
+                "2s": "hast geschrieben",
+                "3p": "haben geschrieben",
+                "3s": "hat geschrieben",
+            },
+            "present": {
+                "1p": "schreiben",
+                "1s": "schreibe",
+                "2p": "schreibt",
+                "2s": "schreibst",
+                "3p": "schreiben",
+                "3s": "schreibt",
+            },
+            "preterite": {
+                "1p": "schreiben",
+                "1s": "schrieb",
+                "2p": "schriebt",
+                "2s": "schriebst",
+                "3p": "schrieben",
+                "3s": "schrieb",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schreiben",
+    },
+    "schwimmen": {
+        "extra_forms": {"partizip_ii": "geschwommen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden schwimmen",
+                "1s": "werde schwimmen",
+                "2p": "werdet schwimmen",
+                "2s": "wirst schwimmen",
+                "3p": "werden schwimmen",
+                "3s": "wird schwimmen",
+            },
+            "perfect": {
+                "1p": "haben geschwommen",
+                "1s": "habe geschwommen",
+                "2p": "habt geschwommen",
+                "2s": "hast geschwommen",
+                "3p": "haben geschwommen",
+                "3s": "hat geschwommen",
+            },
+            "present": {
+                "1p": "schwimmen",
+                "1s": "schwimme",
+                "2p": "schwimmt",
+                "2s": "schwimmst",
+                "3p": "schwimmen",
+                "3s": "schwimmt",
+            },
+            "preterite": {
+                "1p": "schwammen",
+                "1s": "schwamm",
+                "2p": "schwammt",
+                "2s": "schwammst",
+                "3p": "schwammen",
+                "3s": "schwamm",
+            },
+        },
+        "language_code": "de",
+        "lemma": "schwimmen",
+    },
+    "sehen": {
+        "extra_forms": {"partizip_ii": "gesehen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sehen",
+                "1s": "werde sehen",
+                "2p": "werdet sehen",
+                "2s": "wirst sehen",
+                "3p": "werden sehen",
+                "3s": "wird sehen",
+            },
+            "perfect": {
+                "1p": "haben gesehen",
+                "1s": "habe gesehen",
+                "2p": "habt gesehen",
+                "2s": "hast gesehen",
+                "3p": "haben gesehen",
+                "3s": "hat gesehen",
+            },
+            "present": {
+                "1p": "sehen",
+                "1s": "sehe",
+                "2p": "seht",
+                "2s": "siehst",
+                "3p": "sehen",
+                "3s": "sieht",
+            },
+            "preterite": {
+                "1p": "sahen",
+                "1s": "sah",
+                "2p": "saht",
+                "2s": "sahst",
+                "3p": "sahen",
+                "3s": "sah",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sehen",
+    },
+    "sein": {
+        "extra_forms": {"partizip_ii": "gewesen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sein",
+                "1s": "werde sein",
+                "2p": "werdet sein",
+                "2s": "wirst sein",
+                "3p": "werden sein",
+                "3s": "wird sein",
+            },
+            "perfect": {
+                "1p": "sind gewesen",
+                "1s": "bin gewesen",
+                "2p": "seid gewesen",
+                "2s": "bist gewesen",
+                "3p": "sind gewesen",
+                "3s": "ist gewesen",
+            },
+            "present": {
+                "1p": "sind",
+                "1s": "bin",
+                "2p": "seid",
+                "2s": "bist",
+                "3p": "sind",
+                "3s": "ist",
+            },
+            "preterite": {
+                "1p": "waren",
+                "1s": "war",
+                "2p": "wart",
+                "2s": "warst",
+                "3p": "waren",
+                "3s": "war",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sein",
+    },
+    "singen": {
+        "extra_forms": {"partizip_ii": "gesungen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden singen",
+                "1s": "werde singen",
+                "2p": "werdet singen",
+                "2s": "wirst singen",
+                "3p": "werden singen",
+                "3s": "wird singen",
+            },
+            "perfect": {
+                "1p": "haben gesungen",
+                "1s": "habe gesungen",
+                "2p": "habt gesungen",
+                "2s": "hast gesungen",
+                "3p": "haben gesungen",
+                "3s": "hat gesungen",
+            },
+            "present": {
+                "1p": "singen",
+                "1s": "singe",
+                "2p": "singt",
+                "2s": "singst",
+                "3p": "singen",
+                "3s": "singt",
+            },
+            "preterite": {
+                "1p": "sangen",
+                "1s": "sang",
+                "2p": "sangt",
+                "2s": "sangst",
+                "3p": "sangen",
+                "3s": "sang",
+            },
+        },
+        "language_code": "de",
+        "lemma": "singen",
+    },
+    "sitzen": {
+        "extra_forms": {"partizip_ii": "gesessen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sitzen",
+                "1s": "werde sitzen",
+                "2p": "werdet sitzen",
+                "2s": "wirst sitzen",
+                "3p": "werden sitzen",
+                "3s": "wird sitzen",
+            },
+            "perfect": {
+                "1p": "haben gesessen",
+                "1s": "habe gesessen",
+                "2p": "habt gesessen",
+                "2s": "hast gesessen",
+                "3p": "haben gesessen",
+                "3s": "hat gesessen",
+            },
+            "present": {
+                "1p": "sitzen",
+                "1s": "sitze",
+                "2p": "sitzt",
+                "2s": "sitzt",
+                "3p": "sitzen",
+                "3s": "sitzt",
+            },
+            "preterite": {
+                "1p": "saßen",
+                "1s": "saß",
+                "2p": "saßt",
+                "2s": "saßest",
+                "3p": "saßen",
+                "3s": "saß",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sitzen",
+    },
+    "sollen": {
+        "extra_forms": {"partizip_ii": "gesollt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sollen",
+                "1s": "werde sollen",
+                "2p": "werdet sollen",
+                "2s": "wirst sollen",
+                "3p": "werden sollen",
+                "3s": "wird sollen",
+            },
+            "perfect": {
+                "1p": "haben gesollt",
+                "1s": "habe gesollt",
+                "2p": "habt gesollt",
+                "2s": "hast gesollt",
+                "3p": "haben gesollt",
+                "3s": "hat gesollt",
+            },
+            "present": {
+                "1p": "sollen",
+                "1s": "soll",
+                "2p": "sollt",
+                "2s": "sollst",
+                "3p": "sollen",
+                "3s": "soll",
+            },
+            "preterite": {
+                "1p": "sollten",
+                "1s": "sollte",
+                "2p": "solltet",
+                "2s": "solltest",
+                "3p": "sollten",
+                "3s": "sollte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sollen",
+    },
+    "sprechen": {
+        "extra_forms": {"partizip_ii": "gesprochen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sprechen",
+                "1s": "werde sprechen",
+                "2p": "werdet sprechen",
+                "2s": "wirst sprechen",
+                "3p": "werden sprechen",
+                "3s": "wird sprechen",
+            },
+            "perfect": {
+                "1p": "haben gesprochen",
+                "1s": "habe gesprochen",
+                "2p": "habt gesprochen",
+                "2s": "hast gesprochen",
+                "3p": "haben gesprochen",
+                "3s": "hat gesprochen",
+            },
+            "present": {
+                "1p": "sprechen",
+                "1s": "spreche",
+                "2p": "sprecht",
+                "2s": "sprichst",
+                "3p": "sprechen",
+                "3s": "spricht",
+            },
+            "preterite": {
+                "1p": "sprachen",
+                "1s": "sprach",
+                "2p": "spracht",
+                "2s": "sprachst",
+                "3p": "sprachen",
+                "3s": "sprach",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sprechen",
+    },
+    "springen": {
+        "extra_forms": {"partizip_ii": "gesprungen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden springen",
+                "1s": "werde springen",
+                "2p": "werdet springen",
+                "2s": "wirst springen",
+                "3p": "werden springen",
+                "3s": "wird springen",
+            },
+            "perfect": {
+                "1p": "sind gesprungen",
+                "1s": "bin gesprungen",
+                "2p": "seid gesprungen",
+                "2s": "bist gesprungen",
+                "3p": "sind gesprungen",
+                "3s": "ist gesprungen",
+            },
+            "present": {
+                "1p": "springen",
+                "1s": "springe",
+                "2p": "springt",
+                "2s": "springst",
+                "3p": "springen",
+                "3s": "springt",
+            },
+            "preterite": {
+                "1p": "sprangen",
+                "1s": "sprang",
+                "2p": "sprangt",
+                "2s": "sprangst",
+                "3p": "sprangen",
+                "3s": "sprang",
+            },
+        },
+        "language_code": "de",
+        "lemma": "springen",
+    },
+    "stehen": {
+        "extra_forms": {"partizip_ii": "gestanden"},
+        "forms": {
+            "future_i": {
+                "1p": "werden stehen",
+                "1s": "werde stehen",
+                "2p": "werdet stehen",
+                "2s": "wirst stehen",
+                "3p": "werden stehen",
+                "3s": "wird stehen",
+            },
+            "perfect": {
+                "1p": "haben gestanden",
+                "1s": "habe gestanden",
+                "2p": "habt gestanden",
+                "2s": "hast gestanden",
+                "3p": "haben gestanden",
+                "3s": "hat gestanden",
+            },
+            "present": {
+                "1p": "stehen",
+                "1s": "stehe",
+                "2p": "steht",
+                "2s": "stehst",
+                "3p": "stehen",
+                "3s": "steht",
+            },
+            "preterite": {
+                "1p": "standen",
+                "1s": "stand",
+                "2p": "standet",
+                "2s": "standest",
+                "3p": "standen",
+                "3s": "stand",
+            },
+        },
+        "language_code": "de",
+        "lemma": "stehen",
+    },
+    "steigen": {
+        "extra_forms": {"partizip_ii": "gestiegen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden steigen",
+                "1s": "werde steigen",
+                "2p": "werdet steigen",
+                "2s": "wirst steigen",
+                "3p": "werden steigen",
+                "3s": "wird steigen",
+            },
+            "perfect": {
+                "1p": "sind gestiegen",
+                "1s": "bin gestiegen",
+                "2p": "seid gestiegen",
+                "2s": "bist gestiegen",
+                "3p": "sind gestiegen",
+                "3s": "ist gestiegen",
+            },
+            "present": {
+                "1p": "steigen",
+                "1s": "steige",
+                "2p": "steigt",
+                "2s": "steigst",
+                "3p": "steigen",
+                "3s": "steigt",
+            },
+            "preterite": {
+                "1p": "stiegen",
+                "1s": "stieg",
+                "2p": "stiegt",
+                "2s": "stiegst",
+                "3p": "stiegen",
+                "3s": "stieg",
+            },
+        },
+        "language_code": "de",
+        "lemma": "steigen",
+    },
+    "sterben": {
+        "extra_forms": {"partizip_ii": "gestorben"},
+        "forms": {
+            "future_i": {
+                "1p": "werden sterben",
+                "1s": "werde sterben",
+                "2p": "werdet sterben",
+                "2s": "wirst sterben",
+                "3p": "werden sterben",
+                "3s": "wird sterben",
+            },
+            "perfect": {
+                "1p": "sind gestorben",
+                "1s": "bin gestorben",
+                "2p": "seid gestorben",
+                "2s": "bist gestorben",
+                "3p": "sind gestorben",
+                "3s": "ist gestorben",
+            },
+            "present": {
+                "1p": "sterben",
+                "1s": "sterbe",
+                "2p": "sterbt",
+                "2s": "stirbst",
+                "3p": "sterben",
+                "3s": "stirbt",
+            },
+            "preterite": {
+                "1p": "starben",
+                "1s": "starb",
+                "2p": "starbt",
+                "2s": "starbst",
+                "3p": "starben",
+                "3s": "starb",
+            },
+        },
+        "language_code": "de",
+        "lemma": "sterben",
+    },
+    "stoßen": {
+        "extra_forms": {"partizip_ii": "gestoßen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden stoßen",
+                "1s": "werde stoßen",
+                "2p": "werdet stoßen",
+                "2s": "wirst stoßen",
+                "3p": "werden stoßen",
+                "3s": "wird stoßen",
+            },
+            "perfect": {
+                "1p": "haben gestoßen",
+                "1s": "habe gestoßen",
+                "2p": "habt gestoßen",
+                "2s": "hast gestoßen",
+                "3p": "haben gestoßen",
+                "3s": "hat gestoßen",
+            },
+            "present": {
+                "1p": "stoßen",
+                "1s": "stoße",
+                "2p": "stoßt",
+                "2s": "stößt",
+                "3p": "stoßen",
+                "3s": "stößt",
+            },
+            "preterite": {
+                "1p": "stießen",
+                "1s": "stieß",
+                "2p": "stießt",
+                "2s": "stießest",
+                "3p": "stießen",
+                "3s": "stieß",
+            },
+        },
+        "language_code": "de",
+        "lemma": "stoßen",
+    },
+    "streiten": {
+        "extra_forms": {"partizip_ii": "gestritten"},
+        "forms": {
+            "future_i": {
+                "1p": "werden streiten",
+                "1s": "werde streiten",
+                "2p": "werdet streiten",
+                "2s": "wirst streiten",
+                "3p": "werden streiten",
+                "3s": "wird streiten",
+            },
+            "perfect": {
+                "1p": "haben gestritten",
+                "1s": "habe gestritten",
+                "2p": "habt gestritten",
+                "2s": "hast gestritten",
+                "3p": "haben gestritten",
+                "3s": "hat gestritten",
+            },
+            "present": {
+                "1p": "streiten",
+                "1s": "streite",
+                "2p": "streitet",
+                "2s": "streitest",
+                "3p": "streiten",
+                "3s": "streitet",
+            },
+            "preterite": {
+                "1p": "stritten",
+                "1s": "stritt",
+                "2p": "strittet",
+                "2s": "strittest",
+                "3p": "stritten",
+                "3s": "stritt",
+            },
+        },
+        "language_code": "de",
+        "lemma": "streiten",
+    },
+    "tragen": {
+        "extra_forms": {"partizip_ii": "getragen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden tragen",
+                "1s": "werde tragen",
+                "2p": "werdet tragen",
+                "2s": "wirst tragen",
+                "3p": "werden tragen",
+                "3s": "wird tragen",
+            },
+            "perfect": {
+                "1p": "haben getragen",
+                "1s": "habe getragen",
+                "2p": "habt getragen",
+                "2s": "hast getragen",
+                "3p": "haben getragen",
+                "3s": "hat getragen",
+            },
+            "present": {
+                "1p": "tragen",
+                "1s": "trage",
+                "2p": "tragt",
+                "2s": "trägst",
+                "3p": "tragen",
+                "3s": "trägt",
+            },
+            "preterite": {
+                "1p": "trugen",
+                "1s": "trug",
+                "2p": "trugt",
+                "2s": "trugst",
+                "3p": "trugen",
+                "3s": "trug",
+            },
+        },
+        "language_code": "de",
+        "lemma": "tragen",
+    },
+    "treffen": {
+        "extra_forms": {"partizip_ii": "getroffen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden treffen",
+                "1s": "werde treffen",
+                "2p": "werdet treffen",
+                "2s": "wirst treffen",
+                "3p": "werden treffen",
+                "3s": "wird treffen",
+            },
+            "perfect": {
+                "1p": "haben getroffen",
+                "1s": "habe getroffen",
+                "2p": "habt getroffen",
+                "2s": "hast getroffen",
+                "3p": "haben getroffen",
+                "3s": "hat getroffen",
+            },
+            "present": {
+                "1p": "treffen",
+                "1s": "treffe",
+                "2p": "trefft",
+                "2s": "triffst",
+                "3p": "treffen",
+                "3s": "trifft",
+            },
+            "preterite": {
+                "1p": "trafen",
+                "1s": "traf",
+                "2p": "traft",
+                "2s": "trafst",
+                "3p": "trafen",
+                "3s": "traf",
+            },
+        },
+        "language_code": "de",
+        "lemma": "treffen",
+    },
+    "treiben": {
+        "extra_forms": {"partizip_ii": "getrieben"},
+        "forms": {
+            "future_i": {
+                "1p": "werden treiben",
+                "1s": "werde treiben",
+                "2p": "werdet treiben",
+                "2s": "wirst treiben",
+                "3p": "werden treiben",
+                "3s": "wird treiben",
+            },
+            "perfect": {
+                "1p": "haben getrieben",
+                "1s": "habe getrieben",
+                "2p": "habt getrieben",
+                "2s": "hast getrieben",
+                "3p": "haben getrieben",
+                "3s": "hat getrieben",
+            },
+            "present": {
+                "1p": "treiben",
+                "1s": "treibe",
+                "2p": "treibt",
+                "2s": "treibst",
+                "3p": "treiben",
+                "3s": "treibt",
+            },
+            "preterite": {
+                "1p": "trieben",
+                "1s": "trieb",
+                "2p": "triebt",
+                "2s": "triebst",
+                "3p": "trieben",
+                "3s": "trieb",
+            },
+        },
+        "language_code": "de",
+        "lemma": "treiben",
+    },
+    "trinken": {
+        "extra_forms": {"partizip_ii": "getrunken"},
+        "forms": {
+            "future_i": {
+                "1p": "werden trinken",
+                "1s": "werde trinken",
+                "2p": "werdet trinken",
+                "2s": "wirst trinken",
+                "3p": "werden trinken",
+                "3s": "wird trinken",
+            },
+            "perfect": {
+                "1p": "haben getrunken",
+                "1s": "habe getrunken",
+                "2p": "habt getrunken",
+                "2s": "hast getrunken",
+                "3p": "haben getrunken",
+                "3s": "hat getrunken",
+            },
+            "present": {
+                "1p": "trinken",
+                "1s": "trinke",
+                "2p": "trinkt",
+                "2s": "trinkst",
+                "3p": "trinken",
+                "3s": "trinkt",
+            },
+            "preterite": {
+                "1p": "tranken",
+                "1s": "trank",
+                "2p": "trankt",
+                "2s": "trankst",
+                "3p": "tranken",
+                "3s": "trank",
+            },
+        },
+        "language_code": "de",
+        "lemma": "trinken",
+    },
+    "tun": {
+        "extra_forms": {"partizip_ii": "getan"},
+        "forms": {
+            "future_i": {
+                "1p": "werden tun",
+                "1s": "werde tun",
+                "2p": "werdet tun",
+                "2s": "wirst tun",
+                "3p": "werden tun",
+                "3s": "wird tun",
+            },
+            "perfect": {
+                "1p": "haben getan",
+                "1s": "habe getan",
+                "2p": "habt getan",
+                "2s": "hast getan",
+                "3p": "haben getan",
+                "3s": "hat getan",
+            },
+            "present": {
+                "1p": "tun",
+                "1s": "tue",
+                "2p": "tut",
+                "2s": "tust",
+                "3p": "tun",
+                "3s": "tut",
+            },
+            "preterite": {
+                "1p": "taten",
+                "1s": "tat",
+                "2p": "tatet",
+                "2s": "tatst",
+                "3p": "taten",
+                "3s": "tat",
+            },
+        },
+        "language_code": "de",
+        "lemma": "tun",
+    },
+    "vergessen": {
+        "extra_forms": {"partizip_ii": "vergessen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden vergessen",
+                "1s": "werde vergessen",
+                "2p": "werdet vergessen",
+                "2s": "wirst vergessen",
+                "3p": "werden vergessen",
+                "3s": "wird vergessen",
+            },
+            "perfect": {
+                "1p": "haben vergessen",
+                "1s": "habe vergessen",
+                "2p": "habt vergessen",
+                "2s": "hast vergessen",
+                "3p": "haben vergessen",
+                "3s": "hat vergessen",
+            },
+            "present": {
+                "1p": "vergessen",
+                "1s": "vergesse",
+                "2p": "vergesst",
+                "2s": "vergisst",
+                "3p": "vergessen",
+                "3s": "vergisst",
+            },
+            "preterite": {
+                "1p": "vergaßen",
+                "1s": "vergaß",
+                "2p": "vergaßt",
+                "2s": "vergaßt",
+                "3p": "vergaßen",
+                "3s": "vergaß",
+            },
+        },
+        "language_code": "de",
+        "lemma": "vergessen",
+    },
+    "wachsen": {
+        "extra_forms": {"partizip_ii": "gewachsen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden wachsen",
+                "1s": "werde wachsen",
+                "2p": "werdet wachsen",
+                "2s": "wirst wachsen",
+                "3p": "werden wachsen",
+                "3s": "wird wachsen",
+            },
+            "perfect": {
+                "1p": "sind gewachsen",
+                "1s": "bin gewachsen",
+                "2p": "seid gewachsen",
+                "2s": "bist gewachsen",
+                "3p": "sind gewachsen",
+                "3s": "ist gewachsen",
+            },
+            "present": {
+                "1p": "wachsen",
+                "1s": "wachse",
+                "2p": "wächst",
+                "2s": "wächst",
+                "3p": "wachsen",
+                "3s": "wächst",
+            },
+            "preterite": {
+                "1p": "wuchsen",
+                "1s": "wuchs",
+                "2p": "wuchst",
+                "2s": "wuchs(e)st",
+                "3p": "wuchsen",
+                "3s": "wuchs",
+            },
+        },
+        "language_code": "de",
+        "lemma": "wachsen",
+    },
+    "waschen": {
+        "extra_forms": {"partizip_ii": "gewaschen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden waschen",
+                "1s": "werde waschen",
+                "2p": "werdet waschen",
+                "2s": "wirst waschen",
+                "3p": "werden waschen",
+                "3s": "wird waschen",
+            },
+            "perfect": {
+                "1p": "haben gewaschen",
+                "1s": "habe gewaschen",
+                "2p": "habt gewaschen",
+                "2s": "hast gewaschen",
+                "3p": "haben gewaschen",
+                "3s": "hat gewaschen",
+            },
+            "present": {
+                "1p": "waschen",
+                "1s": "wasche",
+                "2p": "wascht",
+                "2s": "wäschst",
+                "3p": "waschen",
+                "3s": "wäscht",
+            },
+            "preterite": {
+                "1p": "wuschen",
+                "1s": "wusch",
+                "2p": "wuscht",
+                "2s": "wuschest",
+                "3p": "wuschen",
+                "3s": "wusch",
+            },
+        },
+        "language_code": "de",
+        "lemma": "waschen",
+    },
+    "werden": {
+        "extra_forms": {"partizip_ii": "geworden"},
+        "forms": {
+            "future_i": {
+                "1p": "werden werden",
+                "1s": "werde werden",
+                "2p": "werdet werden",
+                "2s": "wirst werden",
+                "3p": "werden werden",
+                "3s": "wird werden",
+            },
+            "perfect": {
+                "1p": "sind geworden",
+                "1s": "bin geworden",
+                "2p": "seid geworden",
+                "2s": "bist geworden",
+                "3p": "sind geworden",
+                "3s": "ist geworden",
+            },
+            "present": {
+                "1p": "werden",
+                "1s": "werde",
+                "2p": "werdet",
+                "2s": "wirst",
+                "3p": "werden",
+                "3s": "wird",
+            },
+            "preterite": {
+                "1p": "wurden",
+                "1s": "wurde",
+                "2p": "wurdet",
+                "2s": "wurdest",
+                "3p": "wurden",
+                "3s": "wurde",
+            },
+        },
+        "language_code": "de",
+        "lemma": "werden",
+    },
+    "werfen": {
+        "extra_forms": {"partizip_ii": "geworfen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden werfen",
+                "1s": "werde werfen",
+                "2p": "werdet werfen",
+                "2s": "wirst werfen",
+                "3p": "werden werfen",
+                "3s": "wird werfen",
+            },
+            "perfect": {
+                "1p": "haben geworfen",
+                "1s": "habe geworfen",
+                "2p": "habt geworfen",
+                "2s": "hast geworfen",
+                "3p": "haben geworfen",
+                "3s": "hat geworfen",
+            },
+            "present": {
+                "1p": "werfen",
+                "1s": "werfe",
+                "2p": "werft",
+                "2s": "wirfst",
+                "3p": "werfen",
+                "3s": "wirft",
+            },
+            "preterite": {
+                "1p": "warfen",
+                "1s": "warf",
+                "2p": "warft",
+                "2s": "warfst",
+                "3p": "warfen",
+                "3s": "warf",
+            },
+        },
+        "language_code": "de",
+        "lemma": "werfen",
+    },
+    "wissen": {
+        "extra_forms": {"partizip_ii": "gewusst"},
+        "forms": {
+            "future_i": {
+                "1p": "werden wissen",
+                "1s": "werde wissen",
+                "2p": "werdet wissen",
+                "2s": "wirst wissen",
+                "3p": "werden wissen",
+                "3s": "wird wissen",
+            },
+            "perfect": {
+                "1p": "haben gewusst",
+                "1s": "habe gewusst",
+                "2p": "habt gewusst",
+                "2s": "hast gewusst",
+                "3p": "haben gewusst",
+                "3s": "hat gewusst",
+            },
+            "present": {
+                "1p": "wissen",
+                "1s": "weiß",
+                "2p": "wisst",
+                "2s": "weißt",
+                "3p": "wissen",
+                "3s": "weiß",
+            },
+            "preterite": {
+                "1p": "wussten",
+                "1s": "wusste",
+                "2p": "wusstet",
+                "2s": "wusstest",
+                "3p": "wussten",
+                "3s": "wusste",
+            },
+        },
+        "language_code": "de",
+        "lemma": "wissen",
+    },
+    "wollen": {
+        "extra_forms": {"partizip_ii": "gewollt"},
+        "forms": {
+            "future_i": {
+                "1p": "werden wollen",
+                "1s": "werde wollen",
+                "2p": "werdet wollen",
+                "2s": "wirst wollen",
+                "3p": "werden wollen",
+                "3s": "wird wollen",
+            },
+            "perfect": {
+                "1p": "haben gewollt",
+                "1s": "habe gewollt",
+                "2p": "habt gewollt",
+                "2s": "hast gewollt",
+                "3p": "haben gewollt",
+                "3s": "hat gewollt",
+            },
+            "present": {
+                "1p": "wollen",
+                "1s": "will",
+                "2p": "wollt",
+                "2s": "willst",
+                "3p": "wollen",
+                "3s": "will",
+            },
+            "preterite": {
+                "1p": "wollten",
+                "1s": "wollte",
+                "2p": "wolltet",
+                "2s": "wolltest",
+                "3p": "wollten",
+                "3s": "wollte",
+            },
+        },
+        "language_code": "de",
+        "lemma": "wollen",
+    },
+    "ziehen": {
+        "extra_forms": {"partizip_ii": "gezogen"},
+        "forms": {
+            "future_i": {
+                "1p": "werden ziehen",
+                "1s": "werde ziehen",
+                "2p": "werdet ziehen",
+                "2s": "wirst ziehen",
+                "3p": "werden ziehen",
+                "3s": "wird ziehen",
+            },
+            "perfect": {
+                "1p": "haben gezogen",
+                "1s": "habe gezogen",
+                "2p": "habt gezogen",
+                "2s": "hast gezogen",
+                "3p": "haben gezogen",
+                "3s": "hat gezogen",
+            },
+            "present": {
+                "1p": "ziehen",
+                "1s": "ziehe",
+                "2p": "zieht",
+                "2s": "ziehst",
+                "3p": "ziehen",
+                "3s": "zieht",
+            },
+            "preterite": {
+                "1p": "zogen",
+                "1s": "zog",
+                "2p": "zogen",
+                "2s": "zogst",
+                "3p": "zogen",
+                "3s": "zog",
+            },
+        },
+        "language_code": "de",
+        "lemma": "ziehen",
+    },
 }

--- a/src/langtools/de/utils.py
+++ b/src/langtools/de/utils.py
@@ -107,6 +107,7 @@ def detect_gender_from_article(article: str) -> str:
 
     return ""
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a German subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_german_text(text.strip().lower())
@@ -123,4 +124,3 @@ def strip_subject_pronoun(text: str) -> str:
         if normalized.startswith(pronoun):
             return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/langtools/en/grammatical_words.py
+++ b/src/langtools/en/grammatical_words.py
@@ -93,7 +93,9 @@ ENGLISH_AUXILIARY_VERBS: Final[list[str]] = [
     "may",
     "might",
     "must",
+    "ought",
     "can",
+    "cannot",
     "could",
 ]
 

--- a/src/langtools/es/utils.py
+++ b/src/langtools/es/utils.py
@@ -130,6 +130,7 @@ def detect_gender_from_word(word: str) -> Optional["SpanishGender"]:
 
     return None
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a Spanish subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_spanish_text(text.strip().lower())
@@ -139,7 +140,7 @@ def strip_subject_pronoun(text: str) -> str:
     combined_pronouns = ["él/ella ", "ella/él ", "el/ella ", "ella/el ", "él / ella ", "ella / él "]
     for pronoun in combined_pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
 
     pronouns = [
         "yo ",
@@ -159,6 +160,5 @@ def strip_subject_pronoun(text: str) -> str:
     ]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/langtools/fr/verb_forms.py
+++ b/src/langtools/fr/verb_forms.py
@@ -18,4 +18,3 @@ def get_verb_forms_config() -> dict:
             "single generic past tense."
         ),
     }
-

--- a/src/langtools/kn/utils.py
+++ b/src/langtools/kn/utils.py
@@ -98,6 +98,7 @@ def clean_form(text: str) -> List[str]:
 
     return cleaned_forms
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a Kannada subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_kannada_text(text.strip().lower())
@@ -107,11 +108,10 @@ def strip_subject_pronoun(text: str) -> str:
     combined_pronouns = ["ಅವನು/ಅವಳು ", "ಅವಳು/ಅವನು ", "ಅವನು / ಅವಳು ", "ಅವಳು / ಅವನು "]
     for pronoun in combined_pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
 
     pronouns = ["ನಾನು ", "ನೀನು ", "ಅವನು ", "ಅವಳು ", "ಅದು ", "ನಾವು ", "ನೀವು ", "ಅವರು "]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/langtools/lt/utils.py
+++ b/src/langtools/lt/utils.py
@@ -127,6 +127,7 @@ def clean_form(text: str) -> List[str]:
 
     return cleaned_forms
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a Lithuanian subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_lithuanian_text(text.strip().lower())
@@ -136,11 +137,10 @@ def strip_subject_pronoun(text: str) -> str:
     combined_pronouns = ["jis/ji ", "ji/jis ", "jis / ji ", "ji / jis "]
     for pronoun in combined_pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
 
     pronouns = ["aš ", "tu ", "jis ", "ji ", "mes ", "jūs ", "jie ", "jos "]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/langtools/nl/utils.py
+++ b/src/langtools/nl/utils.py
@@ -12,7 +12,21 @@ def strip_subject_pronoun(text: str) -> str:
         if normalized.startswith(pronoun):
             return normalized[len(pronoun) :].strip()
 
-    pronouns = ["ik ", "jij ", "je ", "u ", "hij ", "zij ", "ze ", "het ", "wij ", "we ", "jullie ", "zij ", "ze "]
+    pronouns = [
+        "ik ",
+        "jij ",
+        "je ",
+        "u ",
+        "hij ",
+        "zij ",
+        "ze ",
+        "het ",
+        "wij ",
+        "we ",
+        "jullie ",
+        "zij ",
+        "ze ",
+    ]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
             return normalized[len(pronoun) :].strip()

--- a/src/langtools/pt/utils.py
+++ b/src/langtools/pt/utils.py
@@ -12,7 +12,22 @@ def strip_subject_pronoun(text: str) -> str:
         if normalized.startswith(pronoun):
             return normalized[len(pronoun) :].strip()
 
-    pronouns = ["eu ", "tu ", "ele ", "ela ", "você ", "voce ", "nós ", "nos ", "vós ", "vos ", "vocês ", "voces ", "eles ", "elas "]
+    pronouns = [
+        "eu ",
+        "tu ",
+        "ele ",
+        "ela ",
+        "você ",
+        "voce ",
+        "nós ",
+        "nos ",
+        "vós ",
+        "vos ",
+        "vocês ",
+        "voces ",
+        "eles ",
+        "elas ",
+    ]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
             return normalized[len(pronoun) :].strip()

--- a/src/langtools/uk/utils.py
+++ b/src/langtools/uk/utils.py
@@ -93,6 +93,7 @@ def clean_form(text: str) -> List[str]:
 
     return cleaned_forms
 
+
 def strip_subject_pronoun(text: str) -> str:
     """Strip a Ukrainian subject pronoun from the beginning of a verb phrase."""
     normalized = normalize_ukrainian_text(text.strip().lower())
@@ -102,11 +103,10 @@ def strip_subject_pronoun(text: str) -> str:
     combined_pronouns = ["він/вона ", "вона/він ", "він / вона ", "вона / він "]
     for pronoun in combined_pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
 
     pronouns = ["я ", "ти ", "він ", "вона ", "воно ", "ми ", "ви ", "вони "]
     for pronoun in pronouns:
         if normalized.startswith(pronoun):
-            return normalized[len(pronoun):].strip()
+            return normalized[len(pronoun) :].strip()
     return normalized
-

--- a/src/storage/connection_pool.py
+++ b/src/storage/connection_pool.py
@@ -16,7 +16,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from storage.backend.config import BackendType, DataSourceConfig
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/storage/crud/derivative_form.py
+++ b/src/storage/crud/derivative_form.py
@@ -530,6 +530,7 @@ def add_complete_word_entry(
     translations: Optional[object] = None,  # Can be TranslationSet or None
     chinese_translation: Optional[str] = None,
     french_translation: Optional[str] = None,
+    spanish_translation: Optional[str] = None,
     korean_translation: Optional[str] = None,
     swahili_translation: Optional[str] = None,
     lithuanian_translation: Optional[str] = None,
@@ -561,6 +562,7 @@ def add_complete_word_entry(
         if isinstance(translations, TranslationSet):
             chinese_translation = translations.chinese.text if translations.chinese else None
             french_translation = translations.french.text if translations.french else None
+            spanish_translation = translations.spanish.text if translations.spanish else None
             korean_translation = translations.korean.text if translations.korean else None
             swahili_translation = translations.swahili.text if translations.swahili else None
             lithuanian_translation = (
@@ -585,6 +587,7 @@ def add_complete_word_entry(
         tags=tags,
         chinese_translation=chinese_translation,
         french_translation=french_translation,
+        spanish_translation=spanish_translation,
         korean_translation=korean_translation,
         swahili_translation=swahili_translation,
         lithuanian_translation=lithuanian_translation,

--- a/src/storage/crud/lemma.py
+++ b/src/storage/crud/lemma.py
@@ -3,10 +3,12 @@
 import json
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from storage.crud.operation_log import log_translation_change
 from storage.models.schema import DerivativeForm, Lemma, LemmaTranslation
+from storage.translation_helpers import set_translation
 from storage.utils.guid import generate_guid
 
 
@@ -21,6 +23,7 @@ def add_lemma(
     tags: Optional[List[str]] = None,
     chinese_translation: Optional[str] = None,
     french_translation: Optional[str] = None,
+    spanish_translation: Optional[str] = None,
     korean_translation: Optional[str] = None,
     swahili_translation: Optional[str] = None,
     lithuanian_translation: Optional[str] = None,
@@ -66,12 +69,6 @@ def add_lemma(
         difficulty_level=difficulty_level,
         frequency_rank=frequency_rank,
         tags=tags_json,
-        chinese_translation=chinese_translation,
-        french_translation=french_translation,
-        korean_translation=korean_translation,
-        swahili_translation=swahili_translation,
-        lithuanian_translation=lithuanian_translation,
-        vietnamese_translation=vietnamese_translation,
         confidence=confidence,
         verified=verified,
         notes=notes,
@@ -79,18 +76,24 @@ def add_lemma(
     session.add(lemma)
     session.flush()
 
-    # Log translation additions
+    # Translations go to the LemmaTranslation table via set_translation. The
+    # legacy Lemma.<language>_translation columns are gone -- that table is the
+    # only home for translations.
+    # TODO: replace the per-language keyword arguments with a single
+    # translations dict keyed by language code.
     translation_map = {
-        "zh": chinese_translation,
+        "lt": lithuanian_translation,
+        "es": spanish_translation,
         "fr": french_translation,
+        "zh": chinese_translation,
         "ko": korean_translation,
         "sw": swahili_translation,
-        "lt": lithuanian_translation,
         "vi": vietnamese_translation,
     }
 
     for lang_code, translation in translation_map.items():
         if translation:
+            set_translation(session, lemma, lang_code, translation)
             log_translation_change(
                 session=session,
                 source=source or "lemma-crud/add",
@@ -116,6 +119,7 @@ def update_lemma(
     tags: Optional[List[str]] = None,
     chinese_translation: Optional[str] = None,
     french_translation: Optional[str] = None,
+    spanish_translation: Optional[str] = None,
     korean_translation: Optional[str] = None,
     swahili_translation: Optional[str] = None,
     lithuanian_translation: Optional[str] = None,
@@ -137,22 +141,25 @@ def update_lemma(
     if not lemma:
         return False
 
-    # Map of translation parameters to language codes
+    # TODO: replace the per-language keyword arguments on add_lemma/update_lemma
+    # with a single translations dict keyed by language code, so adding a
+    # language does not mean touching every signature.
     translation_updates = {
-        "zh": ("chinese_translation", chinese_translation),
-        "fr": ("french_translation", french_translation),
-        "ko": ("korean_translation", korean_translation),
-        "sw": ("swahili_translation", swahili_translation),
-        "lt": ("lithuanian_translation", lithuanian_translation),
-        "vi": ("vietnamese_translation", vietnamese_translation),
+        "lt": lithuanian_translation,
+        "es": spanish_translation,
+        "fr": french_translation,
+        "zh": chinese_translation,
+        "ko": korean_translation,
+        "sw": swahili_translation,
+        "vi": vietnamese_translation,
     }
 
-    # Track translation changes for logging
-    for lang_code, (field_name, new_value) in translation_updates.items():
+    # Translations live in LemmaTranslation; set_translation returns the
+    # previous value so the change can still be logged.
+    for lang_code, new_value in translation_updates.items():
         if new_value is not None:
-            old_value = getattr(lemma, field_name, None)
+            old_value, _ = set_translation(session, lemma, lang_code, new_value)
             if old_value != new_value:
-                # Log the translation change
                 log_translation_change(
                     session=session,
                     source=source or "lemma-crud/update",
@@ -177,18 +184,7 @@ def update_lemma(
         lemma.frequency_rank = frequency_rank
     if tags is not None:
         lemma.tags = json.dumps(tags)
-    if chinese_translation is not None:
-        lemma.chinese_translation = chinese_translation
-    if french_translation is not None:
-        lemma.french_translation = french_translation
-    if korean_translation is not None:
-        lemma.korean_translation = korean_translation
-    if swahili_translation is not None:
-        lemma.swahili_translation = swahili_translation
-    if lithuanian_translation is not None:
-        lemma.lithuanian_translation = lithuanian_translation
-    if vietnamese_translation is not None:
-        lemma.vietnamese_translation = vietnamese_translation
+    # Translations were written to LemmaTranslation above.
     if confidence is not None:
         lemma.confidence = confidence
     if verified is not None:
@@ -227,6 +223,19 @@ def get_lemmas_without_subtypes(session: Session, limit: int = 100) -> List[Lemm
     return result
 
 
+def _has_translation_clause(language_code: str) -> Any:
+    """Return a filter clause matching lemmas that have a translation in ``language_code``."""
+    return (
+        select(LemmaTranslation.id)
+        .where(
+            LemmaTranslation.lemma_id == Lemma.id,
+            LemmaTranslation.language_code == language_code,
+            LemmaTranslation.translation != "",
+        )
+        .exists()
+    )
+
+
 def get_all_subtypes(session: Session, lang: Optional[str] = None) -> List[str]:
     """Get all pos_subtypes that have lemmas with GUIDs."""
     query = (
@@ -236,7 +245,7 @@ def get_all_subtypes(session: Session, lang: Optional[str] = None) -> List[str]:
     )
 
     if lang == "chinese":
-        query = query.filter(Lemma.chinese_translation != None)
+        query = query.filter(_has_translation_clause("zh"))
 
     subtypes = query.distinct().all()
     return [subtype[0] for subtype in subtypes if subtype[0]]
@@ -248,7 +257,7 @@ def get_lemmas_by_subtype(
     """Get all lemmas for a specific subtype, ordered by GUID."""
     query = session.query(Lemma).filter(Lemma.pos_subtype == pos_subtype).filter(Lemma.guid != None)
     if lang == "chinese":
-        query = query.filter(Lemma.chinese_translation != None)
+        query = query.filter(_has_translation_clause("zh"))
 
     result: list[Lemma] = query.order_by(Lemma.guid).all()
     return result

--- a/src/storage/crud/lemma_embedding.py
+++ b/src/storage/crud/lemma_embedding.py
@@ -113,7 +113,8 @@ def nearest_lemma_embeddings(
         )
         params["min_similarity"] = min_similarity
 
-    sql = text(f"""
+    sql = text(
+        f"""
         SELECT
             e.lemma_id,
             l.lemma_text,
@@ -128,7 +129,8 @@ def nearest_lemma_embeddings(
         WHERE {" AND ".join(where_fragments)}
         ORDER BY e.embedding <=> CAST(:query_vector AS vector)
         LIMIT :limit
-        """)
+        """
+    )
 
     rows = session.execute(sql, params).all()
     matches: list[LemmaEmbeddingMatch] = []

--- a/src/storage/migrate.py
+++ b/src/storage/migrate.py
@@ -326,13 +326,8 @@ def convert_sqlalchemy_lemma_to_jsonl(lemma: Any, session: Any = None) -> Any:
         difficulty_level=lemma.difficulty_level,
         frequency_rank=lemma.frequency_rank,
         tags=lemma.tags,
-        # Legacy translation fields
-        chinese_translation=lemma.chinese_translation,
-        french_translation=lemma.french_translation,
-        korean_translation=lemma.korean_translation,
-        swahili_translation=lemma.swahili_translation,
-        lithuanian_translation=lemma.lithuanian_translation,
-        vietnamese_translation=lemma.vietnamese_translation,
+        # Translations are carried in the `translations` dict below, built from
+        # LemmaTranslation; the JSONL model's per-language fields are left unset.
         # Metadata
         disambiguation=lemma.disambiguation,
         confidence=lemma.confidence,

--- a/src/storage/migrate_to_lemma_translations.py
+++ b/src/storage/migrate_to_lemma_translations.py
@@ -23,7 +23,9 @@ from typing import Dict
 from sqlalchemy.orm import Session
 from storage.database import Lemma, LemmaTranslation, create_database_session
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Mapping of old column names to language codes

--- a/src/storage/models/enums.py
+++ b/src/storage/models/enums.py
@@ -221,7 +221,6 @@ class GrammaticalForm(enum.Enum):
     ADJECTIVE_COMPARATIVE = "adjective/comparative"
     ADJECTIVE_SUPERLATIVE = "adjective/superlative"
 
-
     # Adverb forms
     ADVERB_POSITIVE = "adverb/positive"
     ADVERB_COMPARATIVE = "adverb/comparative"
@@ -229,7 +228,6 @@ class GrammaticalForm(enum.Enum):
 
     # Language-specific adverb base forms (invariant adverbs)
     ADVERB_KO_BASE = "adverb/ko_base"
-
 
     # Pronoun forms - Korean (simplified)
     # Word itself indicates person/number/formality; tag indicates function
@@ -249,27 +247,22 @@ class GrammaticalForm(enum.Enum):
     DETERMINER = "determiner/base"
     ARTICLE = "article/base"
 
-
     # Korean numerals (native Korean vs Sino-Korean systems)
     NUMERAL_KO_NATIVE = "numeral/ko_native"  # 하나, 둘, 셋 (native Korean, for counting)
     NUMERAL_KO_SINO = "numeral/ko_sino"  # 일, 이, 삼 (Sino-Korean, for dates/numbers)
     NUMERAL_KO_ORDINAL = "numeral/ko_ordinal"  # 첫째, 둘째, 셋째
 
-
     # Kannada noun forms (singular/plural only)
     NOUN_KN_SINGULAR = "noun/kn_singular"
     NOUN_KN_PLURAL = "noun/kn_plural"
-
 
     # Estonian noun forms (singular/plural only - no grammatical gender)
     NOUN_ET_SINGULAR = "noun/et_singular"
     NOUN_ET_PLURAL = "noun/et_plural"
 
-
     # Latvian noun forms (legacy singular/plural - kept for backward compatibility)
     NOUN_LV_SINGULAR = "noun/lv_singular"
     NOUN_LV_PLURAL = "noun/lv_plural"
-
 
     # Malay noun forms (singular/plural - plural via reduplication e.g. buku-buku)
     NOUN_MS_SINGULAR = "noun/ms_singular"
@@ -280,7 +273,6 @@ class GrammaticalForm(enum.Enum):
     VERB_MS_PAST = "verb/ms_past"
     VERB_MS_FUTURE = "verb/ms_future"
 
-
     # Filipino (Tagalog) noun forms (singular/plural - plural via mga prefix)
     NOUN_TL_SINGULAR = "noun/tl_singular"
     NOUN_TL_PLURAL = "noun/tl_plural"
@@ -289,7 +281,6 @@ class GrammaticalForm(enum.Enum):
     VERB_TL_PRESENT = "verb/tl_present"
     VERB_TL_PAST = "verb/tl_past"
     VERB_TL_FUTURE = "verb/tl_future"
-
 
     # Bengali noun forms (singular/plural)
     NOUN_BN_SINGULAR = "noun/bn_singular"
@@ -358,12 +349,10 @@ class GrammaticalForm(enum.Enum):
     NOUN_UK_SINGULAR = "noun/uk_singular"
     NOUN_UK_PLURAL = "noun/uk_plural"
 
-
     # Ukrainian verb forms (legacy tense-only - kept for backward compatibility)
     VERB_UK_PRESENT = "verb/uk_present"
     VERB_UK_PAST = "verb/uk_past"
     VERB_UK_FUTURE = "verb/uk_future"
-
 
     # Generic forms
     BASE_FORM = "base_form"

--- a/src/storage/models/schema.py
+++ b/src/storage/models/schema.py
@@ -132,15 +132,11 @@ class Lemma(Base):
     # item in historical/classical languages. Example: "post-classical technology".
     lexical_gap_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    # Language-specific translations of the lemma concept
-    chinese_translation: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., 吃
-    french_translation: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., manger
-    korean_translation: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., 먹다
-    swahili_translation: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., kula
-    lithuanian_translation: Mapped[Optional[str]] = mapped_column(
-        String, nullable=True
-    )  # e.g., valgyti
-    vietnamese_translation: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., ăn
+    # Translations of the lemma concept live in the LemmaTranslation table
+    # (see below); read and write them via storage.translation_helpers. The
+    # per-language columns that used to sit here (chinese_translation,
+    # lithuanian_translation, ...) are gone. The SQLite columns still exist as
+    # dead weight in older database files and are simply not mapped.
 
     # Disambiguation for polysemes (e.g., "mouse (animal)" vs "mouse (computer)")
     disambiguation: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/src/storage/queries/lemma.py
+++ b/src/storage/queries/lemma.py
@@ -122,13 +122,7 @@ def build_lemma_search_query(
             Lemma.lemma_text.ilike(f"%{search}%"),
             Lemma.definition_text.ilike(f"%{search}%"),
             Lemma.disambiguation.ilike(f"%{search}%"),
-            # Search in legacy translation columns
-            Lemma.chinese_translation.ilike(f"%{search}%"),
-            Lemma.french_translation.ilike(f"%{search}%"),
-            Lemma.korean_translation.ilike(f"%{search}%"),
-            Lemma.swahili_translation.ilike(f"%{search}%"),
-            Lemma.lithuanian_translation.ilike(f"%{search}%"),
-            Lemma.vietnamese_translation.ilike(f"%{search}%"),
+            # Translations are matched via the LemmaTranslation subquery below.
         ]
 
         # Also search in LemmaTranslation table
@@ -170,13 +164,15 @@ def build_lemma_search_query(
                 func.lower(Lemma.disambiguation).contains(search_lower),
                 5,
             ),  # Contains in disambiguation
-            # Translation matches
-            (func.lower(Lemma.lithuanian_translation).contains(search_lower), 6),
-            (func.lower(Lemma.chinese_translation).contains(search_lower), 6),
-            (func.lower(Lemma.french_translation).contains(search_lower), 6),
-            (func.lower(Lemma.korean_translation).contains(search_lower), 6),
-            (func.lower(Lemma.swahili_translation).contains(search_lower), 6),
-            (func.lower(Lemma.vietnamese_translation).contains(search_lower), 6),
+            # Translation matches, in any language
+            (
+                Lemma.id.in_(
+                    session.query(LemmaTranslation.lemma_id).filter(
+                        func.lower(LemmaTranslation.translation).contains(search_lower)
+                    )
+                ),
+                6,
+            ),
             else_=7,
         )
         if display_translation_joined:

--- a/src/storage/queries/noun_forms.py
+++ b/src/storage/queries/noun_forms.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from storage.crud.lemma import get_lemma_by_guid
 from storage.models.schema import DerivativeForm
+from storage.translation_helpers import get_translation
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ def check_noun_forms_coverage(session: Session, guid: str) -> Dict[str, Any]:
         "guid": guid,
         "found": True,
         "lemma_text": lemma.lemma_text,
-        "lithuanian": lemma.lithuanian_translation,
+        "lithuanian": get_translation(session, lemma, "lt"),
         "forms_count": len(all_forms),
         "expected_count": len(expected_forms),
         "missing_forms": missing,

--- a/src/storage/queries/translation.py
+++ b/src/storage/queries/translation.py
@@ -2,10 +2,12 @@
 
 from typing import List, Optional, cast
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from storage.crud.operation_log import log_translation_change
-from storage.models.schema import Lemma
+from storage.models.schema import Lemma, LemmaTranslation
+from storage.translation_helpers import get_language_code, set_translation
 
 
 def get_lemmas_without_translation(
@@ -22,24 +24,21 @@ def get_lemmas_without_translation(
     Returns:
         List of Lemma objects without the specified translation
     """
-    language = language.lower()
-    column_map = {
-        "chinese": Lemma.chinese_translation,
-        "french": Lemma.french_translation,
-        "korean": Lemma.korean_translation,
-        "swahili": Lemma.swahili_translation,
-        "lithuanian": Lemma.lithuanian_translation,
-        "vietnamese": Lemma.vietnamese_translation,
-    }
+    lang_code = get_language_code(language)
+    if lang_code is None:
+        raise ValueError(f"Unsupported language: {language}")
 
-    if language not in column_map:
-        raise ValueError(
-            f"Unsupported language: {language}. Supported languages: {', '.join(column_map.keys())}"
+    has_translation = (
+        select(LemmaTranslation.id)
+        .where(
+            LemmaTranslation.lemma_id == Lemma.id,
+            LemmaTranslation.language_code == lang_code,
+            LemmaTranslation.translation != "",
         )
-
-    return cast(
-        List[Lemma], session.query(Lemma).filter(column_map[language].is_(None)).limit(limit).all()
+        .exists()
     )
+
+    return cast(List[Lemma], session.query(Lemma).filter(~has_translation).limit(limit).all())
 
 
 def update_lemma_translation(
@@ -62,28 +61,13 @@ def update_lemma_translation(
     if not lemma:
         return False
 
-    language = language.lower()
-
-    # Map language names to field names and language codes
-    language_map = {
-        "chinese": ("chinese_translation", "zh"),
-        "french": ("french_translation", "fr"),
-        "korean": ("korean_translation", "ko"),
-        "swahili": ("swahili_translation", "sw"),
-        "lithuanian": ("lithuanian_translation", "lt"),
-        "vietnamese": ("vietnamese_translation", "vi"),
-    }
-
-    if language not in language_map:
+    lang_code = get_language_code(language)
+    if lang_code is None:
         return False
 
-    field_name, lang_code = language_map[language]
-
-    # Get old value for logging
-    old_translation = getattr(lemma, field_name, None)
-
-    # Update the translation
-    setattr(lemma, field_name, translation_text)
+    # Translations live in LemmaTranslation; set_translation returns the
+    # previous value so the change can still be logged.
+    old_translation, _ = set_translation(session, lemma, lang_code, translation_text)
 
     # Log the change
     log_translation_change(

--- a/src/storage/translation_helpers.py
+++ b/src/storage/translation_helpers.py
@@ -313,6 +313,9 @@ LANGUAGE_FIELDS = {
 # This is derived from LANGUAGE_FIELDS for convenience
 LANGUAGE_NAMES = {code: name for code, (_, name, _) in LANGUAGE_FIELDS.items()}
 
+# Inverse of LANGUAGE_NAMES, keyed by lowercased display name ("chinese" -> "zh").
+LANGUAGE_NAME_TO_CODE = {name.lower(): code for code, name in LANGUAGE_NAMES.items()}
+
 # LLM field name mappings (used for LLM responses)
 # Maps LLM field names (e.g., "chinese_translation") to language codes (e.g., "zh")
 LLM_FIELD_TO_LANG_CODE = {
@@ -993,6 +996,49 @@ def get_language_name(lang_code: str) -> str:
         raise ValueError(f"Unsupported language code: {lang_code}")
 
     return LANGUAGE_FIELDS[lang_code][1]
+
+
+def has_translation_clause(lang_code: str, translation: Optional[str] = None) -> Any:
+    """
+    Build a SQLAlchemy filter clause for lemmas that have a translation.
+
+    Use in a query against Lemma, e.g.::
+
+        session.query(Lemma).filter(has_translation_clause("lt"))
+        session.query(Lemma).filter(~has_translation_clause("lt"))  # missing it
+
+    Args:
+        lang_code: Language code (e.g., 'lt', 'zh')
+        translation: If given, match only this exact translation text
+
+    Returns:
+        An EXISTS clause correlated to Lemma
+    """
+    from sqlalchemy import select
+
+    conditions = [
+        LemmaTranslation.lemma_id == Lemma.id,
+        LemmaTranslation.language_code == lang_code,
+    ]
+    if translation is None:
+        conditions.append(LemmaTranslation.translation != "")
+    else:
+        conditions.append(LemmaTranslation.translation == translation)
+
+    return select(LemmaTranslation.id).where(*conditions).exists()
+
+
+def get_language_code(language_name: str) -> Optional[str]:
+    """
+    Get the language code for a display name. Inverse of get_language_name.
+
+    Args:
+        language_name: Display name, case-insensitive (e.g., 'Spanish', 'chinese')
+
+    Returns:
+        Language code (e.g., 'es', 'zh'), or None if the name is not recognized
+    """
+    return LANGUAGE_NAME_TO_CODE.get(language_name.lower())
 
 
 def get_supported_languages() -> Dict[str, str]:

--- a/src/tests/barsukas/helpers/test_audio_helpers.py
+++ b/src/tests/barsukas/helpers/test_audio_helpers.py
@@ -17,23 +17,24 @@ class TestLinkAudioToLemma:
         result = link_audio_to_lemma(seeded_session, "V01_001", "anything", "en")
         assert result == 1
 
-    def test_falls_back_to_column_translation_match(self, db_session: Session) -> None:
-        """When GUID doesn't match, fall back to column-based text lookup."""
+    def test_falls_back_to_translation_match(self, db_session: Session) -> None:
+        """When GUID doesn't match, fall back to translation text lookup."""
         lemma = Lemma(
             lemma_text="dog",
             definition_text="a pet",
             pos_type="noun",
-            chinese_translation="狗",
             confidence=0.0,
         )
         db_session.add(lemma)
+        db_session.flush()
+        db_session.add(LemmaTranslation(lemma_id=lemma.id, language_code="zh", translation="狗"))
         db_session.flush()
 
         result = link_audio_to_lemma(db_session, "NONEXISTENT", "狗", "zh")
         assert result == lemma.id
 
     def test_falls_back_to_table_translation_match(self, db_session: Session) -> None:
-        """Table-based languages (es, de, pt) use LemmaTranslation table."""
+        """Every language resolves through the LemmaTranslation table."""
         lemma = Lemma(
             lemma_text="cat",
             definition_text="a pet",
@@ -62,16 +63,17 @@ class TestLinkAudioToLemma:
 class TestValidateAudioTranslation:
     """Tests for validate_audio_translation."""
 
-    def test_valid_column_translation(self, db_session: Session) -> None:
+    def test_valid_translation(self, db_session: Session) -> None:
         lemma = Lemma(
             lemma_text="water",
             definition_text="H2O",
             pos_type="noun",
             guid="N99_001",
-            french_translation="eau",
             confidence=0.0,
         )
         db_session.add(lemma)
+        db_session.flush()
+        db_session.add(LemmaTranslation(lemma_id=lemma.id, language_code="fr", translation="eau"))
         db_session.flush()
 
         result = validate_audio_translation(db_session, "N99_001", "eau", "fr")
@@ -86,10 +88,11 @@ class TestValidateAudioTranslation:
             definition_text="H2O",
             pos_type="noun",
             guid="N99_002",
-            french_translation="eau",
             confidence=0.0,
         )
         db_session.add(lemma)
+        db_session.flush()
+        db_session.add(LemmaTranslation(lemma_id=lemma.id, language_code="fr", translation="eau"))
         db_session.flush()
 
         result = validate_audio_translation(db_session, "N99_002", "wrong", "fr")

--- a/src/tests/clients/test_lib.py
+++ b/src/tests/clients/test_lib.py
@@ -10,8 +10,11 @@ from typing import Any, Dict
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from clients.lib import (
+    MAX_SCHEMA_TOKENS,
     Schema,
     SchemaProperty,
+    SchemaTooLargeError,
+    count_schema_tokens,
     schema_from_dict,
     to_anthropic_schema,
     to_gemini_schema,
@@ -483,6 +486,77 @@ class SchemaConversionTestCase(unittest.TestCase):
         self.assertNotIn(
             "minimum", openai_schema["properties"]["pronunciation"]["properties"]["confidence"]
         )
+
+
+class SchemaSizeLimitTestCase(unittest.TestCase):
+    """Tests for the MAX_SCHEMA_TOKENS guard.
+
+    A schema is sent on every request that uses it, so an oversized one -- in
+    practice, an embedded full enum -- is a recurring per-call cost.
+    """
+
+    def _schema_with_enum(self, values: int) -> Schema:
+        return Schema(
+            name="BigEnumSchema",
+            description="Schema carrying a large enum",
+            properties={
+                "form": SchemaProperty(
+                    "string",
+                    "A grammatical form",
+                    enum=[f"language/form_variant_number_{i:04d}" for i in range(values)],
+                ),
+            },
+        )
+
+    def test_ordinary_schema_passes(self) -> None:
+        """A normal schema converts without raising."""
+        schema = Schema(
+            name="Small",
+            description="A small schema",
+            properties={
+                "word": SchemaProperty("string", "The word"),
+                "pos": SchemaProperty("string", "Part of speech", enum=["noun", "verb"]),
+            },
+        )
+        for converter in (
+            to_openai_schema,
+            to_anthropic_schema,
+            to_gemini_schema,
+            to_ollama_schema,
+        ):
+            with self.subTest(converter=converter.__name__):
+                self.assertLessEqual(count_schema_tokens(converter(schema)), MAX_SCHEMA_TOKENS)
+
+    def test_oversized_enum_raises_for_every_provider(self) -> None:
+        """Each provider's converter rejects a schema over the limit."""
+        schema = self._schema_with_enum(1238)
+        for converter in (
+            to_openai_schema,
+            to_anthropic_schema,
+            to_gemini_schema,
+            to_ollama_schema,
+        ):
+            with self.subTest(converter=converter.__name__):
+                with self.assertRaises(SchemaTooLargeError):
+                    converter(schema)
+
+    def test_error_names_the_offending_enum(self) -> None:
+        """The message points at the largest enum so the cause is obvious."""
+        with self.assertRaises(SchemaTooLargeError) as caught:
+            to_openai_schema(self._schema_with_enum(1238))
+
+        message = str(caught.exception)
+        self.assertIn("BigEnumSchema", message)
+        self.assertIn(str(MAX_SCHEMA_TOKENS), message)
+        self.assertIn("1238 values", message)
+
+    def test_limit_boundary(self) -> None:
+        """A schema just under the limit passes; well over it does not."""
+        small = self._schema_with_enum(50)
+        self.assertLessEqual(count_schema_tokens(to_openai_schema(small)), MAX_SCHEMA_TOKENS)
+
+        with self.assertRaises(SchemaTooLargeError):
+            to_openai_schema(self._schema_with_enum(500))
 
 
 if __name__ == "__main__":

--- a/src/tests/sentences/test_candidate_lookup.py
+++ b/src/tests/sentences/test_candidate_lookup.py
@@ -203,9 +203,7 @@ class TestDerivativeFormPath(CandidateLookupTestCase):
 class TestCapAndScoring(CandidateLookupTestCase):
     def test_max_candidates_respected(self) -> None:
         sentence = add_test_sentence(self.session, {"en": "I can play today"})
-        candidates = find_candidate_lemmas_for_sentence(
-            self.session, sentence.id, max_candidates=1
-        )
+        candidates = find_candidate_lemmas_for_sentence(self.session, sentence.id, max_candidates=1)
         self.assertEqual(len(candidates), 1)
 
     def test_score_equals_number_of_confirming_languages(self) -> None:
@@ -256,11 +254,7 @@ def _release_dog_guid(session: Session) -> str:
     """Look up the release-data GUID for the 'dog' noun lemma."""
     from storage.models.schema import Lemma
 
-    lemma = (
-        session.query(Lemma)
-        .filter(Lemma.lemma_text == "dog", Lemma.pos_type == "noun")
-        .first()
-    )
+    lemma = session.query(Lemma).filter(Lemma.lemma_text == "dog", Lemma.pos_type == "noun").first()
     assert lemma is not None and lemma.guid, "release fixture must include 'dog' noun"
     return lemma.guid
 

--- a/src/tests/wordfreq/test_sense_selection.py
+++ b/src/tests/wordfreq/test_sense_selection.py
@@ -1,0 +1,99 @@
+"""Tests for sense selection in wordfreq.translation.definitions."""
+
+from typing import Any, Dict, List
+
+from storage.models.schema import (
+    SENSE_PROMINENCE_COMMON,
+    SENSE_PROMINENCE_RARE,
+    SENSE_PROMINENCE_UNCOMMON,
+    SENSE_PROMINENCE_VERY_COMMON,
+)
+from wordfreq.translation.definitions import SENSE_PROMINENCE_ORDER, select_senses_to_add
+
+
+def _senses(*pairs: Any) -> List[Dict[str, Any]]:
+    """Build a definitions list from (definition, prominence) pairs."""
+    return [{"definition": text, "sense_prominence": prominence} for text, prominence in pairs]
+
+
+def _texts(senses: List[Dict[str, Any]]) -> List[str]:
+    return [sense["definition"] for sense in senses]
+
+
+class TestSelectSensesToAdd:
+    """The 2-4 sense rule: always a couple, more only while they stay common."""
+
+    def test_keeps_prominent_senses_beyond_the_minimum(self) -> None:
+        selected = select_senses_to_add(
+            _senses(
+                ("a", SENSE_PROMINENCE_VERY_COMMON),
+                ("b", SENSE_PROMINENCE_COMMON),
+                ("c", SENSE_PROMINENCE_COMMON),
+                ("d", SENSE_PROMINENCE_COMMON),
+            )
+        )
+        assert _texts(selected) == ["a", "b", "c", "d"]
+
+    def test_stops_once_senses_become_marginal(self) -> None:
+        """One everyday sense plus obscure ones yields the minimum, not all four."""
+        selected = select_senses_to_add(
+            _senses(
+                ("main", SENSE_PROMINENCE_VERY_COMMON),
+                ("obscure a", SENSE_PROMINENCE_RARE),
+                ("obscure b", SENSE_PROMINENCE_RARE),
+                ("obscure c", SENSE_PROMINENCE_RARE),
+            )
+        )
+        assert _texts(selected) == ["main", "obscure a"]
+
+    def test_caps_at_max_senses(self) -> None:
+        selected = select_senses_to_add(
+            _senses(*[(f"sense {i}", SENSE_PROMINENCE_COMMON) for i in range(6)])
+        )
+        assert len(selected) == 4
+
+    def test_orders_by_prominence(self) -> None:
+        """Input order does not matter; the prominent sense comes first."""
+        selected = select_senses_to_add(
+            _senses(
+                ("rare one", SENSE_PROMINENCE_RARE),
+                ("main", SENSE_PROMINENCE_VERY_COMMON),
+                ("second", SENSE_PROMINENCE_COMMON),
+            )
+        )
+        assert _texts(selected) == ["main", "second"]
+
+    def test_uncommon_sense_survives_as_the_second(self) -> None:
+        """min_senses wins over the threshold, so 'arrive' keeps both senses."""
+        selected = select_senses_to_add(
+            _senses(
+                ("reach a destination", SENSE_PROMINENCE_VERY_COMMON),
+                ("make a formal appearance", SENSE_PROMINENCE_UNCOMMON),
+            )
+        )
+        assert _texts(selected) == ["reach a destination", "make a formal appearance"]
+
+    def test_single_sense(self) -> None:
+        selected = select_senses_to_add(_senses(("only", SENSE_PROMINENCE_VERY_COMMON)))
+        assert _texts(selected) == ["only"]
+
+    def test_empty_input(self) -> None:
+        assert select_senses_to_add([]) == []
+
+    def test_missing_prominence_is_treated_as_common(self) -> None:
+        """An unrated sense should not be discarded as if it were rare."""
+        selected = select_senses_to_add(
+            [{"definition": "x"}, {"definition": "y"}, {"definition": "z"}]
+        )
+        assert _texts(selected) == ["x", "y", "z"]
+
+    def test_respects_explicit_limits(self) -> None:
+        senses = _senses(*[(f"sense {i}", SENSE_PROMINENCE_COMMON) for i in range(5)])
+        assert len(select_senses_to_add(senses, max_senses=2)) == 2
+        assert len(select_senses_to_add(senses, max_senses=5)) == 5
+
+    def test_prominence_order_matches_the_schema_values(self) -> None:
+        """The prompt's enum must stay in sync with Lemma.sense_prominence."""
+        from storage.models.schema import SENSE_PROMINENCE_VALUES
+
+        assert set(SENSE_PROMINENCE_ORDER) == SENSE_PROMINENCE_VALUES

--- a/src/util/prompt_loader.py
+++ b/src/util/prompt_loader.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import Dict, Optional
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 import constants

--- a/src/wordfreq/dictionary/export_wordlist.py
+++ b/src/wordfreq/dictionary/export_wordlist.py
@@ -16,7 +16,9 @@ import constants
 from storage import database as linguistic_db
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/wordfreq/dictionary/reviewer.py
+++ b/src/wordfreq/dictionary/reviewer.py
@@ -12,7 +12,9 @@ from storage import database as linguistic_db
 from storage.translation_helpers import get_translation
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/wordfreq/tools/word_categorizer.py
+++ b/src/wordfreq/tools/word_categorizer.py
@@ -14,7 +14,9 @@ from util.prompt_loader import get_context
 from storage import database as linguistic_db
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 

--- a/src/wordfreq/translation/check_lithuanian.py
+++ b/src/wordfreq/translation/check_lithuanian.py
@@ -10,7 +10,7 @@ import logging
 from typing import Any, Dict
 
 from storage.models.schema import DerivativeForm, Lemma
-from storage.translation_helpers import get_translation
+from storage.translation_helpers import get_translation, has_translation_clause
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +24,7 @@ def check_missing_lithuanian_base_forms(agent: Any) -> Dict[str, Any]:
 
     session = agent.get_session()
     try:
-        lemmas_with_lt = (
-            session.query(Lemma)
-            .filter(Lemma.lithuanian_translation.isnot(None), Lemma.lithuanian_translation != "")
-            .all()
-        )
+        lemmas_with_lt = session.query(Lemma).filter(has_translation_clause("lt")).all()
 
         logger.info(f"Found {len(lemmas_with_lt)} lemmas with Lithuanian translations")
 
@@ -92,8 +88,7 @@ def check_noun_declension_coverage(agent: Any) -> Dict[str, Any]:
             session.query(Lemma)
             .filter(
                 Lemma.pos_type == "noun",
-                Lemma.lithuanian_translation.isnot(None),
-                Lemma.lithuanian_translation != "",
+                has_translation_clause("lt"),
             )
             .all()
         )

--- a/src/wordfreq/translation/definitions.py
+++ b/src/wordfreq/translation/definitions.py
@@ -9,6 +9,12 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 import util.prompt_loader
 from clients.types import Schema, SchemaProperty
 from storage import database as linguistic_db
+from storage.models.schema import (
+    SENSE_PROMINENCE_COMMON,
+    SENSE_PROMINENCE_RARE,
+    SENSE_PROMINENCE_UNCOMMON,
+    SENSE_PROMINENCE_VERY_COMMON,
+)
 from wordfreq.translation.constants import VALID_POS_TYPES
 
 logger = logging.getLogger(__name__)
@@ -19,16 +25,70 @@ logger = logging.getLogger(__name__)
 # silently yielding no translation.
 DEFINITIONS_PROMPT_LANGUAGES: Tuple[str, ...] = ("lt", "es", "fr", "zh")
 
-# How common a sense is, most to least. A word's senses are rated
-# independently, so "arrive" can have two "most_common" senses; this is a
-# judgement about the sense, not a ranking within the response.
-SENSE_FREQUENCIES: Tuple[str, ...] = (
-    "most_common",
-    "somewhat_common",
-    "uncommon",
-    "rare",
-    "very_rare",
+# How common a sense is, most to least. These are the values of
+# Lemma.sense_prominence, so an answer can be stored directly on the lemma and
+# feeds the frequency rollup in wordfreq.lexeme_frequency via
+# SENSE_PROMINENCE_WEIGHTS. Senses are rated independently: a word may have two
+# "very_common" senses, or none.
+SENSE_PROMINENCE_ORDER: Tuple[str, ...] = (
+    SENSE_PROMINENCE_VERY_COMMON,
+    SENSE_PROMINENCE_COMMON,
+    SENSE_PROMINENCE_UNCOMMON,
+    SENSE_PROMINENCE_RARE,
 )
+
+
+def select_senses_to_add(
+    definitions_list: List[Dict[str, Any]],
+    max_senses: int = 4,
+    min_senses: int = 2,
+) -> List[Dict[str, Any]]:
+    """
+    Pick which of a word's senses are worth adding as lemmas.
+
+    ``query_definitions`` returns every sense it can think of, including
+    marginal ones -- "arrive" comes back with "reach a destination" and also
+    "make a formal or public appearance". Adding all of them buries the common
+    meaning; adding only the first loses real vocabulary.
+
+    Senses are ordered by prominence and taken while they stay common enough:
+    always the first ``min_senses``, then further senses only while they are
+    ``common`` or better, up to ``max_senses``. So a word with four solid
+    senses contributes four, and a word with one everyday sense plus three
+    obscure ones contributes two.
+
+    Args:
+        definitions_list: Senses as returned by query_definitions
+        max_senses: Never return more than this many
+        min_senses: Return at least this many (if that many exist)
+
+    Returns:
+        The selected senses, most prominent first
+    """
+    if not definitions_list:
+        return []
+
+    rank = {value: index for index, value in enumerate(SENSE_PROMINENCE_ORDER)}
+    default_rank = rank[SENSE_PROMINENCE_COMMON]
+
+    ordered = sorted(
+        definitions_list,
+        key=lambda sense: rank.get(sense.get("sense_prominence", ""), default_rank),
+    )
+
+    # Senses at or above this prominence are worth adding beyond min_senses.
+    keep_threshold = rank[SENSE_PROMINENCE_COMMON]
+
+    selected: List[Dict[str, Any]] = []
+    for sense in ordered[:max_senses]:
+        prominence_rank = rank.get(sense.get("sense_prominence", ""), default_rank)
+        if len(selected) < min_senses or prominence_rank <= keep_threshold:
+            selected.append(sense)
+        else:
+            # Ordered by prominence, so nothing after this qualifies either.
+            break
+
+    return selected
 
 
 def query_definitions(
@@ -131,11 +191,11 @@ def query_definitions(
                         "chinese_translation": SchemaProperty(
                             "string", "The Chinese translation of this form"
                         ),
-                        "sense_frequency": SchemaProperty(
+                        "sense_prominence": SchemaProperty(
                             "string",
                             "How common this sense is for this word in general "
                             "modern English, independent of the other senses",
-                            enum=list(SENSE_FREQUENCIES),
+                            enum=list(SENSE_PROMINENCE_ORDER),
                         ),
                         "confidence": SchemaProperty("number", "Confidence score from 0-1"),
                     },

--- a/src/wordfreq/translation/definitions.py
+++ b/src/wordfreq/translation/definitions.py
@@ -9,10 +9,26 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 import util.prompt_loader
 from clients.types import Schema, SchemaProperty
 from storage import database as linguistic_db
-from storage.models.enums import GrammaticalForm
 from wordfreq.translation.constants import VALID_POS_TYPES
 
 logger = logging.getLogger(__name__)
+
+# Language codes whose "<language>_translation" fields the definitions schema
+# below requests. Callers that pick a translation field by language code should
+# check against this so an unsupported language fails loudly instead of
+# silently yielding no translation.
+DEFINITIONS_PROMPT_LANGUAGES: Tuple[str, ...] = ("lt", "es", "fr", "zh")
+
+# How common a sense is, most to least. A word's senses are rated
+# independently, so "arrive" can have two "most_common" senses; this is a
+# judgement about the sense, not a ranking within the response.
+SENSE_FREQUENCIES: Tuple[str, ...] = (
+    "most_common",
+    "somewhat_common",
+    "uncommon",
+    "rare",
+    "very_rare",
+)
 
 
 def query_definitions(
@@ -37,9 +53,6 @@ def query_definitions(
     if not word or not isinstance(word, str):
         logger.error("Invalid word parameter provided")
         return [], False
-
-    # Get valid grammatical forms for the schema
-    valid_grammatical_forms = [form.value for form in GrammaticalForm]
 
     schema = Schema(
         name="WordDefinitions",
@@ -68,11 +81,14 @@ def query_definitions(
                         "lemma": SchemaProperty(
                             "string", "The base form (lemma) for this definition"
                         ),
-                        "grammatical_form": SchemaProperty(
-                            "string",
-                            "The specific grammatical form (e.g., verb/infinitive, noun/plural)",
-                            enum=valid_grammatical_forms,
-                        ),
+                        # No grammatical_form property: this prompt analyses one
+                        # English word per definition and process_word records a
+                        # single form, so the form follows from pos_type and is
+                        # derived by determine_default_grammatical_form. Listing
+                        # the enum here meant sending all 1238 GrammaticalForm
+                        # values -- every language's full conjugation tables,
+                        # ~28.5k characters, roughly two thirds of the prompt --
+                        # to ask about one English word.
                         "is_base_form": SchemaProperty(
                             "boolean", "Whether this is the base form (infinitive, singular, etc.)"
                         ),
@@ -95,23 +111,31 @@ def query_definitions(
                             },
                         ),
                         "notes": SchemaProperty("string", "Additional notes about this form"),
-                        "chinese_translation": SchemaProperty(
-                            "string", "The Chinese translation of this form"
+                        # Translations are limited to the current target
+                        # languages (lt/es/fr/zh). The prompt previously asked
+                        # for Korean, Swahili and Vietnamese as well; those
+                        # dated to an older target set, were never stored, and
+                        # only inflated the prompt. Callers that build a field
+                        # name as f"{language}_translation" (dramblys
+                        # --target-language, client.get_translation_for_form)
+                        # can only request one of these four.
+                        "lithuanian_translation": SchemaProperty(
+                            "string", "The Lithuanian translation of this form"
                         ),
-                        "korean_translation": SchemaProperty(
-                            "string", "The Korean translation of this form"
+                        "spanish_translation": SchemaProperty(
+                            "string", "The Spanish translation of this form"
                         ),
                         "french_translation": SchemaProperty(
                             "string", "The French translation of this form"
                         ),
-                        "swahili_translation": SchemaProperty(
-                            "string", "The Swahili translation of this form"
+                        "chinese_translation": SchemaProperty(
+                            "string", "The Chinese translation of this form"
                         ),
-                        "vietnamese_translation": SchemaProperty(
-                            "string", "The Vietnamese translation of this form"
-                        ),
-                        "lithuanian_translation": SchemaProperty(
-                            "string", "The Lithuanian translation of this form"
+                        "sense_frequency": SchemaProperty(
+                            "string",
+                            "How common this sense is for this word in general "
+                            "modern English, independent of the other senses",
+                            enum=list(SENSE_FREQUENCIES),
                         ),
                         "confidence": SchemaProperty("number", "Confidence score from 0-1"),
                     },

--- a/src/wordfreq/translation/processor.py
+++ b/src/wordfreq/translation/processor.py
@@ -17,7 +17,9 @@ from storage.connection_pool import close_thread_sessions, get_session
 from wordfreq.translation.client import LinguisticClient
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Constants

--- a/src/wordfreq/translation/wiki.py
+++ b/src/wordfreq/translation/wiki.py
@@ -713,7 +713,10 @@ def test_clean_declension_form() -> bool:
 
 if __name__ == "__main__":
     # Set up logging for testing
-    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s - %(filename)s:%(lineno)d - %(levelname)s - %(message)s",
+    )
 
     # Run unit tests first
     stress_tests_passed = test_stress_mark_removal()

--- a/src/wordfreq/translation/word_processing.py
+++ b/src/wordfreq/translation/word_processing.py
@@ -15,63 +15,76 @@ from wordfreq.translation.constants import VALID_POS_TYPES
 logger = logging.getLogger(__name__)
 
 
+# Base (dictionary) form per part of speech, for English. The definitions
+# prompt analyses one English word per definition, so the form follows from the
+# POS -- there is nothing to ask the LLM about. Language-tagged ("en_") values
+# only; the untagged generic forms (verb/infinitive, noun/singular, ...) are
+# deprecated because they carry no language code.
+#
+# The en_ members are added by _auto_extend_grammatical_form() at import time
+# and are not real class attributes, so they must be looked up by name via
+# GrammaticalForm[...] rather than GrammaticalForm.NAME.
+EN_BASE_FORM_BY_POS: Dict[str, str] = {
+    "verb": GrammaticalForm["VERB_EN_INFINITIVE"].value,
+    "noun": GrammaticalForm["NOUN_EN_SINGULAR"].value,
+    "adjective": GrammaticalForm["ADJ_EN_POSITIVE"].value,
+    "adverb": GrammaticalForm["ADVERB_EN_POSITIVE"].value,
+    "pronoun": GrammaticalForm["PRONOUN_EN_SUBJECTIVE"].value,
+    "numeral": GrammaticalForm["NUMERAL_EN_CARDINAL"].value,
+    "article": GrammaticalForm["ARTICLE_EN_BASE"].value,
+}
+
+# Inflected English forms used by the suffix heuristics below.
+_EN_INFLECTED = {
+    name: GrammaticalForm[name].value
+    for name in (
+        "VERB_EN_PRESENT_PARTICIPLE",
+        "VERB_EN_PAST_PARTICIPLE",
+        "NOUN_EN_PLURAL",
+        "ADJ_EN_COMPARATIVE",
+        "ADJ_EN_SUPERLATIVE",
+        "ADVERB_EN_COMPARATIVE",
+        "ADVERB_EN_SUPERLATIVE",
+    )
+}
+
+
 def determine_default_grammatical_form(word_text: str, pos_type: str, lemma_text: str) -> str:
     """
-    Determine a default grammatical form based on word, POS, and lemma.
+    Determine the English grammatical form for a word given its POS and lemma.
 
-    This is a heuristic fallback when the LLM doesn't provide grammatical_form.
+    ``query_definitions`` analyses English words and ``process_word`` records a
+    single form per definition, so this is derived rather than asked for. When
+    the word is its own lemma the form is the POS's base form; otherwise a few
+    suffix heuristics cover the common inflections.
     """
     pos_lower = pos_type.lower()
 
     if word_text == lemma_text:
-        # Word matches lemma, likely base form
-        if pos_lower == "verb":
-            return GrammaticalForm.VERB_INFINITIVE.value
-        elif pos_lower == "noun":
-            return GrammaticalForm.NOUN_SINGULAR.value
-        elif pos_lower == "adjective":
-            return GrammaticalForm.ADJECTIVE_POSITIVE.value
-        elif pos_lower == "adverb":
-            return GrammaticalForm.ADVERB_POSITIVE.value
-        elif pos_lower == "preposition":
-            return GrammaticalForm.PREPOSITION.value
-        elif pos_lower == "conjunction":
-            return GrammaticalForm.CONJUNCTION.value
-        elif pos_lower == "interjection":
-            return GrammaticalForm.INTERJECTION.value
-        elif pos_lower == "determiner":
-            return GrammaticalForm.DETERMINER.value
-        elif pos_lower == "article":
-            return GrammaticalForm.ARTICLE.value
-        else:
-            return GrammaticalForm.BASE_FORM.value
+        return EN_BASE_FORM_BY_POS.get(pos_lower, GrammaticalForm.OTHER.value)
 
     # Basic heuristics for English inflected forms
     if pos_lower == "verb":
         if word_text.endswith("ing"):
-            return GrammaticalForm.VERB_PRESENT_PARTICIPLE.value  # Default to participle
+            return _EN_INFLECTED["VERB_EN_PRESENT_PARTICIPLE"]
         elif word_text.endswith("ed"):
-            return GrammaticalForm.VERB_PAST_PARTICIPLE.value
-        elif word_text.endswith("s"):
-            return GrammaticalForm.OTHER.value
+            return _EN_INFLECTED["VERB_EN_PAST_PARTICIPLE"]
 
     elif pos_lower == "noun":
         if word_text.endswith("s") and not lemma_text.endswith("s"):
-            return GrammaticalForm.NOUN_PLURAL.value
-        elif word_text.endswith("'s"):
-            return GrammaticalForm.NOUN_POSSESSIVE_SINGULAR.value
+            return _EN_INFLECTED["NOUN_EN_PLURAL"]
 
     elif pos_lower == "adjective":
         if word_text.endswith("er"):
-            return GrammaticalForm.ADJECTIVE_COMPARATIVE.value
+            return _EN_INFLECTED["ADJ_EN_COMPARATIVE"]
         elif word_text.endswith("est"):
-            return GrammaticalForm.ADJECTIVE_SUPERLATIVE.value
+            return _EN_INFLECTED["ADJ_EN_SUPERLATIVE"]
 
     elif pos_lower == "adverb":
         if word_text.endswith("er"):
-            return GrammaticalForm.ADVERB_COMPARATIVE.value
+            return _EN_INFLECTED["ADVERB_EN_COMPARATIVE"]
         elif word_text.endswith("est"):
-            return GrammaticalForm.ADVERB_SUPERLATIVE.value
+            return _EN_INFLECTED["ADVERB_EN_SUPERLATIVE"]
 
     return GrammaticalForm.OTHER.value
 
@@ -186,45 +199,36 @@ def process_word(
             if not is_base_form_flag:
                 is_base_form_flag = is_likely_base_form(word, def_data.get("lemma", word), pos_type)
 
-            # Create Translation objects for each language
-            chinese_trans = None
-            chinese_text = def_data.get("chinese_translation")
-            if chinese_text and isinstance(chinese_text, str):
-                chinese_trans = Translation(text=chinese_text)
+            # Create Translation objects for each language the definitions
+            # prompt returns: lt/es/fr/zh. The prompt previously also asked for
+            # Korean, Swahili and Vietnamese; those dated to an older target
+            # language set and are no longer requested.
+            lithuanian_trans = None
+            lithuanian_text = def_data.get("lithuanian_translation")
+            if lithuanian_text and isinstance(lithuanian_text, str):
+                lithuanian_trans = Translation(text=lithuanian_text)
 
-            korean_trans = None
-            korean_text = def_data.get("korean_translation")
-            if korean_text and isinstance(korean_text, str):
-                korean_trans = Translation(text=korean_text)
+            spanish_trans = None
+            spanish_text = def_data.get("spanish_translation")
+            if spanish_text and isinstance(spanish_text, str):
+                spanish_trans = Translation(text=spanish_text)
 
             french_trans = None
             french_text = def_data.get("french_translation")
             if french_text and isinstance(french_text, str):
                 french_trans = Translation(text=french_text)
 
-            swahili_trans = None
-            swahili_text = def_data.get("swahili_translation")
-            if swahili_text and isinstance(swahili_text, str):
-                swahili_trans = Translation(text=swahili_text)
-
-            vietnamese_trans = None
-            vietnamese_text = def_data.get("vietnamese_translation")
-            if vietnamese_text and isinstance(vietnamese_text, str):
-                vietnamese_trans = Translation(text=vietnamese_text)
-
-            lithuanian_trans = None
-            lithuanian_text = def_data.get("lithuanian_translation")
-            if lithuanian_text and isinstance(lithuanian_text, str):
-                lithuanian_trans = Translation(text=lithuanian_text)
+            chinese_trans = None
+            chinese_text = def_data.get("chinese_translation")
+            if chinese_text and isinstance(chinese_text, str):
+                chinese_trans = Translation(text=chinese_text)
 
             # Create TranslationSet with Translation objects
             translations_set = TranslationSet(
-                chinese=chinese_trans,
-                korean=korean_trans,
-                french=french_trans,
-                swahili=swahili_trans,
-                vietnamese=vietnamese_trans,
                 lithuanian=lithuanian_trans,
+                spanish=spanish_trans,
+                french=french_trans,
+                chinese=chinese_trans,
             )
 
             # Create complete word entry (WordToken + Lemma + DerivativeForm)

--- a/src/workqueue/handlers/vieversys.py
+++ b/src/workqueue/handlers/vieversys.py
@@ -138,10 +138,7 @@ def handle_generate_audio(session: Session, payload: Dict) -> str:
                 gpt_voice_list.append(gpt_voice)
 
         if invalid_voice_names:
-            raise RuntimeError(
-                "Invalid OpenAI voice names: "
-                + ", ".join(invalid_voice_names)
-            )
+            raise RuntimeError("Invalid OpenAI voice names: " + ", ".join(invalid_voice_names))
 
         if not gpt_voice_list:
             supported_languages = sorted({voice.language_code for voice in GptVoice})


### PR DESCRIPTION
A few blocking fixes for the "add a word" pipeline:

* remove all use of the old "french_translation", "chinese_translation" fields in the Lemma table - always use LemmaTranslation
* don't include all 1300 GrammaticalForm values in an enum for an LLM schema - this was bloating requests by 8K tokens for no use.
* we still *do* include the ~130 pos_subtype values (food noun, furniture noun, possession verb, etc.)
* the default languages are ES FR ZH LT, no longer KO SW VI