### PR TITLE
Add portable test target for optional native dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,12 @@ their local browser.
 
 Testing
 -------
-There are three test targets, run via ./run_tests.sh :
+There are four test targets, run via ./run_tests.sh :
 
-  ./run_tests.sh smoke    ~16 tests, ~1s   - run on every commit
-  ./run_tests.sh base     ~1700 tests, ~16s - run often, not every commit
-  ./run_tests.sh all      everything, including the audio suite
+  ./run_tests.sh smoke     ~16 tests, ~1s    - run on every commit
+  ./run_tests.sh portable  ~1676 tests       - base minus optional-native-dep tests
+  ./run_tests.sh base      ~1700 tests, ~16s - run often, not every commit
+  ./run_tests.sh all       everything, including the audio suite
 
 Extra arguments pass through to pytest:
   ./run_tests.sh base -k combined_rank -x
@@ -76,6 +77,27 @@ total under ~20 - it is worthless if it stops being fast.  Tests needing a
 database, an LLM client, or fixtures belong in base instead.
 
 base is everything except src/tests/clients/audio ; all adds that back.
+
+portable is base with the tests that require optional native dependencies
+removed, so the suite runs cleanly where those wheels do not build or install.
+It is a superset of smoke and a subset of base.  Three dependencies drive the
+exclusions, all listed in PORTABLE_EXCLUDES in run_tests.sh :
+
+* jieba (Chinese segmentation) is imported at module load by
+  benchmarks.lib.generators.pinyin_letter_count_generator, and
+  benchmarks.lib.utils pulls that generators package in eagerly, so the whole
+  benchmarks tree fails to *collect* without it - portable drops
+  src/tests/benchmarks and src/tests/lib/benchmarks wholesale.
+* pypinyin + pykakasi (Chinese pinyin / Japanese readings) are needed by
+  src/tests/wireword/test_readings.py, which asserts real reading output;
+  portable drops that file.
+
+The exclusions are pytest path --ignore flags, not -m "not ..." marker
+deselection: jieba breaks collection before any marker could deselect a test.
+Tests that gate themselves on a missing dep (skipif / skipUnless / an
+*_AVAILABLE flag, e.g. test_zh_pinyin_sort.py, test_dialect_overrides.py,
+test_cognates.py) already skip cleanly and are not excluded.  When the exclusion
+set changes, update both run_tests.sh and this section.
 
 Two things to know when writing tests:
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,19 +1,41 @@
 #!/bin/bash
 # Test targets for greenland.
 #
-#   ./run_tests.sh smoke   fast import/startup checks; run on every commit
-#   ./run_tests.sh base    the tests known to pass; run often, not every commit
-#   ./run_tests.sh all     everything, including known-failing suites
+#   ./run_tests.sh smoke      fast import/startup checks; run on every commit
+#   ./run_tests.sh portable   base minus tests that need native/optional deps
+#   ./run_tests.sh base       the tests known to pass; run often, not every commit
+#   ./run_tests.sh all        everything, including known-failing suites
 #
 # Any extra arguments are passed through to pytest, so this works:
 #   ./run_tests.sh base -k combined_rank -x
 #
 # base excludes one directory:
 #   clients/audio   - needs the audio submodule synced to its recorded commit
+#
+# portable is base with the tests that require optional native dependencies
+# removed, so the suite runs cleanly in environments where those wheels do not
+# build or install (jieba, pypinyin, opencc, pykakasi). It is a strict superset
+# of smoke and a strict subset of base. The exclusions below are paths rather
+# than pytest markers on purpose: the offending imports (notably jieba, pulled
+# in eagerly by benchmarks.lib.generators) fail at collection time, before any
+# marker-based deselection would apply. Keep this list in sync with the Testing
+# section of AGENTS.md when it changes.
 set -euo pipefail
 
 cd "$(dirname "$0")"
 export PYTHONPATH=src
+
+# Tests that cannot be collected or cannot pass without optional native deps.
+# See the comment above for why these are path exclusions.
+PORTABLE_EXCLUDES=(
+  # jieba: benchmarks.lib.generators.pinyin_letter_count_generator imports jieba
+  # at module load, and benchmarks.lib.utils eagerly imports the generators
+  # package, so the whole benchmarks tree fails to collect without it.
+  --ignore=src/tests/benchmarks
+  --ignore=src/tests/lib/benchmarks
+  # pypinyin + pykakasi: reading-field construction for Chinese/Japanese.
+  --ignore=src/tests/wireword/test_readings.py
+)
 
 TARGET="${1:-base}"
 shift || true
@@ -22,6 +44,9 @@ case "$TARGET" in
   smoke)
     exec python -m pytest src/tests -m smoke "$@"
     ;;
+  portable)
+    exec python -m pytest src/tests "${PORTABLE_EXCLUDES[@]}" "$@"
+    ;;
   base)
     exec python -m pytest src/tests "$@"
     ;;
@@ -29,7 +54,7 @@ case "$TARGET" in
     exec python -m pytest src/tests "$@"
     ;;
   *)
-    echo "usage: $0 {smoke|base|all} [pytest args...]" >&2
+    echo "usage: $0 {smoke|portable|base|all} [pytest args...]" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary
Adds a new `portable` test target to the test suite that runs the base test suite while excluding tests that require optional native dependencies (jieba, pypinyin, opencc, pykakasi). This allows the test suite to run cleanly in environments where these optional wheels do not build or install.

## Changes
- **run_tests.sh**: 
  - Added `portable` as a new test target between `smoke` and `base`
  - Defined `PORTABLE_EXCLUDES` array with path-based exclusions for tests requiring optional native dependencies
  - Updated usage message to include the new `portable` target
  - Added detailed comments explaining why path exclusions are used instead of pytest markers (jieba breaks collection before markers can deselect)

- **AGENTS.md**:
  - Updated testing documentation to describe four test targets instead of three
  - Added `portable` target description with test count (~1676 tests)
  - Added comprehensive explanation of the `portable` target, including:
    - Its relationship to `smoke` (superset) and `base` (subset)
    - Detailed rationale for each exclusion (jieba, pypinyin/pykakasi)
    - Explanation of why path exclusions are used instead of markers
    - Note about tests that gate themselves on missing deps (which skip cleanly)
    - Instruction to keep exclusion sets in sync between run_tests.sh and AGENTS.md

## Implementation Details
The `portable` target excludes:
- `src/tests/benchmarks` and `src/tests/lib/benchmarks` (jieba imported at module load by generators)
- `src/tests/wireword/test_readings.py` (requires pypinyin and pykakasi)

These are path-based `--ignore` flags rather than pytest markers because jieba's eager import at collection time prevents marker-based deselection from working.

https://claude.ai/code/session_01UUKr6PMUv3qYy21m7fSvzs