### PR TITLE
Add POST /api/v1/words/add: create a lemma from just an English word

### DIFF
--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -219,6 +219,26 @@ def add_lemmas(lemmas: List[AddLemmaInput]) -> Any:
     return post_json(f"{API_V1_PREFIX}/lemmas/add", {"lemmas": lemmas})
 
 
+@mirrored_route("/api/v1/words/add", "POST")
+def add_word(word: str, model: str, dry_run: bool = False) -> Any:
+    """Add a single English word to the database, from just the word.
+
+    Unlike :func:`add_lemmas` (which takes fully specified lemma rows), this runs
+    the intelligent pipeline: it queries the LLM for the word's senses, sizes how
+    many senses to add by corpus frequency, caps closed-class words to one sense,
+    collapses over-split senses, and writes one lemma per surviving sense.
+    **Makes an LLM call and costs money.**
+
+    A word already accounted for -- as a lemma, disambiguated lemma, English
+    derivative form or alternate spelling -- returns ``status`` ``"already_exists"``
+    and nothing is written. Pass ``dry_run=True`` to preview without writing.
+    """
+    return post_json(
+        f"{API_V1_PREFIX}/words/add",
+        {"word": word, "model": model, "dry_run": dry_run},
+    )
+
+
 @mirrored_route("/api/v1/lemma/<guid>", "GET")
 def get_lemma(guid: str) -> Any:
     """Basic lemma details."""

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -46,6 +46,26 @@ Base prefix: `/api`.
   - `lemma_text`/`definition_text`/`pos_type`/`pos_subtype` are required per entry; `difficulty_level` and `translations` are optional. Max 100 entries.
   - GUIDs are assigned automatically from the `pos_type`/`pos_subtype` prefix. An entry whose `(lemma_text, pos_type)` already exists is returned with `status: "already_exists"` and its existing GUID, and is not modified; created entries return `status: "created"`.
 
+- `POST /api/v1/words/add`
+  - Add a single English word to the database from **just the word** — the
+    intelligent counterpart to `/v1/lemmas/add`. **Makes an LLM call and costs
+    money.**
+  - Body: `{"word": "...", "model": "<model-name>", "dry_run": <bool, optional>}`.
+  - Queries the LLM for the word's senses, sizes how many senses to add by the
+    word's corpus frequency (rarer words get fewer senses), caps closed-class
+    words — anything other than noun/verb/adjective/adverb — to a single sense,
+    collapses senses the LLM over-split (same POS and identical translations),
+    and writes one lemma per surviving sense at difficulty `-1` with the
+    lt/es/fr/zh translations the definitions call returned.
+  - A word already accounted for — as a lemma, disambiguated lemma, English
+    derivative form, or alternate spelling (`variant_forms`) — returns
+    `status: "already_exists"` and nothing is written.
+  - Response `data`: `{word, status, frequency_rank, senses: [{guid, pos_type, pos_subtype, definition_text, sense_prominence, translations}], dropped_senses}`.
+    `status` is one of `created`, `already_exists`, `no_definitions`.
+    `metadata` carries `{model, dry_run, created}`.
+  - `dry_run: true` runs the whole pipeline (still making the LLM call) but
+    writes nothing; the response shows what would be created.
+
 - `POST /api/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>`
   - Merge the synonym lemma into the main lemma. Requires the same `pos_type` and at least 3 matching non-empty translations after normalization.
   - Adds the synonym lemma text/translations as per-language `synonym` derivative forms on the main lemma, tombstones `synonym_guid`, repoints sentence/audio references, and deletes the synonym lemma row.

--- a/src/barsukas/routes/api/lemma_routes.py
+++ b/src/barsukas/routes/api/lemma_routes.py
@@ -997,7 +997,88 @@ def add_lemmas() -> ResponseReturnValue:
     )
 
 
+@bp.route("/v1/words/add", methods=["POST"])
+@mirrored_facade("/api/v1/words/add", "POST")
+def add_word_endpoint() -> ResponseReturnValue:
+    """Add a single English word to the database, from just the word.
+
+    Unlike ``/v1/lemmas/add`` (which takes fully specified lemma rows), this
+    endpoint takes a bare word and runs the intelligent pipeline: it queries the
+    LLM for the word's senses, sizes how many senses to add by the word's corpus
+    frequency, caps closed-class words to a single sense, collapses senses the
+    LLM over-split, and writes one lemma per surviving sense. **It makes an LLM
+    call and costs money.**
+
+    JSON body:
+      - ``word``: the English word to add (required).
+      - ``model``: LLM model name (required).
+      - ``dry_run``: if true, run the pipeline (including the LLM call) but write
+        nothing; the response shows what would be created. Optional, default
+        false.
+
+    Synchronous, one word per request. A word already accounted for -- as a
+    lemma, disambiguated lemma, English derivative form or alternate spelling --
+    is returned with ``status: "already_exists"`` and nothing is written.
+    """
+    from storage.backend.config import BackendType, DataSourceConfig
+    from words.add_word import add_word
+
+    model, error = _require_model()
+    if error is not None:
+        return error
+
+    payload = request.get_json(silent=True) or {}
+    word = payload.get("word")
+    if not isinstance(word, str) or not word.strip():
+        return _build_error_response("word is required and must be a non-empty string")
+
+    dry_run_raw = payload.get("dry_run", False)
+    if not isinstance(dry_run_raw, bool):
+        return _build_error_response("dry_run must be a boolean")
+
+    config = DataSourceConfig(
+        backend_type=BackendType.SQLITE,
+        sqlite_path=Config.DB_PATH,
+        model=model,
+        debug=Config.DEBUG,
+    )
+    result = add_word(
+        g.db,
+        word.strip(),
+        config=config,
+        model=model,
+        source=Config.OPERATION_LOG_SOURCE,
+        dry_run=dry_run_raw,
+    )
+
+    if result.status == "error":
+        return _build_error_response(result.error or "failed to add word")
+
+    data = {
+        "word": result.word,
+        "status": result.status,
+        "frequency_rank": _serialize_value(result.frequency_rank),
+        "senses": [
+            {
+                "guid": sense.guid,
+                "pos_type": sense.pos_type,
+                "pos_subtype": sense.pos_subtype,
+                "definition_text": sense.definition_text,
+                "sense_prominence": sense.sense_prominence,
+                "translations": sense.translations,
+            }
+            for sense in result.senses
+        ],
+        "dropped_senses": result.dropped_senses,
+    }
+    return _build_success_response(
+        data,
+        {"model": model, "dry_run": dry_run_raw, "created": len(result.senses)},
+    )
+
+
 @bp.route("/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>", methods=["POST"])
+@mirrored_facade("/api/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>", "POST")
 @mirrored_facade("/api/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>", "POST")
 def merge_lemma_synonym(main_guid: str, synonym_guid: str) -> ResponseReturnValue:
     """Merge one lemma into another as per-language synonym forms.

--- a/src/storage/utils/guid.py
+++ b/src/storage/utils/guid.py
@@ -31,6 +31,11 @@ def generate_guid(session: Session, pos_type: str, subtype: str) -> str:
 
     prefix = SUBTYPE_GUID_PREFIXES[pos_type][subtype]
 
+    # TODO: this only sees rows the query returns (the DB plus flushed session
+    # state). Lemmas that have been session.add()-ed but not yet flushed are
+    # invisible here, so two same-subtype lemmas added before a flush get the
+    # same GUID. Callers must flush after each add for now; fix by also folding
+    # in the session's pending new Lemma rows (session.new).
     # Find the highest existing GUID number for this subtype
     existing_guids = (
         session.query(Lemma.guid)

--- a/src/tests/words/test_add_word.py
+++ b/src/tests/words/test_add_word.py
@@ -1,0 +1,385 @@
+"""Tests for the single-word add pipeline (words.add_word).
+
+add_word turns a bare English word into one lemma per sense worth adding. The
+LLM call is stubbed here by replacing the LinguisticClient it constructs, so no
+real definitions call is made -- the tests cover the logic layered on top of the
+LLM: the existence guard, frequency-driven sense sizing, the closed-class
+single-sense cap, translation-duplicate collapse, and subtype normalization.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Generator, List, Tuple
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from storage.backend.config import BackendType, DataSourceConfig
+from storage.models import Base, Lemma, WordToken
+from storage.models.variant_form import VARIANT_KIND_SPELLING, VariantForm
+from words import add_word as add_word_module
+from words.add_word import (
+    AddWordResult,
+    _apply_pos_sense_cap,
+    _drop_translation_duplicates,
+    _extend_for_prominence_ties,
+    _normalize_subtype,
+    _sense_bounds,
+    add_word,
+)
+from wordfreq.translation.definitions import select_senses_to_add
+
+
+@pytest.fixture()
+def db_engine(tmp_path: Path) -> Generator[Engine, None, None]:
+    import storage.models  # noqa: F401
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'add_word.sqlite'}")
+    Base.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def session(db_engine: Engine) -> Generator[Session, None, None]:
+    factory = sessionmaker(bind=db_engine)
+    db_session = factory()
+    yield db_session
+    db_session.close()
+
+
+@pytest.fixture()
+def config() -> DataSourceConfig:
+    return DataSourceConfig(
+        backend_type=BackendType.SQLITE, sqlite_path=":memory:", model="test-model"
+    )
+
+
+class _FakeClient:
+    """Stand-in for LinguisticClient that returns canned definitions."""
+
+    def __init__(self, definitions: List[Dict[str, Any]]) -> None:
+        self._definitions = definitions
+        self.model = "test-model"
+        self.calls = 0
+
+    def query_definitions(self, word: str, **kwargs: Any) -> Tuple[List[Dict[str, Any]], bool]:
+        self.calls += 1
+        return self._definitions, bool(self._definitions)
+
+
+@pytest.fixture()
+def patch_client(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return a helper that installs a _FakeClient with the given definitions."""
+
+    def _install(definitions: List[Dict[str, Any]]) -> _FakeClient:
+        fake = _FakeClient(definitions)
+        monkeypatch.setattr(add_word_module, "LinguisticClient", lambda config=None: fake)
+        return fake
+
+    return _install
+
+
+def _def(
+    definition: str,
+    pos: str = "noun",
+    pos_subtype: str = "animal",
+    prominence: str = "common",
+    **translations: str,
+) -> Dict[str, Any]:
+    """Build one LLM definition dict. Translation kwargs use LLM field names."""
+    entry: Dict[str, Any] = {
+        "definition": definition,
+        "pos": pos,
+        "pos_subtype": pos_subtype,
+        "sense_prominence": prominence,
+    }
+    entry.update(translations)
+    return entry
+
+
+def _senses(*pairs: Tuple[str, str]) -> List[Dict[str, Any]]:
+    """Build a definitions list from (definition, prominence) pairs."""
+    return [{"definition": text, "sense_prominence": prominence} for text, prominence in pairs]
+
+
+def _seed_word_token(session: Session, token: str, rank: int) -> None:
+    session.add(WordToken(token=token, language_code="en", frequency_rank=rank))
+    session.commit()
+
+
+# --- Pure helpers -----------------------------------------------------------
+
+
+def test_sense_bounds_by_rank() -> None:
+    # min stays 1 at every rank: sense_prominence, not word frequency, decides
+    # whether a second sense is added. Frequency only raises the max.
+    assert _sense_bounds(500) == (1, 4)
+    assert _sense_bounds(2000) == (1, 4)
+    assert _sense_bounds(2001) == (1, 3)
+    assert _sense_bounds(10000) == (1, 3)
+    assert _sense_bounds(10001) == (1, 2)
+    assert _sense_bounds(None) == (1, 2)
+
+
+def _select_and_extend(defs: List[Dict[str, Any]], max_senses: int) -> List[str]:
+    """Run add_word's ceiling + tie-extension over a definitions list."""
+    selected = select_senses_to_add(defs, max_senses=max_senses, min_senses=1)
+    extended = _extend_for_prominence_ties(selected, defs)
+    return [sense["definition"] for sense in extended]
+
+
+def test_tie_extension_cuts_between_prominence_tiers() -> None:
+    # 2 very_common + 2 common, ceiling 2: the cut lands between tiers, so keep
+    # only the two very_common and drop the commons.
+    defs = _senses(
+        ("a", "very_common"),
+        ("b", "very_common"),
+        ("c", "common"),
+        ("d", "common"),
+    )
+    assert _select_and_extend(defs, max_senses=2) == ["a", "b"]
+
+
+def test_tie_extension_keeps_whole_common_tier() -> None:
+    # 1 very_common + 4 common, ceiling 3: the cut lands inside the common tier,
+    # so include all five rather than dropping one common for list position.
+    defs = _senses(
+        ("a", "very_common"),
+        ("b", "common"),
+        ("c", "common"),
+        ("d", "common"),
+        ("e", "common"),
+    )
+    assert _select_and_extend(defs, max_senses=3) == ["a", "b", "c", "d", "e"]
+
+
+def test_tie_extension_never_reaches_uncommon() -> None:
+    # A prominent sense plus uncommon ones: the boundary tier is very_common,
+    # so nothing is pulled in and the uncommons stay dropped.
+    defs = _senses(
+        ("a", "very_common"),
+        ("b", "uncommon"),
+        ("c", "uncommon"),
+    )
+    assert _select_and_extend(defs, max_senses=3) == ["a"]
+
+
+def test_closed_class_capped_to_one_sense() -> None:
+    senses = [
+        {"pos": "conjunction", "definition": "except on the condition that"},
+        {"pos": "conjunction", "definition": "if not"},
+    ]
+    kept, dropped = _apply_pos_sense_cap(senses)
+    assert len(kept) == 1
+    assert kept[0]["definition"] == "except on the condition that"
+    assert len(dropped) == 1
+
+
+def test_open_class_not_capped() -> None:
+    senses = [
+        {"pos": "noun", "definition": "a financial institution"},
+        {"pos": "noun", "definition": "the side of a river"},
+    ]
+    kept, dropped = _apply_pos_sense_cap(senses)
+    assert len(kept) == 2
+    assert dropped == []
+
+
+def test_translation_duplicates_collapsed() -> None:
+    senses = [
+        _def("keep happening", pos="verb", lithuanian_translation="tęsti"),
+        _def("make something keep happening", pos="verb", lithuanian_translation="tęsti"),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 1
+    assert len(collapsed) == 1
+
+
+def test_normalize_subtype_closed_class() -> None:
+    assert _normalize_subtype("preposition", "preposition") == "preposition_other"
+    assert _normalize_subtype("conjunction", "other") == "conjunction_other"
+    assert _normalize_subtype("noun", "abstract") == "abstract"
+
+
+# --- add_word end to end ----------------------------------------------------
+
+
+def test_add_word_creates_lemma(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    fake = patch_client(
+        [
+            _def(
+                "a domesticated carnivore",
+                pos="noun",
+                pos_subtype="animal",
+                lithuanian_translation="šuo",
+            )
+        ]
+    )
+    _seed_word_token(session, "dog", rank=300)
+
+    result = add_word(session, "dog", config=config)
+
+    assert isinstance(result, AddWordResult)
+    assert result.status == "created"
+    assert result.frequency_rank == 300
+    assert len(result.senses) == 1
+    assert fake.calls == 1
+
+    lemma = session.query(Lemma).filter(Lemma.lemma_text == "dog").one()
+    assert lemma.pos_type == "noun"
+    assert lemma.difficulty_level == -1
+    assert result.senses[0].translations.get("lt") == "šuo"
+
+
+def test_add_word_skips_existing_lemma(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    session.add(
+        Lemma(lemma_text="cat", definition_text="a small feline", pos_type="noun", guid="N01_001")
+    )
+    session.commit()
+    fake = patch_client([_def("a small feline", pos="noun")])
+
+    result = add_word(session, "cat", config=config)
+
+    assert result.status == "already_exists"
+    assert result.senses == []
+    # The existence guard must short-circuit before any LLM call.
+    assert fake.calls == 0
+
+
+def test_add_word_skips_spelling_variant(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    lemma = Lemma(lemma_text="gray", definition_text="a color", pos_type="noun", guid="N01_002")
+    session.add(lemma)
+    session.flush()
+    session.add(
+        VariantForm(
+            lemma_id=lemma.id,
+            variant_form_text="grey",
+            language_code="en",
+            variant_kind=VARIANT_KIND_SPELLING,
+            variant_key="grey",
+            grammatical_form="noun/en_singular",
+            is_base_form=True,
+        )
+    )
+    session.commit()
+    fake = patch_client([_def("a color", pos="noun")])
+
+    result = add_word(session, "grey", config=config)
+
+    assert result.status == "already_exists"
+    assert fake.calls == 0
+
+
+def test_add_word_all_very_common_senses_kept(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    # Three equally very_common senses on a rare word (max 2): all three are
+    # kept, because a very_common sense is never dropped for list position -- the
+    # ceiling only bounds lower tiers.
+    patch_client(
+        [
+            _def("first sense", pos="noun", prominence="very_common"),
+            _def("second sense", pos="noun", prominence="very_common"),
+            _def("third sense", pos="noun", prominence="very_common"),
+        ]
+    )
+
+    result = add_word(session, "obscureword", config=config)
+
+    assert result.status == "created"
+    assert len(result.senses) == 3
+
+
+def test_add_word_frequent_word_with_one_real_sense(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    # A very common word (rank < 2000) whose only prominent meaning is one
+    # sense, plus a rare sense. Frequency must NOT force the rare sense in --
+    # sense_prominence decides, so this yields a single lemma.
+    patch_client(
+        [
+            _def("the animal", pos="noun", prominence="very_common"),
+            _def("an obscure technical meaning", pos="noun", prominence="rare"),
+        ]
+    )
+    _seed_word_token(session, "dog", rank=200)
+
+    result = add_word(session, "dog", config=config)
+
+    assert result.status == "created"
+    assert result.frequency_rank == 200
+    assert len(result.senses) == 1
+    assert result.senses[0].definition_text == "the animal"
+
+
+def test_add_word_frequent_word_keeps_multiple_prominent_senses(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    # A common, genuinely polysemous word: two prominent senses both survive
+    # because they are "common", and the high frequency raises the ceiling.
+    patch_client(
+        [
+            _def(
+                "hit forcibly", pos="verb", pos_subtype="physical_action", prominence="very_common"
+            ),
+            _def("a work stoppage", pos="noun", pos_subtype="animal", prominence="common"),
+        ]
+    )
+    _seed_word_token(session, "strike", rank=800)
+
+    result = add_word(session, "strike", config=config)
+
+    assert result.status == "created"
+    assert len(result.senses) == 2
+
+
+def test_add_word_closed_class_single_sense(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    patch_client(
+        [
+            _def(
+                "except on the condition that", pos="conjunction", pos_subtype="conjunction_other"
+            ),
+            _def("if not", pos="conjunction", pos_subtype="conjunction_other"),
+        ]
+    )
+    _seed_word_token(session, "unless", rank=400)
+
+    result = add_word(session, "unless", config=config)
+
+    assert result.status == "created"
+    assert len(result.senses) == 1
+    assert session.query(Lemma).filter(Lemma.lemma_text == "unless").count() == 1
+
+
+def test_add_word_dry_run_writes_nothing(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    patch_client([_def("a domesticated carnivore", pos="noun", pos_subtype="animal")])
+    _seed_word_token(session, "dog", rank=300)
+
+    result = add_word(session, "dog", config=config, dry_run=True)
+
+    assert result.status == "created"
+    assert len(result.senses) == 1
+    assert session.query(Lemma).filter(Lemma.lemma_text == "dog").count() == 0
+
+
+def test_add_word_no_definitions(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    patch_client([])
+
+    result = add_word(session, "zzznotaword", config=config)
+
+    assert result.status == "no_definitions"
+    assert result.senses == []

--- a/src/words/add_word.py
+++ b/src/words/add_word.py
@@ -1,0 +1,564 @@
+"""Add a single English word to the database, from just the word.
+
+This is the intelligent word-addition pipeline: given a bare English word, it
+queries the LLM for the word's senses, decides which senses are worth adding
+(sized by the word's corpus frequency and capped for closed-class parts of
+speech), collapses senses the LLM over-split, and writes one lemma per surviving
+sense with a freshly minted GUID and the translations the definitions call
+already returned.
+
+It is the single implementation of that pipeline. The HTTP endpoint
+``POST /api/v1/words/add`` calls :func:`add_word`; batch scripts should too,
+rather than re-deriving sense selection and dedup. DRAMBLYS keeps its own
+two-step pending-import flow (staging queue + human review) for a different
+workflow, but shares the same ``select_senses_to_add`` / ``query_definitions``
+building blocks.
+
+The "does the database already have this word?" guard is
+``word_exists_in_english`` -- the canonical check that folds in lemmas,
+disambiguated lemmas, English derivative forms and alternate spellings
+(``variant_forms``), so "grey" resolves to the existing "gray" rather than
+splitting one lexeme across two rows.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from storage.backend.config import DataSourceConfig
+from storage.crud.operation_log import log_translation_change
+from storage.models.guid_prefixes import SUBTYPE_GUID_PREFIXES
+from storage.models.schema import (
+    SENSE_PROMINENCE_COMMON,
+    ExternalLexemeAnnotation,
+    Lemma,
+    WordToken,
+)
+from storage.queries.lemma import word_exists_in_english
+from storage.translation_helpers import convert_llm_response_to_lang_codes, set_translation
+from storage.utils.guid import generate_guid
+from wordfreq.translation.client import LinguisticClient
+from wordfreq.translation.constants import MAJOR_POS_TYPES
+from wordfreq.translation.definitions import (
+    DEFINITIONS_PROMPT_LANGUAGES,
+    SENSE_PROMINENCE_ORDER,
+    select_senses_to_add,
+)
+
+logger = logging.getLogger(__name__)
+
+# Per CLAUDE.md: newly added words default to -1 (unset difficulty).
+DIFFICULTY_LEVEL = -1
+# Languages the definitions call already returns per sense, stored as the lemma
+# is created so no second LLM call is needed for them.
+TRANSLATION_LANGUAGES: Tuple[str, ...] = DEFINITIONS_PROMPT_LANGUAGES
+
+# Frequency-driven sense sizing. A word's overall corpus rank sets only the
+# *ceiling* on how many senses to bother with -- it is a signal about the word,
+# not about any one meaning. Whether a given sense is worth a lemma is decided
+# by that sense's own ``sense_prominence`` inside select_senses_to_add, which
+# keeps a sense beyond the first only while it stays "common" or better.
+#
+# So min_senses is held at 1: a frequent word with a single real sense ("dog")
+# gets one lemma, not two padded out with a rare sense just because the word is
+# common. Frequency raises the max so a common, genuinely polysemous word
+# ("strike", "bank") can contribute its several *prominent* senses, while a rare
+# or corpus-absent word is capped low. Ordered most-common first; the first band
+# whose ``max_rank`` the word's rank falls at or under wins. ``None`` rank (word
+# absent from the corpora) falls through to the last, tightest band.
+_SENSE_MIN = 1
+_SENSE_BANDS: Tuple[Tuple[Optional[int], int], ...] = (
+    (2000, 4),  # rank <= 2000: up to 4 prominent senses
+    (10000, 3),  # rank 2001-10000: up to 3
+    (None, 2),  # rank > 10000 or unknown: up to 2
+)
+
+
+@dataclass
+class SenseResult:
+    """One lemma created (or that would be created) for a sense of the word."""
+
+    guid: str
+    pos_type: str
+    pos_subtype: str
+    definition_text: str
+    sense_prominence: str
+    translations: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AddWordResult:
+    """Outcome of an :func:`add_word` call.
+
+    ``status`` is one of:
+      * ``"created"`` -- one or more lemmas were created (see ``senses``)
+      * ``"already_exists"`` -- the word is already accounted for; nothing done
+      * ``"no_definitions"`` -- the LLM returned no usable senses
+      * ``"error"`` -- a sense failed validation/GUID minting; see ``error``
+    """
+
+    word: str
+    status: str
+    frequency_rank: Optional[int] = None
+    senses: List[SenseResult] = field(default_factory=list)
+    dropped_senses: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def _lookup_frequency(session: Session, word: str) -> Tuple[Optional[int], List[Dict[str, Any]]]:
+    """Return the word's overall corpus rank and its per-corpus rank breakdown.
+
+    ``frequency_rank`` is the combined harmonic-mean rank on the ``WordToken``;
+    the per-corpus list mirrors what DRAMBLYS records so the operation log
+    carries the same provenance. Both are ``None``/empty when the word is not in
+    the frequency corpora -- which is not an error here: the word is added
+    anyway, the rank just informs sense sizing.
+    """
+    token = (
+        session.query(WordToken)
+        .filter(WordToken.language_code == "en", WordToken.token == word)
+        .first()
+    )
+    if token is None:
+        return None, []
+
+    corpus_info: List[Dict[str, Any]] = []
+    annotations = (
+        session.query(ExternalLexemeAnnotation)
+        .filter(
+            ExternalLexemeAnnotation.word_token_id == token.id,
+            ExternalLexemeAnnotation.source.like("wordfreq_%"),
+        )
+        .all()
+    )
+    for annotation in annotations:
+        corpus_info.append(
+            {
+                "corpus": annotation.source.removeprefix("wordfreq_"),
+                "rank": annotation.ordinal_rank,
+                "frequency": annotation.frequency,
+            }
+        )
+    return token.frequency_rank, corpus_info
+
+
+def _sense_bounds(frequency_rank: Optional[int]) -> Tuple[int, int]:
+    """Return ``(min_senses, max_senses)`` for a word at this corpus rank.
+
+    ``min_senses`` is always ``_SENSE_MIN`` (1): whether a word deserves a
+    second sense is a question about that sense's ``sense_prominence``, not about
+    how frequent the word is, and select_senses_to_add already keeps prominent
+    senses beyond the first on its own. Frequency sets only ``max_senses`` -- the
+    ceiling -- so a common polysemous word can contribute several prominent
+    senses while a rare word is capped low. The closed-class cap in
+    :func:`_apply_pos_sense_cap` tightens this further, per-POS.
+    """
+    for max_rank, max_senses in _SENSE_BANDS:
+        if max_rank is None or (frequency_rank is not None and frequency_rank <= max_rank):
+            return _SENSE_MIN, max_senses
+    # _SENSE_BANDS ends with a None band, so this is unreachable; satisfy mypy.
+    return _SENSE_MIN, 2
+
+
+def _apply_pos_sense_cap(senses: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Cap closed-class words to a single sense.
+
+    Only the four major (open-class) POS types -- noun, verb, adjective, adverb
+    -- carry several genuinely distinct senses worth separate lemmas. The LLM
+    reliably over-splits closed-class words into overlapping senses ("unless"
+    comes back with two near-identical conjunction senses), so once the word's
+    POS is known to be closed-class, keep only the most prominent sense.
+
+    ``select_senses_to_add`` has already ordered senses by prominence, so the
+    first surviving sense is the one to keep. POS is read from the first sense:
+    a word is one part of speech here, and mixed-POS answers are the LLM
+    guessing.
+
+    Returns:
+        (kept senses, human-readable descriptions of the senses dropped)
+    """
+    if not senses:
+        return senses, []
+    pos_type = (senses[0].get("pos") or "").lower()
+    if pos_type in MAJOR_POS_TYPES or len(senses) <= 1:
+        return senses, []
+
+    dropped = [
+        f"{(sense.get('definition') or '')[:40]} (closed-class {pos_type}: 1 sense only)"
+        for sense in senses[1:]
+    ]
+    return senses[:1], dropped
+
+
+def _drop_translation_duplicates(
+    senses: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Collapse senses that share a pos_type and every translation.
+
+    The LLM over-splits grammatical words: "continue" comes back as a separate
+    intransitive "keep happening" and transitive "make something keep happening"
+    whose definitions differ but whose lt/es/fr/zh translations are identical --
+    the signal that these are one sense described twice. Storing both would mint
+    two GUIDs no downstream consumer can tell apart.
+
+    Keyed on pos_type plus the translation tuple, ignoring pos_subtype and
+    definition text: a differing subtype on identical translations is the LLM
+    guessing, not a real distinction. Senses arrive prominence-ordered, so the
+    first one wins.
+
+    Returns:
+        (kept senses, human-readable descriptions of the senses collapsed)
+    """
+    kept: List[Dict[str, Any]] = []
+    collapsed: List[str] = []
+    seen: Dict[Tuple[str, ...], str] = {}
+
+    for sense in senses:
+        by_lang_code = convert_llm_response_to_lang_codes(sense)
+        translations = tuple(
+            (by_lang_code.get(lang_code) or "").strip().lower()
+            for lang_code in TRANSLATION_LANGUAGES
+        )
+        if not any(translations):
+            kept.append(sense)
+            continue
+
+        key = (sense.get("pos") or "",) + translations
+        first = seen.get(key)
+        if first is not None:
+            definition = (sense.get("definition") or "")[:40]
+            collapsed.append(f"{definition} (same pos+translations as {first!r})")
+            continue
+
+        seen[key] = (sense.get("definition") or "")[:40]
+        kept.append(sense)
+
+    return kept, collapsed
+
+
+def _normalize_subtype(pos_type: str, pos_subtype: Optional[str]) -> Optional[str]:
+    """Map an LLM-supplied subtype onto the spelling ``guid_prefixes`` expects.
+
+    For the closed-class POS types the only subtype is "<pos>_other", but the
+    LLM tends to answer with the bare pos name ("preposition") or "other".
+    ``storage/utils/guid.py`` already special-cases exactly this for
+    interjection; the same mismatch exists for preposition, conjunction,
+    pronoun, article and determiner, so normalize them all here.
+    """
+    if pos_subtype is None:
+        return None
+    canonical = f"{pos_type}_other"
+    subtypes = SUBTYPE_GUID_PREFIXES.get(pos_type, {})
+    if canonical in subtypes and pos_subtype in (pos_type, "other", canonical):
+        return canonical
+    # Verbs/nouns/adjectives/adverbs spell their catch-all "<pos>_other" too,
+    # while storage.utils.enums spells it plain "other".
+    if pos_subtype == "other" and canonical in subtypes:
+        return canonical
+    return pos_subtype
+
+
+def _validate_pos(pos_type: str, pos_subtype: Optional[str]) -> Optional[str]:
+    """Return an error string if pos_type/pos_subtype are not a valid GUID pair.
+
+    ``guid_prefixes`` is the binding constraint: a lemma needs a GUID, and
+    ``storage.utils.enums`` lists pos_types ("modal", "auxiliary") that have no
+    GUID prefix at all, and spells the catch-all subtype differently.
+    """
+    if pos_type not in SUBTYPE_GUID_PREFIXES:
+        return f"pos_type {pos_type!r} has no GUID prefix; not a lemma pos_type"
+    if pos_subtype is None:
+        return f"pos_type {pos_type!r} requires a subtype"
+    if pos_subtype not in SUBTYPE_GUID_PREFIXES[pos_type]:
+        return f"invalid pos_subtype {pos_subtype!r} for {pos_type!r}"
+    return None
+
+
+def _prominence_rank(sense: Dict[str, Any]) -> int:
+    """Ordinal of a sense's prominence (0 = very_common); unrated counts as common."""
+    order = {value: index for index, value in enumerate(SENSE_PROMINENCE_ORDER)}
+    default = order[SENSE_PROMINENCE_COMMON]
+    return order.get(sense.get("sense_prominence", ""), default)
+
+
+def _extend_for_prominence_ties(
+    selected: List[Dict[str, Any]], definitions_list: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Re-include senses the ``max_senses`` ceiling split off mid-prominence-tier.
+
+    ``max_senses`` is a soft target, not a hard cut. When the ceiling lands
+    *between* prominence tiers -- two very_common senses with a max of two, the
+    rest merely common -- that cut is right: keep the two, drop the commons.
+    But when it lands *inside* a tier -- one very_common plus four common with a
+    max of three -- cutting arbitrarily keeps three of the four equally-common
+    senses and drops one for no reason but list position. In that case keep the
+    whole tied tier.
+
+    Only same-prominence senses are pulled back in, and only at the boundary
+    tier of what ``select_senses_to_add`` already kept, so this never reaches
+    down into ``uncommon``/``rare``: those stay dropped.
+
+    Returns the (possibly extended) selection, most-prominent first.
+    """
+    if not selected:
+        return selected
+
+    boundary_rank = _prominence_rank(selected[-1])
+    # Only extend within common-or-better tiers. If the boundary sense is only
+    # there because min_senses forced an uncommon/rare one in, do not drag its
+    # equally-marginal siblings along.
+    if boundary_rank > _prominence_rank({"sense_prominence": SENSE_PROMINENCE_COMMON}):
+        return selected
+
+    kept_ids = {id(sense) for sense in selected}
+    extras = [
+        sense
+        for sense in definitions_list
+        if id(sense) not in kept_ids and _prominence_rank(sense) == boundary_rank
+    ]
+    return selected + extras
+
+
+def _pick_senses(
+    client: LinguisticClient, word: str, frequency_rank: Optional[int]
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Ask the LLM for the word's senses and keep the ones worth adding.
+
+    One LLM call. Selection is frequency-sized (``_sense_bounds``), extended to
+    include senses tied in prominence at the ceiling (``_extend_for_prominence_ties``),
+    then capped for closed-class parts of speech (``_apply_pos_sense_cap``), then
+    collapsed where the LLM over-split into translation-identical senses
+    (``_drop_translation_duplicates``).
+
+    Returns:
+        (selected senses, human-readable descriptions of the senses dropped)
+    """
+    definitions_list, success = client.query_definitions(word)
+    if not success or not definitions_list:
+        return [], []
+
+    min_senses, max_senses = _sense_bounds(frequency_rank)
+    selected = select_senses_to_add(definitions_list, max_senses=max_senses, min_senses=min_senses)
+    selected = _extend_for_prominence_ties(selected, definitions_list)
+    kept_ids = {id(sense) for sense in selected}
+    dropped = [
+        f"{(sense.get('definition') or '')[:40]} ({sense.get('sense_prominence', 'unrated')})"
+        for sense in definitions_list
+        if id(sense) not in kept_ids
+    ]
+
+    capped, cap_dropped = _apply_pos_sense_cap(selected)
+    deduped, collapsed = _drop_translation_duplicates(capped)
+    return [dict(sense) for sense in deduped], dropped + cap_dropped + collapsed
+
+
+def _store_sense_translations(
+    session: Session, lemma: Lemma, sense: Dict[str, Any], *, source: str, model: Optional[str]
+) -> Dict[str, str]:
+    """Save the translations the definitions call already returned for this sense.
+
+    The definitions schema returns lt/es/fr/zh per sense, so they arrive with
+    the definition at no extra LLM cost, and each sense gets its own
+    translation. Field names map to language codes through translation_helpers,
+    per CLAUDE.md -- no local mapping.
+
+    Returns:
+        The language code -> translation text pairs actually stored.
+    """
+    by_lang_code = convert_llm_response_to_lang_codes(sense)
+    stored: Dict[str, str] = {}
+    for lang_code in TRANSLATION_LANGUAGES:
+        translation = (by_lang_code.get(lang_code) or "").strip()
+        if not translation:
+            continue
+        set_translation(session, lemma, lang_code, translation)
+        log_translation_change(
+            session=session,
+            source=source,
+            operation_type="translation",
+            lemma_id=lemma.id,
+            language_code=lang_code,
+            old_translation=None,
+            new_translation=translation,
+            guid=lemma.guid,
+            model=model,
+        )
+        stored[lang_code] = translation
+    return stored
+
+
+def add_word(
+    session: Session,
+    word: str,
+    *,
+    config: DataSourceConfig,
+    model: Optional[str] = None,
+    source: str = "add_word",
+    dry_run: bool = False,
+) -> AddWordResult:
+    """Add a single English word to the database, from just the word.
+
+    Runs the full pipeline: existence guard, frequency lookup, one LLM call for
+    the word's senses, frequency-sized and closed-class-capped sense selection,
+    translation-duplicate collapse, then one lemma per surviving sense with a
+    minted GUID and the translations the definitions call returned.
+
+    The word is committed per sense on success (a multi-sense word is a series
+    of small writes, not one all-or-nothing transaction), matching how the
+    batch importer behaves. ``dry_run`` runs the whole pipeline -- including the
+    LLM call, which is needed to show what would be written -- but writes
+    nothing and rolls back.
+
+    Args:
+        session: Database session.
+        word: English word to add.
+        config: Data source configuration for the ``LinguisticClient``.
+        model: LLM model override; falls back to ``config.model``.
+        source: Operation-log source tag.
+        dry_run: Run the pipeline without writing (still makes the LLM call).
+
+    Returns:
+        An :class:`AddWordResult` describing what was (or would be) created.
+    """
+    normalized = word.strip()
+    if not normalized:
+        return AddWordResult(word=word, status="error", error="word must be non-empty")
+
+    # Existence guard: lemmas, disambiguated lemmas, en derivative forms and
+    # alternate spellings. include_exclusions=True because this gates an import
+    # -- a word rejected once should not be re-added.
+    if word_exists_in_english(session, normalized, include_exclusions=True):
+        return AddWordResult(word=normalized, status="already_exists")
+
+    frequency_rank, corpus_info = _lookup_frequency(session, normalized)
+    best_corpus_rank = min((c["rank"] for c in corpus_info if c["rank"] is not None), default=None)
+
+    client_config = config.with_model(model) if model else config
+    client = LinguisticClient(config=client_config)
+    client_model = client_config.model
+
+    senses, dropped = _pick_senses(client, normalized, frequency_rank)
+    if not senses:
+        return AddWordResult(
+            word=normalized,
+            status="no_definitions",
+            frequency_rank=frequency_rank,
+            dropped_senses=dropped,
+        )
+
+    result = AddWordResult(
+        word=normalized,
+        status="created",
+        frequency_rank=frequency_rank,
+        dropped_senses=dropped,
+    )
+    issued_guids: Dict[str, str] = {}
+
+    try:
+        for sense in senses:
+            pos_type = (sense.get("pos") or "").lower()
+            pos_subtype = _normalize_subtype(pos_type, sense.get("pos_subtype"))
+            definition_text = sense.get("definition") or ""
+            prominence = sense.get("sense_prominence") or SENSE_PROMINENCE_COMMON
+
+            if not definition_text:
+                logger.warning("Skipping empty definition for %r", normalized)
+                continue
+
+            pos_error = _validate_pos(pos_type, pos_subtype)
+            if pos_error is not None:
+                session.rollback()
+                return AddWordResult(
+                    word=normalized,
+                    status="error",
+                    frequency_rank=frequency_rank,
+                    senses=result.senses,
+                    dropped_senses=dropped,
+                    error=f"LLM gave {pos_error}",
+                )
+            assert pos_subtype is not None  # _validate_pos rejects None
+
+            try:
+                guid = generate_guid(session, pos_type, pos_subtype)
+            except ValueError as exc:
+                session.rollback()
+                return AddWordResult(
+                    word=normalized,
+                    status="error",
+                    frequency_rank=frequency_rank,
+                    senses=result.senses,
+                    dropped_senses=dropped,
+                    error=f"GUID generation: {exc}",
+                )
+
+            # In dry-run nothing is flushed, so generate_guid returns the same
+            # GUID for same-subtype senses; note the collision rather than
+            # reporting it twice as distinct.
+            issued_guids.setdefault(guid, normalized)
+
+            sense_result = SenseResult(
+                guid=guid,
+                pos_type=pos_type,
+                pos_subtype=pos_subtype,
+                definition_text=definition_text,
+                sense_prominence=prominence,
+            )
+
+            if dry_run:
+                preview = convert_llm_response_to_lang_codes(sense)
+                sense_result.translations = {
+                    code: preview[code] for code in TRANSLATION_LANGUAGES if preview.get(code)
+                }
+                result.senses.append(sense_result)
+                continue
+
+            new_lemma = Lemma(
+                lemma_text=normalized,
+                definition_text=definition_text,
+                pos_type=pos_type,
+                pos_subtype=pos_subtype,
+                guid=guid,
+                difficulty_level=DIFFICULTY_LEVEL,
+                confidence=0.0,
+                verified=False,
+                sense_prominence=prominence,
+            )
+            session.add(new_lemma)
+            session.flush()
+
+            log_translation_change(
+                session=session,
+                source=source,
+                operation_type="lemma_create",
+                lemma_id=new_lemma.id,
+                language_code="en",
+                old_translation=None,
+                new_translation=normalized,
+                guid=guid,
+                pos_type=pos_type,
+                pos_subtype=pos_subtype,
+                definition=definition_text,
+                sense_prominence=prominence,
+                model=client_model,
+                best_corpus_rank=best_corpus_rank,
+            )
+            sense_result.translations = _store_sense_translations(
+                session, new_lemma, sense, source=source, model=client_model
+            )
+
+            # Commit per sense: a multi-sense word is a series of small writes,
+            # so a failure on a later sense does not discard the earlier ones.
+            session.commit()
+            result.senses.append(sense_result)
+
+        if dry_run:
+            session.rollback()
+    except Exception:
+        session.rollback()
+        raise
+
+    if not result.senses:
+        result.status = "no_definitions"
+    return result


### PR DESCRIPTION
Adds a shared src/words/add_word.py pipeline and an HTTP endpoint that turn a bare English word into one lemma per sense worth adding -- the intelligent counterpart to the dumb /v1/lemmas/add writer. Previously this logic lived only in a scratch batch script and inside dramblys' pending-import flow, with no HTTP path from a word to a lemma.

Pipeline (one LLM call): existence guard via word_exists_in_english (folds in lemmas, disambiguated lemmas, en derivative forms, alternate spellings); frequency-sized sense ceiling; closed-class single-sense cap for non noun/verb/adjective/adverb POS; translation-duplicate collapse; GUID mint; lemma at difficulty -1 with the es/fr/lt/zh translations the definitions call returned.

Sense selection uses the word's corpus rank only as a soft ceiling and lets each sense's own sense_prominence decide the floor. When the ceiling lands inside a prominence tier, _extend_for_prominence_ties keeps the whole tied tier rather than dropping an equally-prominent sense for list position; it never reaches down into uncommon/rare. select_senses_to_add is left unchanged so dramblys' behavior is untouched.

Endpoint is synchronous, one word per request, with a mirrored api/ facade (add_word in api/lemmas.py) and API.md docs. Does not generate derivative forms -- that stays a separate generate-forms pass.

Also documents a TODO in generate_guid: it does not see unflushed session rows, so callers must flush after each add (add_word does).