### PR TITLE
Fix dramblys batch-01 follow-ups in /words/add and /search

### DIFF
--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -32,6 +32,11 @@ class SearchResponse(TypedDict):
     metadata: Dict[str, Any]
 
 
+class WordsExistResponse(TypedDict):
+    data: Dict[str, bool]
+    metadata: Dict[str, Any]
+
+
 class TranslationMapResponse(TypedDict):
     data: Dict[str, str]
     metadata: Dict[str, Any]
@@ -219,8 +224,33 @@ def add_lemmas(lemmas: List[AddLemmaInput]) -> Any:
     return post_json(f"{API_V1_PREFIX}/lemmas/add", {"lemmas": lemmas})
 
 
+@mirrored_route("/api/v1/words/exists", "POST")
+def words_exist(words: List[str], include_exclusions: bool = True) -> WordsExistResponse:
+    """Check which English words the database already accounts for.
+
+    The bulk, exact-accounting counterpart to :func:`search`: it answers the same
+    question :func:`add_word` asks before minting, so a wordlist survey agrees
+    with what the add endpoint will do. A word counts as existing if it appears
+    as a lemma, a disambiguated lemma, an English derivative form, or an
+    alternate spelling. Makes no LLM call and writes nothing.
+
+    ``include_exclusions`` defaults to true, matching how :func:`add_word` gates
+    imports. Pass false to measure dictionary coverage, where a word on the
+    exclusions list is genuinely absent.
+
+    ``data`` maps each word, lowercased, to a boolean. At most 150 words.
+    """
+    return cast(
+        WordsExistResponse,
+        post_json(
+            f"{API_V1_PREFIX}/words/exists",
+            {"words": words, "include_exclusions": include_exclusions},
+        ),
+    )
+
+
 @mirrored_route("/api/v1/words/add", "POST")
-def add_word(word: str, model: str, dry_run: bool = False) -> Any:
+def add_word(word: str, model: str) -> Any:
     """Add a single English word to the database, from just the word.
 
     Unlike :func:`add_lemmas` (which takes fully specified lemma rows), this runs
@@ -231,11 +261,20 @@ def add_word(word: str, model: str, dry_run: bool = False) -> Any:
 
     A word already accounted for -- as a lemma, disambiguated lemma, English
     derivative form or alternate spelling -- returns ``status`` ``"already_exists"``
-    and nothing is written. Pass ``dry_run=True`` to preview without writing.
+    and nothing is written. Use :func:`words_exist` to check first without paying
+    for the LLM call.
+
+    Senses landing on a catch-all ``*_other`` subtype for an open-class word are
+    diverted to the pending-import queue for human review rather than written as
+    lemmas, and come back in ``pending_senses``. A word whose every sense is
+    diverted returns ``status`` ``"pending_review"``.
+
+    There is no preview mode: a preview needs the LLM call, and that call is
+    non-deterministic, so it cannot predict what a committing run writes.
     """
     return post_json(
         f"{API_V1_PREFIX}/words/add",
-        {"word": word, "model": model, "dry_run": dry_run},
+        {"word": word, "model": model},
     )
 
 

--- a/src/barsukas/routes/API.md
+++ b/src/barsukas/routes/API.md
@@ -46,11 +46,26 @@ Base prefix: `/api`.
   - `lemma_text`/`definition_text`/`pos_type`/`pos_subtype` are required per entry; `difficulty_level` and `translations` are optional. Max 100 entries.
   - GUIDs are assigned automatically from the `pos_type`/`pos_subtype` prefix. An entry whose `(lemma_text, pos_type)` already exists is returned with `status: "already_exists"` and its existing GUID, and is not modified; created entries return `status: "created"`.
 
+- `POST /api/v1/words/exists`
+  - Check which of a list of English words the database already accounts for —
+    the bulk, exact-accounting counterpart to `/api/v1/search`. Makes no LLM
+    call and writes nothing.
+  - Body: `{"words": ["...", ...], "include_exclusions": <bool, optional, default true>}`. Max 150 entries.
+  - Answers the same question `/api/v1/words/add` asks before minting, so a
+    wordlist survey agrees with what the add endpoint will do. A word counts as
+    existing if it appears as a lemma, a disambiguated lemma, an English
+    derivative form, or an alternate spelling (`variant_forms`).
+  - `include_exclusions` defaults to `true`, matching how `/v1/words/add` gates
+    imports. Pass `false` to measure dictionary coverage, where a word on the
+    exclusions list is genuinely absent.
+  - Response `data`: `{"<word>": true|false}`, keyed by the lowercased word.
+    `metadata` carries `{checked, existing, include_exclusions}`.
+
 - `POST /api/v1/words/add`
   - Add a single English word to the database from **just the word** — the
     intelligent counterpart to `/v1/lemmas/add`. **Makes an LLM call and costs
-    money.**
-  - Body: `{"word": "...", "model": "<model-name>", "dry_run": <bool, optional>}`.
+    money.** Use `/api/v1/words/exists` to check first without paying for it.
+  - Body: `{"word": "...", "model": "<model-name>"}`.
   - Queries the LLM for the word's senses, sizes how many senses to add by the
     word's corpus frequency (rarer words get fewer senses), caps closed-class
     words — anything other than noun/verb/adjective/adverb — to a single sense,
@@ -60,11 +75,22 @@ Base prefix: `/api`.
   - A word already accounted for — as a lemma, disambiguated lemma, English
     derivative form, or alternate spelling (`variant_forms`) — returns
     `status: "already_exists"` and nothing is written.
-  - Response `data`: `{word, status, frequency_rank, senses: [{guid, pos_type, pos_subtype, definition_text, sense_prominence, translations}], dropped_senses}`.
-    `status` is one of `created`, `already_exists`, `no_definitions`.
-    `metadata` carries `{model, dry_run, created}`.
-  - `dry_run: true` runs the whole pipeline (still making the LLM call) but
-    writes nothing; the response shows what would be created.
+  - Senses landing on a catch-all `*_other` subtype for an open-class word
+    (noun/verb/adjective/adverb) are diverted to the pending-import queue for
+    human review instead of being written as lemmas, and are returned in
+    `pending_senses` with an empty `guid`. Closed-class words are unaffected:
+    `<pos>_other` is their only subtype. A word whose every surviving sense is
+    diverted returns `status: "pending_review"`.
+  - The corpus rank falls back to inflected forms when the base form is absent
+    from the corpora (the corpus holds `exclaimed`, not `exclaim`). Candidates
+    are generated only for the POS the LLM returned. `frequency_rank_source`
+    names the surface form the rank came from.
+  - Response `data`: `{word, status, frequency_rank, frequency_rank_source, senses: [{guid, pos_type, pos_subtype, definition_text, sense_prominence, translations}], pending_senses: [...], dropped_senses}`.
+    `status` is one of `created`, `pending_review`, `already_exists`, `no_definitions`.
+    `metadata` carries `{model, created, pending}`.
+  - There is no preview mode. A preview needs the LLM call, and that call is
+    non-deterministic, so it cannot predict what a committing run writes. A
+    request still sending `dry_run` is rejected with a 400 rather than written.
 
 - `POST /api/v1/lemma/<main_guid>/merge-synonym/<synonym_guid>`
   - Merge the synonym lemma into the main lemma. Requires the same `pos_type` and at least 3 matching non-empty translations after normalization.

--- a/src/barsukas/routes/api/lemma_routes.py
+++ b/src/barsukas/routes/api/lemma_routes.py
@@ -997,6 +997,69 @@ def add_lemmas() -> ResponseReturnValue:
     )
 
 
+MAX_EXISTS_WORDS = 150
+
+
+@bp.route("/v1/words/exists", methods=["POST"])
+@mirrored_facade("/api/v1/words/exists", "POST")
+def words_exist_endpoint() -> ResponseReturnValue:
+    """Check which of a list of English words the database already accounts for.
+
+    This is the exact-accounting counterpart to ``/v1/search``: it answers the
+    same question ``/v1/words/add`` asks before minting anything, so a caller
+    surveying a wordlist gets the same verdict the add endpoint will. A word
+    counts as existing if it appears as a lemma, a disambiguated lemma, an
+    English derivative form, or an alternate spelling in ``variant_forms``.
+
+    Makes no LLM call and writes nothing.
+
+    JSON body:
+      - ``words``: list of English words to check (required, max 150).
+      - ``include_exclusions``: also count words on the English exclusions list.
+        Optional, default true -- matching how ``/v1/words/add`` gates imports,
+        so a word rejected once is not re-proposed. Pass false to measure
+        dictionary coverage, where an excluded word is genuinely absent.
+
+    Returns a ``data`` object mapping each word (lowercased) to a boolean.
+    """
+    from storage.queries.lemma import filter_existing_english_words
+
+    payload = request.get_json(silent=True) or {}
+    words = payload.get("words")
+    if not isinstance(words, list) or not words:
+        return _build_error_response("words is required and must be a non-empty list")
+    if not all(isinstance(word, str) for word in words):
+        return _build_error_response("words must be a list of strings")
+    if len(words) > MAX_EXISTS_WORDS:
+        return _build_error_response(
+            f"words may contain at most {MAX_EXISTS_WORDS} entries; got {len(words)}"
+        )
+
+    include_exclusions = payload.get("include_exclusions", True)
+    if not isinstance(include_exclusions, bool):
+        return _build_error_response("include_exclusions must be a boolean")
+
+    existing = filter_existing_english_words(g.db, words, include_exclusions=include_exclusions)
+
+    # Key on the normalized word, since that is what the helper reports back and
+    # what "already exists" is actually keyed on. Duplicates in the request
+    # collapse to one entry.
+    results = {}
+    for word in words:
+        normalized = word.strip().lower()
+        if normalized:
+            results[normalized] = normalized in existing
+
+    return _build_success_response(
+        results,
+        {
+            "checked": len(results),
+            "existing": sum(1 for found in results.values() if found),
+            "include_exclusions": include_exclusions,
+        },
+    )
+
+
 @bp.route("/v1/words/add", methods=["POST"])
 @mirrored_facade("/api/v1/words/add", "POST")
 def add_word_endpoint() -> ResponseReturnValue:
@@ -1012,13 +1075,19 @@ def add_word_endpoint() -> ResponseReturnValue:
     JSON body:
       - ``word``: the English word to add (required).
       - ``model``: LLM model name (required).
-      - ``dry_run``: if true, run the pipeline (including the LLM call) but write
-        nothing; the response shows what would be created. Optional, default
-        false.
 
     Synchronous, one word per request. A word already accounted for -- as a
     lemma, disambiguated lemma, English derivative form or alternate spelling --
     is returned with ``status: "already_exists"`` and nothing is written.
+
+    Senses that land on a catch-all ``*_other`` subtype for an open-class word
+    are diverted to the pending-import queue for human review instead of being
+    written as lemmas; they come back in ``pending_senses`` with an empty GUID.
+    A word whose every sense is diverted returns ``status: "pending_review"``.
+
+    There is no preview mode: a preview needs the LLM call, and that call is
+    non-deterministic, so it cannot predict what a committing run writes. A
+    request still sending ``dry_run`` is rejected rather than silently written.
     """
     from storage.backend.config import BackendType, DataSourceConfig
     from words.add_word import add_word
@@ -1032,9 +1101,14 @@ def add_word_endpoint() -> ResponseReturnValue:
     if not isinstance(word, str) or not word.strip():
         return _build_error_response("word is required and must be a non-empty string")
 
-    dry_run_raw = payload.get("dry_run", False)
-    if not isinstance(dry_run_raw, bool):
-        return _build_error_response("dry_run must be a boolean")
+    # Fail loudly on the removed flag: a caller that still sends dry_run=True is
+    # expecting a preview, and silently committing would be the worst outcome.
+    if "dry_run" in payload:
+        return _build_error_response(
+            "dry_run is no longer supported: the preview required the LLM call and "
+            "was non-deterministic, so it did not predict what a committing run "
+            "writes. Remove the flag to write, or do not call this endpoint."
+        )
 
     config = DataSourceConfig(
         backend_type=BackendType.SQLITE,
@@ -1048,32 +1122,37 @@ def add_word_endpoint() -> ResponseReturnValue:
         config=config,
         model=model,
         source=Config.OPERATION_LOG_SOURCE,
-        dry_run=dry_run_raw,
     )
 
     if result.status == "error":
         return _build_error_response(result.error or "failed to add word")
 
+    def _serialize_sense(sense: Any) -> Dict[str, Any]:
+        return {
+            "guid": sense.guid,
+            "pos_type": sense.pos_type,
+            "pos_subtype": sense.pos_subtype,
+            "definition_text": sense.definition_text,
+            "sense_prominence": sense.sense_prominence,
+            "translations": sense.translations,
+        }
+
     data = {
         "word": result.word,
         "status": result.status,
         "frequency_rank": _serialize_value(result.frequency_rank),
-        "senses": [
-            {
-                "guid": sense.guid,
-                "pos_type": sense.pos_type,
-                "pos_subtype": sense.pos_subtype,
-                "definition_text": sense.definition_text,
-                "sense_prominence": sense.sense_prominence,
-                "translations": sense.translations,
-            }
-            for sense in result.senses
-        ],
+        "frequency_rank_source": _serialize_value(result.frequency_rank_source),
+        "senses": [_serialize_sense(sense) for sense in result.senses],
+        "pending_senses": [_serialize_sense(sense) for sense in result.pending_senses],
         "dropped_senses": result.dropped_senses,
     }
     return _build_success_response(
         data,
-        {"model": model, "dry_run": dry_run_raw, "created": len(result.senses)},
+        {
+            "model": model,
+            "created": len(result.senses),
+            "pending": len(result.pending_senses),
+        },
     )
 
 

--- a/src/barsukas/routes/api/meta_routes.py
+++ b/src/barsukas/routes/api/meta_routes.py
@@ -49,7 +49,7 @@ def api_info() -> ResponseReturnValue:
                     "name": "q",
                     "type": "query",
                     "required": False,
-                    "description": "Search query (searches lemma text, definition, disambiguation, translations). Empty/omitted matches all lemmas.",
+                    "description": "Search query (searches lemma text, definition, disambiguation, translations, and English derivative/variant forms). Empty/omitted matches all lemmas.",
                 },
                 {
                     "name": "pos_type",

--- a/src/langtools/collation.py
+++ b/src/langtools/collation.py
@@ -393,13 +393,21 @@ NON_LATIN_SORT_KEY_LANGUAGES = frozenset(
 SORT_KEY_LANGUAGES = LATIN_SORT_KEY_LANGUAGES | NON_LATIN_SORT_KEY_LANGUAGES
 
 
-def _strip_diacritics(text: str) -> str:
+def strip_diacritics(text: str) -> str:
     """Remove combining diacritical marks via NFD decomposition.
 
     ``"café"`` → ``"cafe"``, ``"über"`` → ``"uber"``, ``"façade"`` → ``"facade"``.
+
+    Public because comparing translations across languages needs the same fold
+    (``words.add_word`` uses it to tell "proteger" and "protéger" apart from a
+    genuine sense distinction).
     """
     nfd = unicodedata.normalize("NFD", text)
     return "".join(ch for ch in nfd if unicodedata.category(ch) != "Mn")
+
+
+# Retained for in-module callers that predate the rename.
+_strip_diacritics = strip_diacritics
 
 
 # Vietnamese tone marks (combining characters) to strip.  These are the

--- a/src/storage/queries/lemma.py
+++ b/src/storage/queries/lemma.py
@@ -5,7 +5,13 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 from sqlalchemy import case, func, or_
 from sqlalchemy.orm import Query, Session
 
-from storage.models.schema import Lemma, LemmaDifficultyOverride, LemmaTranslation
+from storage.models.schema import (
+    DerivativeForm,
+    Lemma,
+    LemmaDifficultyOverride,
+    LemmaTranslation,
+)
+from storage.models.variant_form import VariantForm
 
 
 def apply_effective_difficulty_filter(
@@ -92,9 +98,16 @@ def build_lemma_search_query(
     """
     Build a filtered and ordered lemma query for search/listing.
 
+    The text search covers the same ground as ``word_exists_in_english``: lemma
+    text, definition, disambiguation, translations in any language, and -- for
+    English -- derivative forms and alternate spellings. Folding the last two in
+    keeps search and the import guard agreeing about what the database holds, so
+    "grey" finds the existing "gray" lemma rather than reporting it missing.
+
     Args:
         session: Database session
-        search: Search term to find in lemma text, definition, disambiguation, and translations
+        search: Search term to find in lemma text, definition, disambiguation,
+            translations, and English derivative/variant forms
         pos_type: Filter by part of speech type
         pos_subtype: Filter by part of speech subtype
         difficulty: Filter by difficulty level (supports "-1", "null", or numeric string)
@@ -131,6 +144,23 @@ def build_lemma_search_query(
         )
 
         search_conditions.append(Lemma.id.in_(translation_subquery))
+
+        # English derivative forms ("grayer", "walked") and alternate spellings
+        # ("grey" for "gray"). Without these, search disagrees with
+        # word_exists_in_english about what the database contains -- the guard
+        # folds both in, so a caller surveying for missing words gets one answer
+        # from search and another from the add endpoint.
+        derivative_subquery = session.query(DerivativeForm.lemma_id).filter(
+            DerivativeForm.language_code == "en",
+            DerivativeForm.derivative_form_text.ilike(f"%{search}%"),
+        )
+        search_conditions.append(Lemma.id.in_(derivative_subquery))
+
+        variant_subquery = session.query(VariantForm.lemma_id).filter(
+            VariantForm.language_code == "en",
+            VariantForm.variant_form_text.ilike(f"%{search}%"),
+        )
+        search_conditions.append(Lemma.id.in_(variant_subquery))
 
         query = query.filter(or_(*search_conditions))
 
@@ -173,7 +203,27 @@ def build_lemma_search_query(
                 ),
                 6,
             ),
-            else_=7,
+            # An alternate spelling is a closer hit than an inflection: "grey"
+            # names the same lexeme, "walked" is a form of it.
+            (
+                Lemma.id.in_(
+                    session.query(VariantForm.lemma_id).filter(
+                        VariantForm.language_code == "en",
+                        func.lower(VariantForm.variant_form_text).contains(search_lower),
+                    )
+                ),
+                7,
+            ),
+            (
+                Lemma.id.in_(
+                    session.query(DerivativeForm.lemma_id).filter(
+                        DerivativeForm.language_code == "en",
+                        func.lower(DerivativeForm.derivative_form_text).contains(search_lower),
+                    )
+                ),
+                8,
+            ),
+            else_=9,
         )
         if display_translation_joined:
             display_text_order = func.lower(

--- a/src/tests/barsukas/conftest.py
+++ b/src/tests/barsukas/conftest.py
@@ -23,6 +23,7 @@ from storage.models.schema import (
     Sentence,
     SentenceTranslation,
 )
+from storage.models.variant_form import VariantForm
 
 
 @pytest.fixture()
@@ -75,8 +76,34 @@ def _seed_database(session: Session) -> None:
         confidence=0.9,
         verified=False,
     )
-    session.add_all([lemma1, lemma2])
+    # "gray" carries the alternate spelling "grey" in variant_forms rather than
+    # as its own lemma -- the case where search and the import guard used to
+    # disagree about what the database contains.
+    lemma3 = Lemma(
+        id=3,
+        lemma_text="gray",
+        definition_text="of a color between black and white",
+        pos_type="adjective",
+        pos_subtype="color",
+        guid="J01_001",
+        difficulty_level=2,
+        confidence=0.9,
+        verified=False,
+    )
+    session.add_all([lemma1, lemma2, lemma3])
     session.flush()
+
+    session.add(
+        VariantForm(
+            lemma_id=3,
+            language_code="en",
+            variant_kind="spelling",
+            variant_key="grey",
+            grammatical_form="adjective/en_positive",
+            variant_form_text="grey",
+            is_base_form=True,
+        )
+    )
 
     # Add a table-based translation for lemma1
     t1 = LemmaTranslation(lemma_id=1, language_code="fr", translation="manger")

--- a/src/tests/barsukas/helpers/test_db_optimization.py
+++ b/src/tests/barsukas/helpers/test_db_optimization.py
@@ -34,10 +34,21 @@ class TestGetHomePageStats:
         assert all(v == 0 for v in result.values())
 
     def test_counts_match_seed_data(self, seeded_session: Session) -> None:
+        # Derived from the seed rather than hardcoded: adding a lemma to the
+        # shared fixture should not require editing a literal here.
+        expected_total = seeded_session.query(Lemma).count()
+        expected_verified = seeded_session.query(Lemma).filter(Lemma.verified.is_(True)).count()
+        expected_with_difficulty = (
+            seeded_session.query(Lemma).filter(Lemma.difficulty_level.isnot(None)).count()
+        )
+
         result = get_home_page_stats(seeded_session)
-        assert result["total_lemmas"] == 2
-        assert result["verified_lemmas"] == 1  # only "eat" is verified
-        assert result["with_difficulty"] == 2  # both have difficulty_level
+
+        assert result["total_lemmas"] == expected_total
+        assert result["verified_lemmas"] == expected_verified
+        assert result["with_difficulty"] == expected_with_difficulty
+        # Guard the derivation itself: the seed must exercise both branches.
+        assert 0 < expected_verified < expected_total
 
 
 class TestGetLemmaListFilterOptions:

--- a/src/tests/barsukas/test_api_search_forms.py
+++ b/src/tests/barsukas/test_api_search_forms.py
@@ -1,0 +1,54 @@
+"""Tests that /api/v1/search folds in English derivative and variant forms.
+
+Search used to match only lemma text, definitions, disambiguation and
+translations, so it disagreed with ``word_exists_in_english`` -- which also folds
+in derivative forms and alternate spellings -- about what the database contains.
+A caller surveying a wordlist got one answer from search and another from the add
+endpoint. These tests pin the agreement.
+"""
+
+from __future__ import annotations
+
+from flask.testing import FlaskClient
+
+
+def _guids(client: FlaskClient, query: str) -> list[str]:
+    response = client.get(f"/api/v1/search?q={query}")
+    assert response.status_code == 200
+    return [item["guid"] for item in response.get_json()["data"]]
+
+
+def test_alternate_spelling_finds_its_lemma(client: FlaskClient) -> None:
+    """An alternate spelling finds its lemma: "grey" resolves to "gray"."""
+    assert "J01_001" in _guids(client, "grey")
+
+
+def test_derivative_form_finds_its_lemma(client: FlaskClient) -> None:
+    """A derivative form finds its lemma: "eating" resolves to "eat"."""
+    assert "V01_001" in _guids(client, "eating")
+
+
+def test_search_agrees_with_the_existence_guard(client: FlaskClient) -> None:
+    """Every word the guard calls existing is now findable through search."""
+    words = ["eat", "eating", "grey", "gray"]
+
+    exists = client.post("/api/v1/words/exists", json={"words": words}).get_json()
+    assert all(exists["data"][word] for word in words)
+
+    for word in words:
+        assert _guids(client, word), f"search found nothing for {word!r}"
+
+
+def test_direct_lemma_match_outranks_a_form_match(client: FlaskClient) -> None:
+    """Relevance ordering: the lemma itself comes before a form-only hit.
+
+    "gray" matches lemma 3 directly; nothing else in the seed matches it, so this
+    also guards against the form subqueries dragging in unrelated rows.
+    """
+    guids = _guids(client, "gray")
+    assert guids[0] == "J01_001"
+
+
+def test_unmatched_query_still_returns_nothing(client: FlaskClient) -> None:
+    """The added OR-conditions must not turn a miss into a match."""
+    assert _guids(client, "zzznotaword") == []

--- a/src/tests/barsukas/test_api_translation_absence.py
+++ b/src/tests/barsukas/test_api_translation_absence.py
@@ -98,8 +98,9 @@ def test_lemma_summaries_include_lexical_gap_reason(client, db_engine) -> None:
         detail_response.get_json()["data"]["lexical_gap_reason"]
         == "post-classical domestic architecture sense"
     )
-    listed = list_response.get_json()["data"][0]
-    assert listed["guid"] == "N01_001"
+    # Find the lemma under test rather than indexing: other seed lemmas share
+    # difficulty 2, and the listing is ordered alphabetically within a level.
+    listed = next(item for item in list_response.get_json()["data"] if item["guid"] == "N01_001")
     assert listed["lexical_gap_reason"] == "post-classical domestic architecture sense"
 
 

--- a/src/tests/barsukas/test_api_words_exists.py
+++ b/src/tests/barsukas/test_api_words_exists.py
@@ -1,0 +1,101 @@
+"""Tests for POST /api/v1/words/exists.
+
+The endpoint is the bulk, exact-accounting counterpart to /api/v1/search: it must
+agree with ``word_exists_in_english``, which counts a word as present when it is a
+lemma, a disambiguated lemma, an English derivative form, or an alternate
+spelling. The seed data supplies one of each shape ("eat"/"eating", "gray"/"grey").
+"""
+
+from __future__ import annotations
+
+from flask.testing import FlaskClient
+
+
+def _post(client: FlaskClient, payload: dict) -> tuple[int, dict]:
+    response = client.post("/api/v1/words/exists", json=payload)
+    return response.status_code, response.get_json()
+
+
+def test_reports_lemma_derivative_and_variant_as_existing(client: FlaskClient) -> None:
+    """All three ways a word can be accounted for count as existing."""
+    status, payload = _post(client, {"words": ["eat", "eating", "grey", "zzznotaword"]})
+
+    assert status == 200
+    assert payload["data"] == {
+        "eat": True,  # lemma
+        "eating": True,  # English derivative form
+        "grey": True,  # alternate spelling of "gray" in variant_forms
+        "zzznotaword": False,
+    }
+
+
+def test_metadata_counts_checked_and_existing(client: FlaskClient) -> None:
+    status, payload = _post(client, {"words": ["eat", "house", "zzznotaword"]})
+
+    assert status == 200
+    assert payload["metadata"]["checked"] == 3
+    assert payload["metadata"]["existing"] == 2
+    assert payload["metadata"]["include_exclusions"] is True
+
+
+def test_words_are_normalized_and_deduplicated(client: FlaskClient) -> None:
+    """Keys come back lowercased and stripped; duplicates collapse to one entry."""
+    status, payload = _post(client, {"words": ["  EAT  ", "eat", "Eat"]})
+
+    assert status == 200
+    assert payload["data"] == {"eat": True}
+    assert payload["metadata"]["checked"] == 1
+
+
+def test_include_exclusions_is_accepted(client: FlaskClient) -> None:
+    """Passing the flag explicitly is echoed back in metadata."""
+    status, payload = _post(client, {"words": ["zzznotaword"], "include_exclusions": False})
+
+    assert status == 200
+    assert payload["metadata"]["include_exclusions"] is False
+
+
+def test_missing_words_list_is_rejected(client: FlaskClient) -> None:
+    status, payload = _post(client, {})
+
+    assert status == 400
+    assert "words" in payload["error"]
+
+
+def test_empty_words_list_is_rejected(client: FlaskClient) -> None:
+    status, _ = _post(client, {"words": []})
+
+    assert status == 400
+
+
+def test_non_string_entries_are_rejected(client: FlaskClient) -> None:
+    status, _ = _post(client, {"words": ["eat", 7]})
+
+    assert status == 400
+
+
+def test_oversized_words_list_is_rejected(client: FlaskClient) -> None:
+    """The cap keeps a single request from building an unbounded IN-list."""
+    from barsukas.routes.api.lemma_routes import MAX_EXISTS_WORDS
+
+    status, payload = _post(client, {"words": [f"word{n}" for n in range(MAX_EXISTS_WORDS + 1)]})
+
+    assert status == 400
+    assert str(MAX_EXISTS_WORDS) in payload["error"]
+
+
+def test_at_the_cap_is_accepted(client: FlaskClient) -> None:
+    """Exactly at the limit still works -- the check is strictly greater-than."""
+    from barsukas.routes.api.lemma_routes import MAX_EXISTS_WORDS
+
+    words = [f"word{n}" for n in range(MAX_EXISTS_WORDS - 1)] + ["eat"]
+    status, payload = _post(client, {"words": words})
+
+    assert status == 200
+    assert payload["data"]["eat"] is True
+
+
+def test_bad_include_exclusions_type_is_rejected(client: FlaskClient) -> None:
+    status, _ = _post(client, {"words": ["eat"], "include_exclusions": "yes"})
+
+    assert status == 400

--- a/src/tests/words/test_add_word.py
+++ b/src/tests/words/test_add_word.py
@@ -3,8 +3,10 @@
 add_word turns a bare English word into one lemma per sense worth adding. The
 LLM call is stubbed here by replacing the LinguisticClient it constructs, so no
 real definitions call is made -- the tests cover the logic layered on top of the
-LLM: the existence guard, frequency-driven sense sizing, the closed-class
-single-sense cap, translation-duplicate collapse, and subtype normalization.
+LLM: the existence guard, frequency-driven sense sizing (including the fallback
+to inflected surface forms), the closed-class single-sense cap,
+translation-duplicate collapse, subtype normalization, and the diversion of
+catch-all ``*_other`` subtypes to the pending-import queue.
 """
 
 from pathlib import Path
@@ -17,6 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from storage.backend.config import BackendType, DataSourceConfig
 from storage.models import Base, Lemma, WordToken
+from storage.models.imports import PendingImport
 from storage.models.variant_form import VARIANT_KIND_SPELLING, VariantForm
 from words import add_word as add_word_module
 from words.add_word import (
@@ -24,6 +27,7 @@ from words.add_word import (
     _apply_pos_sense_cap,
     _drop_translation_duplicates,
     _extend_for_prominence_ties,
+    _inflected_candidates,
     _normalize_subtype,
     _sense_bounds,
     add_word,
@@ -197,6 +201,87 @@ def test_translation_duplicates_collapsed() -> None:
     assert len(collapsed) == 1
 
 
+def test_accent_differences_collapse() -> None:
+    """An accent apart is the same word: "proteger" vs "protéger"."""
+    senses = [
+        _def("to watch over", pos="verb", spanish_translation="proteger"),
+        _def("to prevent harm", pos="verb", spanish_translation="protéger"),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 1
+    assert len(collapsed) == 1
+
+
+def test_prefix_differences_collapse() -> None:
+    """The TODO's case: lt marks aspect with a prefix, so these are one sense."""
+    senses = [
+        _def("to watch over", pos="verb", lithuanian_translation="saugoti"),
+        _def("to prevent harm", pos="verb", lithuanian_translation="apsaugoti"),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 1
+    assert len(collapsed) == 1
+
+
+def test_genuinely_distinct_senses_survive() -> None:
+    """Regression guard from the TODO: "further" must not be over-merged.
+
+    D08_001 (distance) and D09_010 (intensity) are a real English split. Their
+    translations differ outright in every language, so unanimity keeps them.
+    """
+    senses = [
+        _def(
+            "at a greater distance",
+            pos="adverb",
+            lithuanian_translation="toliau",
+            spanish_translation="más lejos",
+            french_translation="plus loin",
+        ),
+        _def(
+            "to a greater extent",
+            pos="adverb",
+            lithuanian_translation="labiau",
+            spanish_translation="más",
+            french_translation="davantage",
+        ),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 2
+    assert collapsed == []
+
+
+def test_unrelated_words_are_not_merged_by_the_prefix_rule() -> None:
+    """The tolerance must not swallow words that merely share an ending."""
+    senses = [
+        _def("a small animal", pos="noun", lithuanian_translation="katinas"),
+        _def("a large animal", pos="noun", lithuanian_translation="arklys"),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 2
+    assert collapsed == []
+
+
+def test_partial_translation_agreement_does_not_collapse() -> None:
+    """Every language must agree; one matching language is not enough."""
+    senses = [
+        _def(
+            "sense one",
+            pos="verb",
+            lithuanian_translation="saugoti",
+            spanish_translation="proteger",
+        ),
+        _def(
+            "sense two",
+            pos="verb",
+            lithuanian_translation="apsaugoti",
+            spanish_translation="vigilar",
+        ),
+    ]
+    kept, collapsed = _drop_translation_duplicates(senses)
+    assert len(kept) == 2
+    assert collapsed == []
+
+
 def test_normalize_subtype_closed_class() -> None:
     assert _normalize_subtype("preposition", "preposition") == "preposition_other"
     assert _normalize_subtype("conjunction", "other") == "conjunction_other"
@@ -361,19 +446,6 @@ def test_add_word_closed_class_single_sense(
     assert session.query(Lemma).filter(Lemma.lemma_text == "unless").count() == 1
 
 
-def test_add_word_dry_run_writes_nothing(
-    session: Session, config: DataSourceConfig, patch_client: Any
-) -> None:
-    patch_client([_def("a domesticated carnivore", pos="noun", pos_subtype="animal")])
-    _seed_word_token(session, "dog", rank=300)
-
-    result = add_word(session, "dog", config=config, dry_run=True)
-
-    assert result.status == "created"
-    assert len(result.senses) == 1
-    assert session.query(Lemma).filter(Lemma.lemma_text == "dog").count() == 0
-
-
 def test_add_word_no_definitions(
     session: Session, config: DataSourceConfig, patch_client: Any
 ) -> None:
@@ -383,3 +455,225 @@ def test_add_word_no_definitions(
 
     assert result.status == "no_definitions"
     assert result.senses == []
+
+
+# --- Frequency rank falls back to inflected forms ---------------------------
+
+
+def test_inflected_candidates_are_pos_directed() -> None:
+    """Each POS gets only its own inflections; closed-class gets none.
+
+    This is the guard against the whole point of the POS-directed lookup: a
+    blind generator would offer "exclaimer" for a verb and "guards" for both a
+    noun and a verb.
+    """
+    assert set(_inflected_candidates("exclaim", "verb")) == {
+        "exclaims",
+        "exclaimed",
+        "exclaiming",
+    }
+    assert _inflected_candidates("guard", "noun") == ["guards"]
+    assert set(_inflected_candidates("merry", "adjective")) == {"merrier", "merriest"}
+    assert _inflected_candidates("within", "preposition") == []
+
+
+def test_rank_falls_back_to_an_inflected_form(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """The TODO's case: the corpus holds "exclaimed", not "exclaim"."""
+    patch_client([_def("to cry out suddenly", pos="verb", pos_subtype="communication")])
+    _seed_word_token(session, "exclaimed", rank=1500)
+
+    result = add_word(session, "exclaim", config=config)
+
+    assert result.frequency_rank == 1500
+    assert result.frequency_rank_source == "exclaimed"
+
+
+def test_exact_form_beats_an_inflected_match(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """A rank for the word itself always wins, even if an inflection ranks better."""
+    patch_client([_def("to watch over", pos="verb", pos_subtype="physical_action")])
+    _seed_word_token(session, "guard", rank=900)
+    _seed_word_token(session, "guarded", rank=100)
+
+    result = add_word(session, "guard", config=config)
+
+    assert result.frequency_rank == 900
+    assert result.frequency_rank_source == "guard"
+
+
+def test_wrong_pos_inflection_is_not_consulted(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """A verb must not pick up the adjective comparative "exclaimer".
+
+    Without POS-directed candidates this token would be found, and because a
+    lower rank means *more* frequent, it would silently widen the sense ceiling.
+    """
+    patch_client([_def("to cry out suddenly", pos="verb", pos_subtype="communication")])
+    _seed_word_token(session, "exclaimer", rank=50)
+
+    result = add_word(session, "exclaim", config=config)
+
+    assert result.frequency_rank is None
+    assert result.frequency_rank_source is None
+
+
+def test_inflected_rank_widens_the_sense_ceiling(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """The rank is only worth recovering because it sizes sense selection.
+
+    Four very_common senses with no rank are capped at 2 by the fallback band;
+    the same senses at rank 500 are allowed 4.
+    """
+    definitions = [
+        _def(f"sense {n}", pos="verb", pos_subtype="physical_action", prominence="very_common")
+        for n in range(4)
+    ]
+    patch_client(definitions)
+    _seed_word_token(session, "guarded", rank=500)
+
+    result = add_word(session, "guard", config=config)
+
+    assert result.frequency_rank == 500
+    assert result.frequency_rank_source == "guarded"
+    assert len(result.senses) == 4
+
+
+def test_irregular_inflections_are_not_reached(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """Known limitation: the candidates are rule-based, so "struck" is missed.
+
+    ``generate_past_tense("strike")`` gives "striked". Recovering irregular
+    forms would need the conjugation tables, which is a larger change; the
+    fallback is documented as best-effort and simply finds nothing here.
+    """
+    patch_client([_def("to hit forcefully", pos="verb", pos_subtype="physical_action")])
+    _seed_word_token(session, "struck", rank=500)
+
+    result = add_word(session, "strike", config=config)
+
+    assert result.frequency_rank is None
+    assert result.status == "created"  # still added, just unsized
+
+
+def test_no_definitions_skips_the_frequency_lookup(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """No POS means no rank: the lookup needs one to pick candidates."""
+    patch_client([])
+    _seed_word_token(session, "zzznotaword", rank=10)
+
+    result = add_word(session, "zzznotaword", config=config)
+
+    assert result.status == "no_definitions"
+    assert result.frequency_rank is None
+
+
+# --- *_other subtypes are diverted to the pending queue ---------------------
+
+
+def test_other_subtype_on_open_class_is_queued_not_written(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    patch_client(
+        [
+            _def(
+                "to watch over and protect",
+                pos="verb",
+                pos_subtype="verb_other",
+                lithuanian_translation="saugoti",
+            )
+        ]
+    )
+
+    result = add_word(session, "guard", config=config)
+
+    assert result.status == "pending_review"
+    assert result.senses == []
+    assert session.query(Lemma).filter(Lemma.lemma_text == "guard").count() == 0
+
+    pending = session.query(PendingImport).filter(PendingImport.english_word == "guard").all()
+    assert len(pending) == 1
+    assert pending[0].pos_subtype == "verb_other"
+    assert pending[0].disambiguation_translation == "saugoti"
+
+    assert len(result.pending_senses) == 1
+    assert result.pending_senses[0].guid == ""
+
+
+def test_other_subtype_on_closed_class_is_still_written(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """The only preposition subtype is "preposition_other" -- not a review signal."""
+    patch_client([_def("inside the limits of", pos="preposition", pos_subtype="preposition_other")])
+
+    result = add_word(session, "within", config=config)
+
+    assert result.status == "created"
+    assert len(result.senses) == 1
+    assert session.query(Lemma).filter(Lemma.lemma_text == "within").count() == 1
+    assert session.query(PendingImport).count() == 0
+
+
+def test_mixed_senses_both_write_and_queue(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """A word can create some lemmas and queue others; status stays "created"."""
+    patch_client(
+        [
+            _def(
+                "a person who watches over",
+                pos="noun",
+                pos_subtype="human",
+                lithuanian_translation="sargas",
+            ),
+            _def(
+                "an unplaceable sense",
+                pos="noun",
+                pos_subtype="noun_other",
+                lithuanian_translation="kita",
+            ),
+        ]
+    )
+    _seed_word_token(session, "guard", rank=500)
+
+    result = add_word(session, "guard", config=config)
+
+    assert result.status == "created"
+    assert len(result.senses) == 1
+    assert len(result.pending_senses) == 1
+    assert session.query(Lemma).filter(Lemma.lemma_text == "guard").count() == 1
+    assert session.query(PendingImport).filter(PendingImport.english_word == "guard").count() == 1
+
+
+def test_queued_sense_falls_back_to_definition_for_disambiguation(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """disambiguation_translation is NOT NULL, so it needs a fallback."""
+    patch_client([_def("an unplaceable sense", pos="noun", pos_subtype="noun_other")])
+
+    add_word(session, "guard", config=config)
+
+    pending = session.query(PendingImport).filter(PendingImport.english_word == "guard").one()
+    assert pending.disambiguation_translation == "an unplaceable sense"
+
+
+def test_queueing_the_same_sense_twice_is_not_duplicated(
+    session: Session, config: DataSourceConfig, patch_client: Any
+) -> None:
+    """Re-running a word must not stack duplicate rows in the review queue."""
+    definitions = [_def("an unplaceable sense", pos="noun", pos_subtype="noun_other")]
+    patch_client(definitions)
+    add_word(session, "guard", config=config)
+
+    patch_client(definitions)
+    result = add_word(session, "guard", config=config)
+
+    assert session.query(PendingImport).filter(PendingImport.english_word == "guard").count() == 1
+    assert result.pending_senses == []
+    assert any("already in the pending queue" in entry for entry in result.dropped_senses)

--- a/src/words/add_word.py
+++ b/src/words/add_word.py
@@ -14,6 +14,12 @@ two-step pending-import flow (staging queue + human review) for a different
 workflow, but shares the same ``select_senses_to_add`` / ``query_definitions``
 building blocks.
 
+Not every sense is committed. A sense that lands on a catch-all ``*_other``
+subtype for an open-class word is diverted to that same pending-import queue
+instead of becoming a lemma, on the reasoning that "noun_other" out of 55
+available noun subtypes is usually the LLM failing to place the sense rather
+than a sense with genuinely no category.
+
 The "does the database already have this word?" guard is
 ``word_exists_in_english`` -- the canonical check that folds in lemmas,
 disambiguated lemmas, English derivative forms and alternate spellings
@@ -27,9 +33,19 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
+from langtools.en.utils import (
+    generate_3s_present,
+    generate_comparative,
+    generate_past_tense,
+    generate_present_participle,
+    generate_regular_plural,
+    generate_superlative,
+)
+from langtools.collation import strip_diacritics
 from storage.backend.config import DataSourceConfig
 from storage.crud.operation_log import log_translation_change
 from storage.models.guid_prefixes import SUBTYPE_GUID_PREFIXES
+from storage.models.imports import PendingImport
 from storage.models.schema import (
     SENSE_PROMINENCE_COMMON,
     ExternalLexemeAnnotation,
@@ -54,6 +70,14 @@ DIFFICULTY_LEVEL = -1
 # Languages the definitions call already returns per sense, stored as the lemma
 # is created so no second LLM call is needed for them.
 TRANSLATION_LANGUAGES: Tuple[str, ...] = DEFINITIONS_PROMPT_LANGUAGES
+# Language whose translation disambiguates a queued sense for the human
+# reviewer, matching what DRAMBLYS stages.
+REVIEW_DISAMBIGUATION_LANGUAGE = "lt"
+# How much extra leading material two translations may differ by and still count
+# as the same word when collapsing duplicate senses. Sized for the Lithuanian
+# aspect prefix ("saugoti" vs "apsaugoti"); wide enough for a prefix, too narrow
+# to merge unrelated words.
+_STEM_PREFIX_TOLERANCE = 3
 
 # Frequency-driven sense sizing. A word's overall corpus rank sets only the
 # *ceiling* on how many senses to bother with -- it is a signal about the word,
@@ -94,41 +118,109 @@ class AddWordResult:
 
     ``status`` is one of:
       * ``"created"`` -- one or more lemmas were created (see ``senses``)
+      * ``"pending_review"`` -- every surviving sense went to the pending queue
+        instead of the database (see ``pending_senses``); no lemma was created
       * ``"already_exists"`` -- the word is already accounted for; nothing done
       * ``"no_definitions"`` -- the LLM returned no usable senses
       * ``"error"`` -- a sense failed validation/GUID minting; see ``error``
+
+    ``created`` and ``pending_review`` are not exclusive in effect: a word can
+    create some lemmas and queue others, in which case the status is
+    ``"created"`` and both lists are populated.
     """
 
     word: str
     status: str
     frequency_rank: Optional[int] = None
+    # Surface form the rank came from. Differs from ``word`` when the corpus
+    # holds only an inflection ("exclaimed" for "exclaim"); None when no rank
+    # was found at all.
+    frequency_rank_source: Optional[str] = None
     senses: List[SenseResult] = field(default_factory=list)
+    # Senses routed to the pending-import queue for human subtype review rather
+    # than written as lemmas. Their ``guid`` is empty: none was minted.
+    pending_senses: List[SenseResult] = field(default_factory=list)
     dropped_senses: List[str] = field(default_factory=list)
     error: Optional[str] = None
 
 
-def _lookup_frequency(session: Session, word: str) -> Tuple[Optional[int], List[Dict[str, Any]]]:
-    """Return the word's overall corpus rank and its per-corpus rank breakdown.
+def _inflected_candidates(word: str, pos_type: str) -> List[str]:
+    """Return mechanically generated surface forms of ``word`` for this POS.
+
+    Used only to find a corpus rank when the base form itself is absent: the
+    19th/20th-century book corpora hold "exclaimed" but not "exclaim".
+
+    Strictly POS-directed, and that is the whole point. Generating every
+    inflection blind would be actively harmful, because the corpora are large
+    enough that wrong-POS candidates hit real tokens -- "exclaim" yields
+    "exclaimer", "further" yields "furtherer", and the noun plural collides with
+    the 3s present outright ("guards" is both). A spurious match returns a
+    *lower* rank, and ``_SENSE_BANDS`` reads lower as more frequent, so guessing
+    wrong silently buys a word extra senses. Closed-class POS types get no
+    candidates at all: they do not inflect, and anything generated for them
+    would be noise.
+
+    All generators here are rule-based, no LLM -- which also bounds what this
+    can recover: irregular forms are out of reach ("strike" yields "striked",
+    never "struck"), so a word whose corpus evidence is entirely irregular still
+    comes back unranked. That is the pre-existing behavior, not a regression;
+    closing it would mean consulting the conjugation tables.
+    """
+    if pos_type == "verb":
+        return [
+            generate_3s_present(word),
+            generate_past_tense(word),
+            generate_present_participle(word),
+        ]
+    if pos_type == "noun":
+        return [generate_regular_plural(word)]
+    if pos_type in ("adjective", "adverb"):
+        return [generate_comparative(word), generate_superlative(word)]
+    return []
+
+
+def _lookup_frequency(
+    session: Session, word: str, pos_type: str
+) -> Tuple[Optional[int], Optional[str], List[Dict[str, Any]]]:
+    """Return the word's corpus rank, the form it came from, and its breakdown.
 
     ``frequency_rank`` is the combined harmonic-mean rank on the ``WordToken``;
     the per-corpus list mirrors what DRAMBLYS records so the operation log
-    carries the same provenance. Both are ``None``/empty when the word is not in
-    the frequency corpora -- which is not an error here: the word is added
-    anyway, the rank just informs sense sizing.
+    carries the same provenance. All three are ``None``/empty when neither the
+    word nor any of its inflections is in the frequency corpora -- which is not
+    an error here: the word is added anyway, the rank just informs sense sizing.
+
+    The exact form always wins when present. Only when it is absent does the
+    best (numerically lowest) rank among ``_inflected_candidates`` stand in, so
+    a word whose corpus evidence is entirely inflected still gets sized against
+    real usage rather than falling to the tightest band by default.
     """
-    token = (
+    candidates = [word] + [
+        candidate for candidate in _inflected_candidates(word, pos_type) if candidate != word
+    ]
+    tokens = (
         session.query(WordToken)
-        .filter(WordToken.language_code == "en", WordToken.token == word)
-        .first()
+        .filter(WordToken.language_code == "en", WordToken.token.in_(candidates))
+        .all()
     )
-    if token is None:
-        return None, []
+    if not tokens:
+        return None, None, []
+
+    by_token = {token.token: token for token in tokens}
+    chosen = by_token.get(word)
+    if chosen is None:
+        ranked: List[Tuple[int, WordToken]] = [
+            (token.frequency_rank, token) for token in tokens if token.frequency_rank is not None
+        ]
+        if not ranked:
+            return None, None, []
+        chosen = min(ranked, key=lambda pair: pair[0])[1]
 
     corpus_info: List[Dict[str, Any]] = []
     annotations = (
         session.query(ExternalLexemeAnnotation)
         .filter(
-            ExternalLexemeAnnotation.word_token_id == token.id,
+            ExternalLexemeAnnotation.word_token_id == chosen.id,
             ExternalLexemeAnnotation.source.like("wordfreq_%"),
         )
         .all()
@@ -141,7 +233,7 @@ def _lookup_frequency(session: Session, word: str) -> Tuple[Optional[int], List[
                 "frequency": annotation.frequency,
             }
         )
-    return token.frequency_rank, corpus_info
+    return chosen.frequency_rank, chosen.token, corpus_info
 
 
 def _sense_bounds(frequency_rank: Optional[int]) -> Tuple[int, int]:
@@ -192,6 +284,46 @@ def _apply_pos_sense_cap(senses: List[Dict[str, Any]]) -> Tuple[List[Dict[str, A
     return senses[:1], dropped
 
 
+def _normalize_translation(text: Optional[str]) -> str:
+    """Accent-fold and case-fold one translation for duplicate comparison."""
+    return strip_diacritics((text or "").strip()).lower()
+
+
+def _same_stem(first: str, second: str) -> bool:
+    """Whether two normalized translations are one word with a prefix apart.
+
+    Lithuanian marks aspect with a prefix, so the LLM's two "guard" senses came
+    back as ``saugoti`` and ``apsaugoti`` -- the same verb, described twice.
+    Matching a bare suffix relation with a short tolerance catches that without
+    doing real stemming: ``proteger``/``protéger`` is already handled by the
+    accent fold, and unrelated words rarely differ by only a two-letter prefix.
+
+    Order-independent: the longer string is chosen before testing the suffix
+    relation, so the caller need not normalize argument order.
+    """
+    if not first or not second:
+        return False
+    if first == second:
+        return True
+    longer, shorter = (first, second) if len(first) >= len(second) else (second, first)
+    extra = len(longer) - len(shorter)
+    return 0 < extra <= _STEM_PREFIX_TOLERANCE and longer.endswith(shorter)
+
+
+def _translations_match(first: Tuple[str, ...], second: Tuple[str, ...]) -> bool:
+    """Whether two whole translation tuples describe the same sense.
+
+    Every language must agree. A real distinction shows up as different words in
+    several languages at once -- "further"'s distance and intensity senses differ
+    in lt/es/fr together -- so requiring unanimity keeps those apart while still
+    collapsing the accent/prefix noise.
+    """
+    return all(
+        _same_stem(left, right) if (left and right) else left == right
+        for left, right in zip(first, second)
+    )
+
+
 def _drop_translation_duplicates(
     senses: List[Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
@@ -208,31 +340,46 @@ def _drop_translation_duplicates(
     guessing, not a real distinction. Senses arrive prominence-ordered, so the
     first one wins.
 
+    Comparison is not literal. Exact matching let "guard" through as two
+    ``verb_other`` senses that were the same sense twice, because the two rows
+    read lt ``saugoti``/``apsaugoti``, es ``proteger``/``protéger`` -- an accent
+    and a prefix apart. Each translation is accent-folded, and two are treated
+    as the same when one is a suffix of the other with at most
+    ``_STEM_PREFIX_TOLERANCE`` characters of extra leading material.
+
     Returns:
         (kept senses, human-readable descriptions of the senses collapsed)
     """
     kept: List[Dict[str, Any]] = []
+    kept_keys: List[Tuple[str, Tuple[str, ...], str]] = []
     collapsed: List[str] = []
-    seen: Dict[Tuple[str, ...], str] = {}
 
     for sense in senses:
         by_lang_code = convert_llm_response_to_lang_codes(sense)
         translations = tuple(
-            (by_lang_code.get(lang_code) or "").strip().lower()
+            _normalize_translation(by_lang_code.get(lang_code))
             for lang_code in TRANSLATION_LANGUAGES
         )
         if not any(translations):
             kept.append(sense)
             continue
 
-        key = (sense.get("pos") or "",) + translations
-        first = seen.get(key)
-        if first is not None:
-            definition = (sense.get("definition") or "")[:40]
-            collapsed.append(f"{definition} (same pos+translations as {first!r})")
+        pos_type = sense.get("pos") or ""
+        definition = (sense.get("definition") or "")[:40]
+
+        duplicate_of = next(
+            (
+                seen_definition
+                for seen_pos, seen_translations, seen_definition in kept_keys
+                if seen_pos == pos_type and _translations_match(seen_translations, translations)
+            ),
+            None,
+        )
+        if duplicate_of is not None:
+            collapsed.append(f"{definition} (same pos+translations as {duplicate_of!r})")
             continue
 
-        seen[key] = (sense.get("definition") or "")[:40]
+        kept_keys.append((pos_type, translations, definition))
         kept.append(sense)
 
     return kept, collapsed
@@ -258,6 +405,70 @@ def _normalize_subtype(pos_type: str, pos_subtype: Optional[str]) -> Optional[st
     if pos_subtype == "other" and canonical in subtypes:
         return canonical
     return pos_subtype
+
+
+def _needs_subtype_review(pos_type: str, pos_subtype: str) -> bool:
+    """Whether this sense should go to the pending queue instead of the database.
+
+    ``*_other`` is the catch-all subtype, and on an open-class word it usually
+    means the LLM could not place the sense rather than that the sense genuinely
+    has no category -- noun has 55 subtypes and verb 14, so "noun_other" is a
+    near-miss worth a human look before it becomes a lemma.
+
+    Restricted to the open-class POS types on purpose. Every closed-class type
+    (preposition, conjunction, article, determiner, pronoun, interjection) has
+    ``<pos>_other`` as its *only* subtype, so treating "_other" as suspicious
+    there would divert every preposition in the language to review.
+    """
+    return pos_type in MAJOR_POS_TYPES and pos_subtype.endswith("_other")
+
+
+def _stage_for_review(
+    session: Session,
+    word: str,
+    sense: Dict[str, Any],
+    *,
+    pos_type: str,
+    pos_subtype: str,
+    definition_text: str,
+    frequency_rank: Optional[int],
+    source: str,
+) -> bool:
+    """Write one sense to the pending-import queue. Returns False if already there.
+
+    ``disambiguation_translation`` is NOT NULL on ``PendingImport``, so it falls
+    back to the definition when the LLM returned no Lithuanian -- the same
+    fallback ``stage_missing_words_for_import`` uses.
+    """
+    existing = (
+        session.query(PendingImport.id)
+        .filter(
+            PendingImport.english_word == word,
+            PendingImport.definition == definition_text,
+        )
+        .first()
+    )
+    if existing is not None:
+        return False
+
+    by_lang_code = convert_llm_response_to_lang_codes(sense)
+    disambiguation = (by_lang_code.get(REVIEW_DISAMBIGUATION_LANGUAGE) or "").strip()
+
+    session.add(
+        PendingImport(
+            english_word=word,
+            definition=definition_text,
+            disambiguation_translation=disambiguation or definition_text,
+            disambiguation_language=REVIEW_DISAMBIGUATION_LANGUAGE,
+            pos_type=pos_type,
+            pos_subtype=pos_subtype,
+            source=source,
+            frequency_rank=frequency_rank,
+            notes=f"add_word: {pos_subtype} needs subtype review before import",
+        )
+    )
+    session.commit()
+    return True
 
 
 def _validate_pos(pos_type: str, pos_subtype: Optional[str]) -> Optional[str]:
@@ -321,22 +532,47 @@ def _extend_for_prominence_ties(
     return selected + extras
 
 
-def _pick_senses(
-    client: LinguisticClient, word: str, frequency_rank: Optional[int]
-) -> Tuple[List[Dict[str, Any]], List[str]]:
-    """Ask the LLM for the word's senses and keep the ones worth adding.
+def _query_senses(client: LinguisticClient, word: str) -> List[Dict[str, Any]]:
+    """Ask the LLM for every sense of the word. One LLM call, no filtering.
 
-    One LLM call. Selection is frequency-sized (``_sense_bounds``), extended to
-    include senses tied in prominence at the ceiling (``_extend_for_prominence_ties``),
-    then capped for closed-class parts of speech (``_apply_pos_sense_cap``), then
+    Split from :func:`_select_senses` because selection is frequency-sized and
+    the frequency lookup is POS-directed -- so the POS has to come back from
+    this call before the rank can be looked up. Nothing about the call itself
+    depends on the rank.
+    """
+    definitions_list, success = client.query_definitions(word)
+    if not success or not definitions_list:
+        return []
+    return definitions_list
+
+
+def _leading_pos_type(definitions_list: List[Dict[str, Any]]) -> str:
+    """POS of the most prominent sense, used to direct the frequency lookup.
+
+    ``query_definitions`` returns senses prominence-ordered, and
+    ``_apply_pos_sense_cap`` already treats the first sense's POS as the word's
+    POS -- mixed-POS answers are the LLM guessing. Same assumption here.
+    """
+    if not definitions_list:
+        return ""
+    return (definitions_list[0].get("pos") or "").lower()
+
+
+def _select_senses(
+    definitions_list: List[Dict[str, Any]], frequency_rank: Optional[int]
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Keep the senses worth adding from an already-fetched definitions list.
+
+    Selection is frequency-sized (``_sense_bounds``), extended to include senses
+    tied in prominence at the ceiling (``_extend_for_prominence_ties``), then
+    capped for closed-class parts of speech (``_apply_pos_sense_cap``), then
     collapsed where the LLM over-split into translation-identical senses
     (``_drop_translation_duplicates``).
 
     Returns:
         (selected senses, human-readable descriptions of the senses dropped)
     """
-    definitions_list, success = client.query_definitions(word)
-    if not success or not definitions_list:
+    if not definitions_list:
         return [], []
 
     min_senses, max_senses = _sense_bounds(frequency_rank)
@@ -396,20 +632,29 @@ def add_word(
     config: DataSourceConfig,
     model: Optional[str] = None,
     source: str = "add_word",
-    dry_run: bool = False,
 ) -> AddWordResult:
     """Add a single English word to the database, from just the word.
 
-    Runs the full pipeline: existence guard, frequency lookup, one LLM call for
-    the word's senses, frequency-sized and closed-class-capped sense selection,
-    translation-duplicate collapse, then one lemma per surviving sense with a
-    minted GUID and the translations the definitions call returned.
+    Runs the full pipeline: existence guard, one LLM call for the word's senses,
+    a POS-directed frequency lookup, frequency-sized and closed-class-capped
+    sense selection, translation-duplicate collapse, then one lemma per
+    surviving sense with a minted GUID and the translations the definitions call
+    returned.
+
+    Note the order: the frequency lookup follows the LLM call rather than
+    preceding it, because knowing which inflections to search the corpora for
+    requires knowing the word's POS. A word the LLM cannot define therefore
+    returns with ``frequency_rank`` unset -- there was no POS to look it up
+    with, and nothing left to size.
 
     The word is committed per sense on success (a multi-sense word is a series
     of small writes, not one all-or-nothing transaction), matching how the
-    batch importer behaves. ``dry_run`` runs the whole pipeline -- including the
-    LLM call, which is needed to show what would be written -- but writes
-    nothing and rolls back.
+    batch importer behaves.
+
+    There is deliberately no preview mode. Showing what would be written
+    requires the LLM call, and that call is non-deterministic, so a preview does
+    not predict what a subsequent committing run produces -- it costs money to
+    show a result that will not reproduce.
 
     Args:
         session: Database session.
@@ -417,10 +662,9 @@ def add_word(
         config: Data source configuration for the ``LinguisticClient``.
         model: LLM model override; falls back to ``config.model``.
         source: Operation-log source tag.
-        dry_run: Run the pipeline without writing (still makes the LLM call).
 
     Returns:
-        An :class:`AddWordResult` describing what was (or would be) created.
+        An :class:`AddWordResult` describing what was created.
     """
     normalized = word.strip()
     if not normalized:
@@ -432,19 +676,30 @@ def add_word(
     if word_exists_in_english(session, normalized, include_exclusions=True):
         return AddWordResult(word=normalized, status="already_exists")
 
-    frequency_rank, corpus_info = _lookup_frequency(session, normalized)
-    best_corpus_rank = min((c["rank"] for c in corpus_info if c["rank"] is not None), default=None)
-
     client_config = config.with_model(model) if model else config
     client = LinguisticClient(config=client_config)
     client_model = client_config.model
 
-    senses, dropped = _pick_senses(client, normalized, frequency_rank)
+    # The definitions call comes first because the frequency lookup needs the
+    # word's POS to know which inflections to look for, and only the LLM knows
+    # the POS. Sense *selection* then consumes the rank, so the order is
+    # definitions -> POS -> rank -> selection.
+    definitions_list = _query_senses(client, normalized)
+    if not definitions_list:
+        return AddWordResult(word=normalized, status="no_definitions")
+
+    frequency_rank, rank_source, corpus_info = _lookup_frequency(
+        session, normalized, _leading_pos_type(definitions_list)
+    )
+    best_corpus_rank = min((c["rank"] for c in corpus_info if c["rank"] is not None), default=None)
+
+    senses, dropped = _select_senses(definitions_list, frequency_rank)
     if not senses:
         return AddWordResult(
             word=normalized,
             status="no_definitions",
             frequency_rank=frequency_rank,
+            frequency_rank_source=rank_source,
             dropped_senses=dropped,
         )
 
@@ -452,9 +707,9 @@ def add_word(
         word=normalized,
         status="created",
         frequency_rank=frequency_rank,
+        frequency_rank_source=rank_source,
         dropped_senses=dropped,
     )
-    issued_guids: Dict[str, str] = {}
 
     try:
         for sense in senses:
@@ -474,11 +729,45 @@ def add_word(
                     word=normalized,
                     status="error",
                     frequency_rank=frequency_rank,
+                    frequency_rank_source=rank_source,
                     senses=result.senses,
                     dropped_senses=dropped,
                     error=f"LLM gave {pos_error}",
                 )
             assert pos_subtype is not None  # _validate_pos rejects None
+
+            # A catch-all subtype on an open-class word is usually the LLM
+            # failing to place the sense. Queue it for review rather than
+            # minting a GUID that a human would have to undo.
+            if _needs_subtype_review(pos_type, pos_subtype):
+                staged = _stage_for_review(
+                    session,
+                    normalized,
+                    sense,
+                    pos_type=pos_type,
+                    pos_subtype=pos_subtype,
+                    definition_text=definition_text,
+                    frequency_rank=frequency_rank,
+                    source=source,
+                )
+                if staged:
+                    result.pending_senses.append(
+                        SenseResult(
+                            guid="",
+                            pos_type=pos_type,
+                            pos_subtype=pos_subtype,
+                            definition_text=definition_text,
+                            sense_prominence=prominence,
+                            translations={
+                                code: value
+                                for code, value in convert_llm_response_to_lang_codes(sense).items()
+                                if code in TRANSLATION_LANGUAGES and value
+                            },
+                        )
+                    )
+                else:
+                    dropped.append(f"{definition_text[:40]} (already in the pending queue)")
+                continue
 
             try:
                 guid = generate_guid(session, pos_type, pos_subtype)
@@ -488,15 +777,11 @@ def add_word(
                     word=normalized,
                     status="error",
                     frequency_rank=frequency_rank,
+                    frequency_rank_source=rank_source,
                     senses=result.senses,
                     dropped_senses=dropped,
                     error=f"GUID generation: {exc}",
                 )
-
-            # In dry-run nothing is flushed, so generate_guid returns the same
-            # GUID for same-subtype senses; note the collision rather than
-            # reporting it twice as distinct.
-            issued_guids.setdefault(guid, normalized)
 
             sense_result = SenseResult(
                 guid=guid,
@@ -505,14 +790,6 @@ def add_word(
                 definition_text=definition_text,
                 sense_prominence=prominence,
             )
-
-            if dry_run:
-                preview = convert_llm_response_to_lang_codes(sense)
-                sense_result.translations = {
-                    code: preview[code] for code in TRANSLATION_LANGUAGES if preview.get(code)
-                }
-                result.senses.append(sense_result)
-                continue
 
             new_lemma = Lemma(
                 lemma_text=normalized,
@@ -552,13 +829,13 @@ def add_word(
             # so a failure on a later sense does not discard the earlier ones.
             session.commit()
             result.senses.append(sense_result)
-
-        if dry_run:
-            session.rollback()
     except Exception:
         session.rollback()
         raise
 
     if not result.senses:
-        result.status = "no_definitions"
+        # Distinguish "the LLM gave us nothing usable" from "everything it gave
+        # us is waiting on a human": the second is a queue to work through, not
+        # a dead end.
+        result.status = "pending_review" if result.pending_senses else "no_definitions"
     return result


### PR DESCRIPTION
Five defects found while adding batch-01 words through POST /api/v1/words/add. No database writes; the deferred items all need the data cleaned first.

Divert *_other subtypes to the pending queue. A sense landing on a catch-all subtype for an open-class word is usually the LLM failing to place it -- noun has 55 subtypes -- so it is staged for review instead of committed, and returned in pending_senses. Gated on MAJOR_POS_TYPES: every closed-class type has <pos>_other as its only subtype, so an ungated check would divert every preposition in the language.

Normalize before collapsing duplicate senses. Translations are accent-folded, and two count as the same word when one is a suffix of the other within a 3-character tolerance -- sized for the Lithuanian aspect prefix, which let "guard" through as saugoti/apsaugoti plus proteger/protéger. All languages must agree before collapsing, so the "further" distance/intensity split survives. _strip_diacritics is promoted to public for this.

Fold derivative and variant forms into /search, so it stops disagreeing with word_exists_in_english about what the database holds ("grey" now finds "gray"). Add POST /api/v1/words/exists as the bulk exact-accounting counterpart, backed by filter_existing_english_words, replacing 58 sequential calls.

Fall back to inflected forms for frequency rank. The lookup now runs after the definitions call so it can be POS-directed; the corpus holds "exclaimed", not "exclaim". Blind generation was rejected: "exclaim" yields "exclaimer" and the noun plural collides with the 3s present ("guards" is both), and because a lower rank reads as more frequent, a spurious match silently widens the sense ceiling. Rule-based, so irregulars stay out of reach ("striked", never "struck").

Drop dry_run. It made the LLM call anyway and was non-deterministic, so the preview did not predict what a committing run wrote. A request still sending the flag is rejected rather than silently committing.

Two pre-existing tests asserted positionally against the seed fixture, which a third seed lemma broke; both now derive from the seed instead.