### PR TITLE
Redesign benchmark dashboard around a single-metric grid

### DIFF
--- a/src/benchmarks/server/analysis.py
+++ b/src/benchmarks/server/analysis.py
@@ -44,6 +44,41 @@ class RunMetrics:
     price_diagnostics: PriceDiagnostics
 
 
+def get_score_color(score: float) -> str:
+    """Return the background colour used for a 0-100 score badge.
+
+    The same thresholds are mirrored in server/static/js/dashboard.js as
+    SCORE_COLORS; keep the two in sync.
+    """
+    if score >= 90:
+        return "#1b5e20"  # Excellent - dark green
+    elif score >= 75:
+        return "#4caf50"  # Good - green
+    elif score >= 50:
+        return "#ff9800"  # Average - orange
+    elif score >= 25:
+        return "#f44336"  # Below average - red
+    else:
+        return "#b71c1c"  # Poor - dark red
+
+
+def describe_run_warnings(metrics: RunMetrics) -> list[str]:
+    """Return short human-readable caveats about a run's aggregate metrics.
+
+    Used by the dashboard grid, the benchmark leaderboard, and the model page so
+    the same caveats are worded identically everywhere.
+    """
+    warnings: list[str] = []
+    if metrics.outlier_count:
+        plural = "s" if metrics.outlier_count != 1 else ""
+        warnings.append(f"{metrics.outlier_count} latency outlier{plural}")
+    if metrics.price_diagnostics.has_mismatch:
+        warnings.append("cost warning")
+    if metrics.excluded_question_count:
+        warnings.append(f"{metrics.excluded_question_count} excluded Q")
+    return warnings
+
+
 def correctness_threshold(benchmark_name: str) -> int:
     """Return the minimum score treated as correct for a benchmark."""
     return 70 if benchmark_name == "0062_sentence_decomposition" else 100

--- a/src/benchmarks/server/routes/benchmarks.py
+++ b/src/benchmarks/server/routes/benchmarks.py
@@ -17,7 +17,11 @@ from benchmarks.datastore.benchmarks import (
     set_question_exclusion,
 )
 from benchmarks.datastore.common import Model, decode_json
-from benchmarks.server.analysis import analyze_run_details
+from benchmarks.server.analysis import (
+    analyze_run_details,
+    describe_run_warnings,
+    get_score_color,
+)
 from benchmarks.lib.utils.factory import get_all_benchmark_codes, get_benchmark_metadata
 from benchmarks.tiers import (
     BENCHMARK_TIERS,
@@ -289,6 +293,18 @@ def view_benchmark(benchmark_name):
     )
     excluded_question_count = sum(1 for question in question_previews if question["is_excluded"])
 
+    for entry in leaderboard:
+        entry_metrics = entry["metrics"]
+        entry["score_color"] = get_score_color(entry_metrics.effective_score)
+        entry["warnings"] = describe_run_warnings(entry_metrics)
+        entry["avg_cost_micro_usd"] = (
+            entry_metrics.total_cost_usd / entry_metrics.included_question_count * 1_000_000
+            if entry_metrics.included_question_count
+            else 0.0
+        )
+
+    benchmark_tier = get_benchmark_tier(benchmark.codename)
+
     return render_template(
         "benchmarks/view.html",
         benchmark=benchmark,
@@ -296,6 +312,8 @@ def view_benchmark(benchmark_name):
         question_previews=question_previews,
         leaderboard=leaderboard,
         excluded_question_count=excluded_question_count,
+        benchmark_tier=benchmark_tier,
+        benchmark_tier_label=get_tier_label(benchmark_tier),
     )
 
 

--- a/src/benchmarks/server/routes/dashboard.py
+++ b/src/benchmarks/server/routes/dashboard.py
@@ -4,14 +4,22 @@
 
 from datetime import datetime
 from itertools import groupby
+from statistics import median
+from typing import Any, Optional
 
 from flask import Blueprint, g, render_template
-from sqlalchemy import case, func
+from sqlalchemy import case
 
 from benchmarks.datastore.benchmarks import Benchmark, Question, Run, RunDetail
 from benchmarks.datastore.common import Model
-from benchmarks.server.analysis import analyze_run_details
+from benchmarks.server.analysis import (
+    analyze_run_details,
+    describe_run_warnings,
+    get_score_color,
+)
 from benchmarks.tiers import BENCHMARK_TIERS, get_benchmark_tier, model_can_run_benchmark
+
+__all__ = ["bp", "get_score_color", "index", "summarize_cells"]
 
 bp = Blueprint(
     "dashboard",
@@ -22,22 +30,24 @@ bp = Blueprint(
 )
 
 
-def get_score_color(score):
-    """Get color for score visualization."""
-    if score >= 90:
-        return "#1b5e20"  # Excellent - dark green
-    elif score >= 75:
-        return "#4caf50"  # Good - green
-    elif score >= 50:
-        return "#ff9800"  # Average - orange
-    elif score >= 25:
-        return "#f44336"  # Below average - red
-    else:
-        return "#b71c1c"  # Poor - dark red
+def summarize_cells(cells: list[dict[str, Any]]) -> Optional[dict[str, float]]:
+    """Aggregate a set of grid cells into mean score, median latency, mean cost.
+
+    Returns None when there is nothing to summarize, so the template can render a
+    placeholder rather than a misleading zero.
+    """
+    if not cells:
+        return None
+    return {
+        "count": len(cells),
+        "score": sum(cell["score"] for cell in cells) / len(cells),
+        "latency_msec": float(median([cell["latency_msec"] for cell in cells])),
+        "cost_micro_usd": sum(cell["cost_micro_usd"] for cell in cells) / len(cells),
+    }
 
 
 @bp.route("/")
-def index():
+def index() -> str:
     """Display the main benchmark dashboard with model-benchmark matrix."""
     # Get models with at least one run, ordered with remote models first.
     models = (
@@ -104,20 +114,25 @@ def index():
                 model_path=model_record.model_path if model_record else None,
                 model_type=model_record.model_type if model_record else None,
             )
+            avg_cost_usd = (
+                metrics.total_cost_usd / metrics.included_question_count
+                if metrics.included_question_count
+                else 0.0
+            )
             candidate = {
                 "run_id": run.run_id,
                 "value": metrics.effective_score,
+                "score": metrics.effective_score,
                 "color": get_score_color(metrics.effective_score),
                 "median_eval_time": metrics.median_time_msec,
-                "avg_cost_usd": (
-                    metrics.total_cost_usd / metrics.included_question_count
-                    if metrics.included_question_count
-                    else 0.0
-                ),
+                "latency_msec": metrics.median_time_msec,
+                "avg_cost_usd": avg_cost_usd,
+                "cost_micro_usd": avg_cost_usd * 1_000_000,
                 "run_ts": run.run_ts,
                 "outlier_count": metrics.outlier_count,
                 "excluded_question_count": metrics.excluded_question_count,
                 "price_diagnostics": metrics.price_diagnostics,
+                "warnings": describe_run_warnings(metrics),
             }
             if best_run_data is None or (
                 candidate["value"],
@@ -143,6 +158,25 @@ def index():
         benchmark.codename: get_benchmark_tier(benchmark.codename) for benchmark in benchmarks
     }
 
+    # Server-rendered summaries cover every model / benchmark; the client
+    # recomputes them for the visible subset whenever filters change.
+    model_summaries = {
+        model.codename: summarize_cells(
+            [cell for (_, model_code), cell in scores.items() if model_code == model.codename]
+        )
+        for model in models
+    }
+    benchmark_summaries = {
+        benchmark.codename: summarize_cells(
+            [
+                cell
+                for (benchmark_code, _), cell in scores.items()
+                if benchmark_code == benchmark.codename
+            ]
+        )
+        for benchmark in benchmarks
+    }
+
     return render_template(
         "dashboard/index.html",
         models=models,
@@ -152,5 +186,7 @@ def index():
         benchmark_tiers=benchmark_tiers,
         tier_definitions=BENCHMARK_TIERS,
         categories=categories,
+        model_summaries=model_summaries,
+        benchmark_summaries=benchmark_summaries,
         current_time=datetime.now().strftime("%B %d, %Y at %H:%M"),
     )

--- a/src/benchmarks/server/routes/models.py
+++ b/src/benchmarks/server/routes/models.py
@@ -2,11 +2,19 @@
 
 """Model routes - list and view model details."""
 
+from itertools import groupby
+from typing import Any
+
 from flask import Blueprint, g, render_template
 from sqlalchemy import func
 
-from benchmarks.datastore.benchmarks import Run
+from benchmarks.datastore.benchmarks import Question, Run, RunDetail
 from benchmarks.datastore.common import Model
+from benchmarks.server.analysis import (
+    analyze_run_details,
+    describe_run_warnings,
+    get_score_color,
+)
 from benchmarks.tiers import get_benchmark_tier, get_model_capability_label
 
 bp = Blueprint("models", __name__, url_prefix="/models", template_folder="../templates")
@@ -74,31 +82,80 @@ def list_models():
 
 
 @bp.route("/<model_name>")
-def view_model(model_name):
+def view_model(model_name: str) -> Any:
     """View detailed information about a specific model."""
-    # Get model
     model = g.bench_db.query(Model).filter(Model.codename == model_name).first()
     if not model:
         return "Model not found", 404
 
-    # Get all runs for this model with benchmark info
-    runs = (
-        g.bench_db.query(Run).filter(Run.model_name == model_name).order_by(Run.run_ts.desc()).all()
+    # Scores here are recomputed from RunDetail with analyze_run_details rather
+    # than read from Run.normed_score, so this page agrees with the dashboard.
+    run_rows = (
+        g.bench_db.query(Run, RunDetail, Question)
+        .outerjoin(RunDetail, RunDetail.run_id == Run.run_id)
+        .outerjoin(Question, RunDetail.question_id == Question.question_id)
+        .filter(Run.model_name == model_name)
+        .order_by(Run.run_id)
+        .all()
     )
 
-    # Calculate best score per benchmark
+    run_entries: list[dict[str, Any]] = []
+    for _run_id, grouped_rows in groupby(run_rows, key=lambda row: row[0].run_id):
+        run = None
+        detail_records: list[dict[str, Any]] = []
+        for current_run, detail, question in grouped_rows:
+            run = current_run
+            if detail is None:
+                continue
+            detail_records.append(
+                {
+                    "question_id": detail.question_id,
+                    "score": detail.score,
+                    "eval_msec": detail.eval_msec,
+                    "cost_usd": detail.cost_usd,
+                    "tokens_used": detail.tokens_used,
+                    "tokens_in": detail.tokens_in,
+                    "tokens_out": detail.tokens_out,
+                    "is_question_excluded": bool(question.is_excluded) if question else False,
+                }
+            )
+
+        if run is None:
+            continue
+
+        metrics = analyze_run_details(
+            run.benchmark_name,
+            detail_records,
+            model_path=model.model_path,
+            model_type=model.model_type,
+        )
+        run_entries.append(
+            {
+                "run": run,
+                "metrics": metrics,
+                "avg_cost_micro_usd": (
+                    metrics.total_cost_usd / metrics.included_question_count * 1_000_000
+                    if metrics.included_question_count
+                    else 0.0
+                ),
+                "score_color": get_score_color(metrics.effective_score),
+                "warnings": describe_run_warnings(metrics),
+            }
+        )
+
+    run_entries.sort(key=lambda entry: entry["run"].run_ts, reverse=True)
+
     best_scores: dict[str, int] = {}
-    for run in runs:
-        if (
-            run.benchmark_name not in best_scores
-            or run.normed_score > best_scores[run.benchmark_name]
-        ):
-            best_scores[run.benchmark_name] = run.normed_score
+    for entry in run_entries:
+        benchmark_name = entry["run"].benchmark_name
+        effective_score = entry["metrics"].effective_score
+        if benchmark_name not in best_scores or effective_score > best_scores[benchmark_name]:
+            best_scores[benchmark_name] = effective_score
 
     return render_template(
         "models/view.html",
         model=model,
-        runs=runs,
+        run_entries=run_entries,
         best_scores=best_scores,
         max_capability_label=get_model_capability_label(model.max_benchmark_tier),
     )

--- a/src/benchmarks/server/static/css/dashboard.css
+++ b/src/benchmarks/server/static/css/dashboard.css
@@ -1,0 +1,261 @@
+/* Benchmark dashboard grid.
+ *
+ * The grid is the page: a compact toolbar sits above it and everything else
+ * (descriptions, per-run caveats) lives in tooltips or the detail pages.
+ */
+
+.bench-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.75rem;
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+    background-color: #f8f9fa;
+}
+
+.bench-toolbar .bench-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.bench-toolbar .bench-field > label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: #6c757d;
+    margin: 0;
+}
+
+.bench-toolbar .bench-field select,
+.bench-toolbar .bench-field input {
+    min-width: 9.5rem;
+}
+
+.bench-toolbar .bench-spacer {
+    flex: 1 1 auto;
+}
+
+/* The grid is the only scrolling region on this page.
+ *
+ * body/.container-fluid are pinned to the viewport and the grid takes the
+ * remaining height via flex, so there is never a page scrollbar wrapped around
+ * the grid's own scrollbar. Scoped to .bench-page so other pages that share
+ * base.html keep normal document scrolling. */
+body.bench-page {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+}
+
+/* The margin override is against base.html's `.container-fluid mt-4`: that top
+ * margin sits outside the height box and would push the grid past the
+ * viewport. */
+body.bench-page > .container-fluid {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    margin-top: 0.75rem !important;
+    padding-bottom: 0.75rem;
+}
+
+.bench-grid-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+}
+
+/* Toolbar and the empty-state alert keep their natural height; only the grid
+ * flexes. */
+body.bench-page .bench-toolbar,
+body.bench-page #noResults {
+    flex: 0 0 auto;
+}
+
+table.bench-grid {
+    margin: 0;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 0.85rem;
+}
+
+table.bench-grid th,
+table.bench-grid td {
+    padding: 0.3rem 0.5rem;
+    vertical-align: middle;
+    border-bottom: 1px solid #e9ecef;
+    background-color: #fff;
+}
+
+table.bench-grid thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background-color: #f1f3f5;
+    border-bottom: 2px solid #dee2e6;
+}
+
+/* Left-pinned label and summary columns. --bench-label-w must match the
+ * width applied to .col-benchmark below. */
+:root {
+    --bench-label-w: 260px;
+}
+
+table.bench-grid .col-benchmark {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    width: var(--bench-label-w);
+    min-width: var(--bench-label-w);
+    max-width: var(--bench-label-w);
+    box-shadow: inset -1px 0 0 #e9ecef;
+}
+
+table.bench-grid .col-summary {
+    position: sticky;
+    left: var(--bench-label-w);
+    z-index: 2;
+    min-width: 5.5rem;
+    text-align: center;
+    box-shadow: inset -1px 0 0 #dee2e6;
+}
+
+/* Pinned header cells must outrank both the sticky row and the sticky column. */
+table.bench-grid thead th.col-benchmark,
+table.bench-grid thead th.col-summary {
+    z-index: 4;
+}
+
+table.bench-grid thead th.col-benchmark,
+table.bench-grid thead th.col-summary,
+table.bench-grid tbody td.col-benchmark,
+table.bench-grid tbody td.col-summary {
+    background-color: #f8f9fa;
+}
+
+table.bench-grid tbody tr:hover td {
+    background-color: #eef2f7;
+}
+
+.bench-name {
+    display: block;
+    font-weight: 600;
+    color: #0d6efd;
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.bench-name:hover {
+    text-decoration: underline;
+}
+
+.bench-code {
+    font-family: var(--bs-font-monospace, monospace);
+    font-size: 0.72rem;
+    color: #6c757d;
+}
+
+.bench-tier {
+    font-size: 0.65rem;
+    padding: 0.1rem 0.3rem;
+    border: 1px solid #ced4da;
+    border-radius: 0.25rem;
+    color: #6c757d;
+}
+
+/* Column headers.
+ *
+ * Model names are long relative to the ~3.4rem chip they sit above, so they
+ * wrap to at most two lines and are ellipsized rather than widening the whole
+ * column. The full name stays available via the link's title attribute. */
+.model-head {
+    text-align: center;
+    width: 5.5rem;
+    min-width: 5.5rem;
+    max-width: 5.5rem;
+    vertical-align: bottom;
+}
+
+.model-head a {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    color: inherit;
+    text-decoration: none;
+    font-size: 0.78rem;
+    line-height: 1.15;
+    overflow-wrap: anywhere;
+}
+
+.model-head a:hover {
+    text-decoration: underline;
+}
+
+.model-head .model-summary {
+    font-weight: 400;
+    font-size: 0.7rem;
+    color: #6c757d;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Metric chips */
+.metric-chip {
+    position: relative;
+    display: block;
+    margin: 0 auto;
+    min-width: 3.4rem;
+    padding: 0.25rem 0.35rem;
+    border-radius: 0.3rem;
+    color: #fff;
+    font-weight: 600;
+    font-size: 0.82rem;
+    line-height: 1.2;
+    text-align: center;
+    text-decoration: none;
+    font-variant-numeric: tabular-nums;
+}
+
+.metric-chip:hover {
+    color: #fff;
+    filter: brightness(1.12);
+}
+
+.metric-chip .chip-warn {
+    position: absolute;
+    top: -3px;
+    right: -1px;
+    font-size: 0.6rem;
+    line-height: 1;
+    color: #ffc107;
+    text-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
+}
+
+.cell-empty {
+    color: #adb5bd;
+}
+
+.cell-na {
+    font-size: 0.7rem;
+    color: #adb5bd;
+    border: 1px solid #e9ecef;
+    border-radius: 0.25rem;
+    padding: 0.1rem 0.3rem;
+}
+
+.summary-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: #495057;
+}

--- a/src/benchmarks/server/static/js/dashboard.js
+++ b/src/benchmarks/server/static/js/dashboard.js
@@ -1,4 +1,8 @@
-/* Dashboard filtering, sorting, and search logic */
+/* Dashboard filtering, sorting, search, and metric switching.
+ *
+ * Every cell carries all three metrics as data attributes; switching the metric
+ * only rewrites chip text and colour, so no round trip to the server is needed.
+ */
 
 document.addEventListener('DOMContentLoaded', function() {
     const modelScopeSelect = document.getElementById('modelScope');
@@ -6,19 +10,166 @@ document.addEventListener('DOMContentLoaded', function() {
     const categorySelect = document.getElementById('categoryFilter');
     const searchBox = document.getElementById('searchBox');
     const benchmarkSortSelect = document.getElementById('benchmarkSort');
+    const metricSwitch = document.getElementById('metricSwitch');
     const resultsTable = document.getElementById('resultsTable');
     const noResults = document.getElementById('noResults');
+    const visibleCount = document.getElementById('visibleCount');
+
+    const STORAGE_KEY = 'benchDashboardPrefs';
+
+    /* Mirrors get_score_color() in server/analysis.py - keep in sync. */
+    const SCORE_COLORS = [
+        { min: 90, color: '#1b5e20' },
+        { min: 75, color: '#4caf50' },
+        { min: 50, color: '#ff9800' },
+        { min: 25, color: '#f44336' },
+        { min: -Infinity, color: '#b71c1c' }
+    ];
+
+    /* Used for latency and cost, which have no absolute scale: cells are ranked
+     * within their row and coloured best-to-worst. */
+    const RANK_COLORS = ['#1b5e20', '#4caf50', '#ff9800', '#f44336', '#b71c1c'];
+
+    let activeMetric = 'score';
+
+    function scoreColor(value) {
+        for (const band of SCORE_COLORS) {
+            if (value >= band.min) return band.color;
+        }
+        return RANK_COLORS[RANK_COLORS.length - 1];
+    }
+
+    function formatMetric(metric, value) {
+        if (metric === 'score') return String(Math.round(value));
+        if (metric === 'latency') {
+            return value >= 10000 ? (value / 1000).toFixed(1) + 's' : Math.round(value) + 'ms';
+        }
+        return Math.round(value) + 'µ$';
+    }
+
+    function cellValue(chip, metric) {
+        const raw = chip.dataset[metric];
+        const parsed = parseFloat(raw);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function isVisible(el) {
+        return el.style.display !== 'none';
+    }
+
+    function visibleChips(row) {
+        return Array.from(row.querySelectorAll('td.model-col'))
+            .filter(isVisible)
+            .map(cell => cell.querySelector('.metric-chip'))
+            .filter(chip => chip !== null);
+    }
+
+    function rowMetricValues(row, metric) {
+        return visibleChips(row)
+            .map(chip => cellValue(chip, metric))
+            .filter(value => value !== null);
+    }
+
+    function mean(values) {
+        if (!values.length) return null;
+        return values.reduce((a, b) => a + b, 0) / values.length;
+    }
+
+    function medianOf(values) {
+        if (!values.length) return null;
+        const sorted = values.slice().sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+
+    /* Aggregate a metric the way the server does: mean for score and cost,
+     * median for latency. */
+    function aggregate(values, metric) {
+        return metric === 'latency' ? medianOf(values) : mean(values);
+    }
+
+    /* Rank-based colouring: split the row's values into as many buckets as we
+     * have colours, best value first. Lower is better for latency and cost. */
+    function rankColors(values) {
+        const unique = Array.from(new Set(values)).sort((a, b) => a - b);
+        const colorFor = new Map();
+        unique.forEach((value, index) => {
+            const bucket = unique.length === 1
+                ? 0
+                : Math.round((index / (unique.length - 1)) * (RANK_COLORS.length - 1));
+            colorFor.set(value, RANK_COLORS[bucket]);
+        });
+        return colorFor;
+    }
+
+    function paintRow(row, metric) {
+        const chips = visibleChips(row);
+        let colorFor = null;
+        if (metric !== 'score') {
+            colorFor = rankColors(chips
+                .map(chip => cellValue(chip, metric))
+                .filter(value => value !== null));
+        }
+
+        chips.forEach(chip => {
+            const value = cellValue(chip, metric);
+            const label = chip.querySelector('.chip-value');
+            if (value === null) {
+                if (label) label.textContent = '?';
+                chip.style.backgroundColor = '#adb5bd';
+                return;
+            }
+            if (label) label.textContent = formatMetric(metric, value);
+            chip.style.backgroundColor = metric === 'score'
+                ? scoreColor(value)
+                : colorFor.get(value);
+        });
+
+        const summaryCell = row.querySelector('.col-summary .summary-value');
+        if (summaryCell) {
+            const rowAggregate = aggregate(rowMetricValues(row, metric), metric);
+            summaryCell.textContent = rowAggregate === null ? '–' : formatMetric(metric, rowAggregate);
+        }
+    }
+
+    function paintColumnSummaries(metric) {
+        const headers = Array.from(resultsTable.querySelectorAll('thead th.model-col'));
+        headers.forEach((header, columnIndex) => {
+            const summary = header.querySelector('.summary-value');
+            if (!summary || !isVisible(header)) return;
+
+            const values = [];
+            resultsTable.querySelectorAll('tbody .benchmark-row').forEach(row => {
+                if (!isVisible(row)) return;
+                const cells = row.querySelectorAll('td.model-col');
+                const cell = cells[columnIndex];
+                if (!cell) return;
+                const chip = cell.querySelector('.metric-chip');
+                if (!chip) return;
+                const value = cellValue(chip, metric);
+                if (value !== null) values.push(value);
+            });
+
+            /* The benchmark count goes in the tooltip rather than the visible
+             * text - it is the widest part of the label and would set the
+             * column width for a cell that only needs to hold a chip. */
+            const columnAggregate = aggregate(values, metric);
+            summary.textContent = columnAggregate === null
+                ? '–'
+                : formatMetric(metric, columnAggregate);
+            summary.title = values.length + ' benchmark' + (values.length === 1 ? '' : 's');
+        });
+    }
+
+    function applyMetric() {
+        resultsTable.querySelectorAll('tbody .benchmark-row').forEach(row => {
+            if (isVisible(row)) paintRow(row, activeMetric);
+        });
+        paintColumnSummaries(activeMetric);
+    }
 
     function getModelScopeConfig() {
         const selectedScope = modelScopeSelect ? modelScopeSelect.value : 'all';
-
-        if (selectedScope === 'all') {
-            return {
-                modelPredicate: () => true,
-                benchmarkPredicate: () => true,
-                forceBenchmarkTier: null,
-            };
-        }
 
         if (selectedScope === 'remote') {
             return {
@@ -51,29 +202,12 @@ document.addEventListener('DOMContentLoaded', function() {
         };
     }
 
-    function getVisibleScores(row) {
-        const scores = [];
-        const cells = row.querySelectorAll('td.model-col');
-        cells.forEach(cell => {
-            if (cell.style.display === 'none') return;
-            const badge = cell.querySelector('.score-badge');
-            if (badge) {
-                const val = parseInt(badge.textContent.trim(), 10);
-                if (!isNaN(val)) scores.push(val);
-            }
-        });
-        return scores;
-    }
-
-    function avgOrNull(scores) {
-        if (!scores.length) return null;
-        return scores.reduce((a, b) => a + b, 0) / scores.length;
-    }
-
     function sortRows() {
         const sortVal = benchmarkSortSelect ? benchmarkSortSelect.value : 'key-asc';
         const tbody = resultsTable.querySelector('tbody');
         const rows = Array.from(tbody.querySelectorAll('.benchmark-row'));
+        /* Lower is better for latency and cost, so "best first" flips. */
+        const lowerIsBetter = activeMetric !== 'score';
 
         rows.sort(function(a, b) {
             const keyA = (a.dataset.benchmarkKey || '').toLowerCase();
@@ -86,17 +220,65 @@ document.addEventListener('DOMContentLoaded', function() {
             if (sortVal === 'name-asc') return nameA.localeCompare(nameB);
             if (sortVal === 'name-desc') return nameB.localeCompare(nameA);
 
-            const avgA = avgOrNull(getVisibleScores(a));
-            const avgB = avgOrNull(getVisibleScores(b));
-            if (avgA === null && avgB === null) return nameA.localeCompare(nameB);
-            if (avgA === null) return 1;
-            if (avgB === null) return -1;
-            if (sortVal === 'avg-desc') return avgB - avgA;
-            if (sortVal === 'avg-asc') return avgA - avgB;
+            const aggA = aggregate(rowMetricValues(a, activeMetric), activeMetric);
+            const aggB = aggregate(rowMetricValues(b, activeMetric), activeMetric);
+            if (aggA === null && aggB === null) return nameA.localeCompare(nameB);
+            if (aggA === null) return 1;
+            if (aggB === null) return -1;
+
+            const bestFirst = lowerIsBetter ? aggA - aggB : aggB - aggA;
+            if (sortVal === 'avg-desc') return bestFirst;
+            if (sortVal === 'avg-asc') return -bestFirst;
             return 0;
         });
 
         rows.forEach(r => tbody.appendChild(r));
+    }
+
+    function savePrefs() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                metric: activeMetric,
+                scope: modelScopeSelect ? modelScopeSelect.value : null,
+                tier: benchmarkTierFilter ? benchmarkTierFilter.value : null,
+                category: categorySelect ? categorySelect.value : null,
+                sort: benchmarkSortSelect ? benchmarkSortSelect.value : null,
+            }));
+        } catch (err) {
+            /* Private browsing or a full quota: preferences just do not persist. */
+        }
+    }
+
+    function restorePrefs() {
+        let prefs = null;
+        try {
+            prefs = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+        } catch (err) {
+            prefs = null;
+        }
+        if (!prefs) return;
+
+        /* Only restore values the current page still offers - benchmarks and
+         * categories come and go. */
+        function restoreSelect(select, value) {
+            if (!select || !value) return;
+            if (Array.from(select.options).some(option => option.value === value)) {
+                select.value = value;
+            }
+        }
+        restoreSelect(modelScopeSelect, prefs.scope);
+        restoreSelect(benchmarkTierFilter, prefs.tier);
+        restoreSelect(categorySelect, prefs.category);
+        restoreSelect(benchmarkSortSelect, prefs.sort);
+
+        if (prefs.metric && metricSwitch) {
+            const button = metricSwitch.querySelector('[data-metric="' + prefs.metric + '"]');
+            if (button) {
+                metricSwitch.querySelectorAll('[data-metric]').forEach(b => b.classList.remove('active'));
+                button.classList.add('active');
+                activeMetric = prefs.metric;
+            }
+        }
     }
 
     function filterTable() {
@@ -119,41 +301,49 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         const rows = resultsTable.querySelectorAll('tbody .benchmark-row');
-        let visibleCount = 0;
+        let shown = 0;
         rows.forEach(row => {
-            const benchmarkText = row.textContent.toLowerCase();
+            const haystack = (row.dataset.search || '').toLowerCase();
             const rowCategory = row.dataset.category || '';
             const rowTier = row.dataset.tier || '';
-            const matchesSearch = benchmarkText.includes(searchTerm);
+            const matchesSearch = haystack.includes(searchTerm);
             const matchesCategory = (selectedCategory === 'all' || rowCategory === selectedCategory);
             const matchesTier = (selectedBenchmarkTier === 'all' || rowTier === selectedBenchmarkTier);
             const matchesScope = scopeConfig.benchmarkPredicate(rowTier);
             const showRow = matchesSearch && matchesCategory && matchesTier && matchesScope;
             row.style.display = showRow ? '' : 'none';
-            if (showRow) visibleCount++;
+            if (showRow) shown++;
         });
 
+        applyMetric();
         sortRows();
-        noResults.style.display = visibleCount === 0 ? 'block' : 'none';
+        noResults.style.display = shown === 0 ? 'block' : 'none';
+        if (visibleCount) {
+            visibleCount.textContent = shown + ' of ' + rows.length + ' benchmarks';
+        }
+        savePrefs();
     }
 
-    if (modelScopeSelect) {
-        modelScopeSelect.addEventListener('change', filterTable);
-    }
-
-    if (benchmarkTierFilter) {
-        benchmarkTierFilter.addEventListener('change', filterTable);
-    }
-
-    if (categorySelect) {
-        categorySelect.addEventListener('change', filterTable);
-    }
-
+    [modelScopeSelect, benchmarkTierFilter, categorySelect, benchmarkSortSelect].forEach(control => {
+        if (control) control.addEventListener('change', filterTable);
+    });
     searchBox.addEventListener('input', filterTable);
 
-    if (benchmarkSortSelect) {
-        benchmarkSortSelect.addEventListener('change', filterTable);
+    if (metricSwitch) {
+        metricSwitch.addEventListener('click', function(event) {
+            const button = event.target.closest('[data-metric]');
+            if (!button) return;
+            metricSwitch.querySelectorAll('[data-metric]').forEach(b => b.classList.remove('active'));
+            button.classList.add('active');
+            activeMetric = button.dataset.metric;
+            filterTable();
+        });
     }
 
+    Array.from(document.querySelectorAll('[data-bs-toggle="popover"]')).forEach(
+        el => new bootstrap.Popover(el)
+    );
+
+    restorePrefs();
     filterTable();
 });

--- a/src/benchmarks/server/templates/base.html
+++ b/src/benchmarks/server/templates/base.html
@@ -60,7 +60,7 @@
 
     {% block extra_head %}{% endblock %}
 </head>
-<body>
+<body class="{% block body_class %}{% endblock %}">
     <!-- Navigation -->
     <nav class="navbar navbar-dark navbar-expand-lg">
         <div class="container-fluid">

--- a/src/benchmarks/server/templates/benchmarks/view.html
+++ b/src/benchmarks/server/templates/benchmarks/view.html
@@ -12,6 +12,11 @@
             </ol>
         </nav>
         <h1><i class="bi bi-award"></i> {{ benchmark.displayname }}</h1>
+        <p class="text-muted mb-1">
+            <span class="font-monospace">{{ benchmark.codename }}</span>
+            &middot; <span title="{{ benchmark_tier_label }}">Tier {{ benchmark_tier }}</span>
+            {% if benchmark.category %}&middot; {{ benchmark.category | title }}{% endif %}
+        </p>
         {% if benchmark.description %}
         <p class="lead">{{ benchmark.description }}</p>
         {% endif %}
@@ -88,6 +93,7 @@
                                 <th>Rank</th>
                                 <th>Model</th>
                                 <th class="text-center">Score</th>
+                                <th class="text-end">Avg cost</th>
                                 <th>Run Date</th>
                                 <th>Actions</th>
                             </tr>
@@ -115,26 +121,16 @@
                                     {% endif %}
                                 </td>
                                 <td class="text-center">
-                                    <div class="score-badge mx-auto"
-                                         style="background-color:
-                                         {% if metrics.effective_score >= 90 %}#1b5e20
-                                         {% elif metrics.effective_score >= 75 %}#4caf50
-                                         {% elif metrics.effective_score >= 50 %}#ff9800
-                                         {% elif metrics.effective_score >= 25 %}#f44336
-                                         {% else %}#b71c1c{% endif %};">
+                                    <div class="score-badge mx-auto" style="background-color: {{ entry.score_color }};">
                                         {{ metrics.effective_score }}
                                     </div>
                                     <div class="small text-muted mt-1">{{ '%.1f'|format(metrics.median_time_msec) }}ms median</div>
-                                    {% if metrics.outlier_count or metrics.excluded_question_count or metrics.price_diagnostics.has_mismatch %}
-                                    <div class="small text-warning-emphasis">
-                                        {% if metrics.outlier_count %}{{ metrics.outlier_count }} latency outlier{% if metrics.outlier_count != 1 %}s{% endif %}{% endif %}
-                                        {% if metrics.outlier_count and (metrics.excluded_question_count or metrics.price_diagnostics.has_mismatch) %} · {% endif %}
-                                        {% if metrics.excluded_question_count %}{{ metrics.excluded_question_count }} excluded Q{% endif %}
-                                        {% if metrics.excluded_question_count and metrics.price_diagnostics.has_mismatch %} · {% endif %}
-                                        {% if metrics.price_diagnostics.has_mismatch %}cost warning{% endif %}
-                                    </div>
+                                    {% if entry.warnings %}
+                                    <div class="small text-warning-emphasis"
+                                         title="{{ metrics.price_diagnostics.message }}">{{ entry.warnings | join(' · ') }}</div>
                                     {% endif %}
                                 </td>
+                                <td class="text-end">{{ '%.0f'|format(entry.avg_cost_micro_usd) }}µ$</td>
                                 <td>
                                     <small>{{ run.run_ts.strftime('%Y-%m-%d %H:%M:%S') }}</small>
                                 </td>

--- a/src/benchmarks/server/templates/dashboard/index.html
+++ b/src/benchmarks/server/templates/dashboard/index.html
@@ -2,186 +2,155 @@
 
 {% block title %}Dashboard{% endblock %}
 
+{% block body_class %}bench-page{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('dashboard.static', filename='css/dashboard.css') }}">
+{% endblock %}
+
+{% macro metric_summary(summary) -%}
+{%- if summary -%}
+<span class="summary-value"
+      data-summary-score="{{ '%.1f'|format(summary.score) }}"
+      data-summary-latency="{{ '%.0f'|format(summary.latency_msec) }}"
+      data-summary-cost="{{ '%.0f'|format(summary.cost_micro_usd) }}"></span>
+{%- else -%}
+<span class="cell-empty">&ndash;</span>
+{%- endif -%}
+{%- endmacro %}
+
 {% block content %}
-<div class="row mb-4">
-    <div class="col">
-        <h1><i class="bi bi-speedometer2"></i> Benchmark Dashboard</h1>
-        <p class="text-muted">Last updated: {{ current_time }}</p>
+<div class="d-flex align-items-baseline gap-3 mb-2">
+    <h4 class="mb-0"><i class="bi bi-speedometer2"></i> Benchmark Dashboard</h4>
+    <span class="text-muted small">Updated {{ current_time }}</span>
+    <button type="button" class="btn btn-sm btn-outline-secondary py-0" data-bs-toggle="popover"
+            data-bs-html="true" data-bs-placement="bottom" title="Legend"
+            data-bs-content="{% for tier in tier_definitions.values() %}<div><strong>{{ tier.short_label }}</strong> &mdash; {{ tier.label }}</div>{% endfor %}<div><strong>N/A</strong> &mdash; excluded by model capability policy.</div><hr class='my-2'><div class='small'>Cells show the best run per benchmark &times; model. Latency is the <strong>median</strong> over non-excluded questions; suspiciously slow incorrect answers are dropped from that latency summary only. Cost is the mean per question. &#9888; marks a run with latency outliers, question exclusions, or a stored-vs-estimated cost mismatch &mdash; hover the chip for details.</div>">
+        <i class="bi bi-question-circle"></i> Legend
+    </button>
+</div>
+
+<div class="bench-toolbar">
+    <div class="bench-field">
+        <label>Metric</label>
+        <div class="btn-group btn-group-sm" role="group" id="metricSwitch">
+            <button type="button" class="btn btn-outline-primary active" data-metric="score">Score</button>
+            <button type="button" class="btn btn-outline-primary" data-metric="latency">Latency</button>
+            <button type="button" class="btn btn-outline-primary" data-metric="cost">Cost</button>
+        </div>
+    </div>
+    <div class="bench-field">
+        <label for="modelScope">Models</label>
+        <select class="form-select form-select-sm" id="modelScope">
+            <option value="all">All</option>
+            <option value="remote" selected>Remote</option>
+            <option value="local-level1">Local (Level 1)</option>
+            <option value="local-level2plus">Local (Level 2+)</option>
+        </select>
+    </div>
+    <div class="bench-field">
+        <label for="benchmarkTierFilter">Tier</label>
+        <select class="form-select form-select-sm" id="benchmarkTierFilter">
+            <option value="all" selected>All tiers</option>
+            {% for tier in tier_definitions.values() %}
+            <option value="{{ tier.level }}">{{ tier.short_label }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="bench-field">
+        <label for="categoryFilter">Category</label>
+        <select class="form-select form-select-sm" id="categoryFilter">
+            <option value="all">All</option>
+            {% for cat in categories %}
+            <option value="{{ cat }}"{% if cat == 'word processing' %} selected{% endif %}>{{ cat | title }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="bench-field">
+        <label for="benchmarkSort">Sort</label>
+        <select class="form-select form-select-sm" id="benchmarkSort">
+            <option value="key-asc" selected>Key (0010 &rarr; 9999)</option>
+            <option value="key-desc">Key (9999 &rarr; 0010)</option>
+            <option value="name-asc">Name (A &rarr; Z)</option>
+            <option value="name-desc">Name (Z &rarr; A)</option>
+            <option value="avg-desc">Metric (best &rarr; worst)</option>
+            <option value="avg-asc">Metric (worst &rarr; best)</option>
+        </select>
+    </div>
+    <div class="bench-field">
+        <label for="searchBox">Search</label>
+        <input type="text" class="form-control form-control-sm" id="searchBox" placeholder="Search benchmarks...">
+    </div>
+    <div class="bench-spacer"></div>
+    <div class="bench-field">
+        <span class="text-muted small" id="visibleCount"></span>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="alert alert-light border">
-            <strong>Tier legend</strong>
-            <div class="mt-2">
-                {% for tier in tier_definitions.values() %}
-                <div class="mb-1">
-                    <span class="badge text-bg-secondary">{{ tier.short_label }}</span>
-                    {{ tier.label }}
-                </div>
+<div class="bench-grid-scroll">
+    <table class="bench-grid" id="resultsTable">
+        <thead>
+            <tr>
+                <th class="col-benchmark">Benchmark</th>
+                <th class="col-summary">All models</th>
+                {% for model in models %}
+                <th class="model-head model-col"
+                    data-model-type="{{ model.model_type }}"
+                    data-model-level="{{ model.max_benchmark_tier }}">
+                    <a href="{{ url_for('models.view_model', model_name=model.codename) }}"
+                       title="{{ model.codename }}{% if model.filesize_mb %} &middot; {{ model.filesize_mb }} MB{% endif %}">
+                        {{ model.displayname }}
+                    </a>
+                    <div class="model-summary">{{ metric_summary(model_summaries[model.codename]) }}</div>
+                </th>
                 {% endfor %}
-                <div>
-                    <span class="badge text-bg-light border">N/A</span>
-                    Excluded by model policy.
-                </div>
-                <div class="mt-2 small text-muted">
-                    Dashboard defaults to <strong>remote</strong> + <strong>word processing</strong>.
-                    Latency is shown as the <strong>median</strong> for non-excluded questions, and suspiciously slow incorrect outliers are ignored in that latency summary.
-                </div>
-            </div>
-        </div>
-    </div>
+            </tr>
+        </thead>
+        <tbody>
+            {% for benchmark in benchmarks %}
+            <tr class="benchmark-row"
+                data-benchmark-name="{{ benchmark.displayname }}"
+                data-benchmark-key="{{ benchmark.codename }}"
+                data-search="{{ benchmark.displayname }} {{ benchmark.codename }} {{ benchmark.description or '' }}"
+                data-category="{{ benchmark.category or '' }}"
+                data-tier="{{ benchmark_tiers[benchmark.codename] }}">
+                <td class="col-benchmark">
+                    <a class="bench-name"
+                       href="{{ url_for('benchmarks.view_benchmark', benchmark_name=benchmark.codename) }}"
+                       title="{{ benchmark.description or benchmark.displayname }}">{{ benchmark.displayname }}</a>
+                    <span class="bench-code">{{ benchmark.codename }}</span>
+                    <span class="bench-tier">{{ tier_definitions[benchmark_tiers[benchmark.codename]].short_label }}</span>
+                </td>
+                <td class="col-summary">{{ metric_summary(benchmark_summaries[benchmark.codename]) }}</td>
+                {% for model in models %}
+                <td class="text-center model-col"
+                    data-model-type="{{ model.model_type }}"
+                    data-model-level="{{ model.max_benchmark_tier }}">
+                    {% if (benchmark.codename, model.codename) in scores %}
+                    {% set cell = scores[(benchmark.codename, model.codename)] %}
+                    <a class="metric-chip"
+                       href="{{ url_for('runs.view_run', run_id=cell.run_id) }}"
+                       data-score="{{ cell.score }}"
+                       data-latency="{{ '%.0f'|format(cell.latency_msec) }}"
+                       data-cost="{{ '%.0f'|format(cell.cost_micro_usd) }}"
+                       title="{{ model.displayname }} &middot; {{ benchmark.displayname }}&#10;Score {{ cell.score }}/100&#10;{{ '%.0f'|format(cell.latency_msec) }}ms median&#10;{{ '%.0f'|format(cell.cost_micro_usd) }}µ$ per question{% if cell.warnings %}&#10;{{ cell.warnings | join(' · ') }}{% endif %}">
+                        <span class="chip-value"></span>
+                        {% if cell.warnings %}<span class="chip-warn">&#9888;</span>{% endif %}
+                    </a>
+                    {% elif not eligibility[(benchmark.codename, model.codename)] %}
+                    <span class="cell-na" title="Excluded by model capability policy">N/A</span>
+                    {% else %}
+                    <span class="cell-empty">&ndash;</span>
+                    {% endif %}
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>
 
-<!-- Filter Controls -->
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-body">
-                <h5 class="card-title">
-                    <i class="bi bi-funnel"></i> Filters
-                </h5>
-                <div class="row g-3">
-                    <div class="col-md-3">
-                        <label class="form-label">Model Scope</label>
-                        <select class="form-select" id="modelScope">
-                            <option value="all">All</option>
-                            <option value="remote" selected>Remote</option>
-                            <option value="local-level1">Local (Level 1)</option>
-                            <option value="local-level2plus">Local (Level 2+)</option>
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label">Benchmark Tier</label>
-                        <select class="form-select" id="benchmarkTierFilter">
-                            <option value="all" selected>All tiers</option>
-                            {% for tier in tier_definitions.values() %}
-                            <option value="{{ tier.level }}">{{ tier.short_label }} · {{ tier.label }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label">Category</label>
-                        <select class="form-select" id="categoryFilter">
-                            <option value="all">All</option>
-                            {% for cat in categories %}
-                            <option value="{{ cat }}"{% if cat == 'word processing' %} selected{% endif %}>{{ cat | title }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label">Sort Benchmarks</label>
-                        <select class="form-select" id="benchmarkSort">
-                            <option value="key-asc" selected>Key (0010 → 9999)</option>
-                            <option value="key-desc">Key (9999 → 0010)</option>
-                            <option value="name-asc">Name (A → Z)</option>
-                            <option value="name-desc">Name (Z → A)</option>
-                            <option value="avg-desc">Avg Score (high → low)</option>
-                            <option value="avg-asc">Avg Score (low → high)</option>
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label">Search</label>
-                        <div class="input-group">
-                            <span class="input-group-text"><i class="bi bi-search"></i></span>
-                            <input type="text" class="form-control" id="searchBox" placeholder="Search benchmarks...">
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Results Table -->
-<div class="row">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-body">
-                <div class="table-responsive">
-                    <table class="table table-hover" id="resultsTable">
-                        <thead class="table-light">
-                            <tr>
-                                <th>Benchmark</th>
-                                {% for model in models %}
-                                <th class="text-center model-col"
-                                    data-model-type="{{ model.model_type }}"
-                                    data-model-level="{{ model.max_benchmark_tier }}">
-                                    <div class="small">{{ model.displayname }}</div>
-                                    <div class="text-muted small">
-                                        {% if model.filesize_mb %}{{ model.filesize_mb }} MB{% endif %}
-                                    </div>
-                                </th>
-                                {% endfor %}
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for benchmark in benchmarks %}
-                            <tr class="benchmark-row"
-                                data-benchmark-name="{{ benchmark.displayname }}"
-                                data-benchmark-key="{{ benchmark.codename }}"
-                                data-category="{{ benchmark.category or '' }}"
-                                data-tier="{{ benchmark_tiers[benchmark.codename] }}">
-                                <td>
-                                    <a href="{{ url_for('benchmarks.view_benchmark', benchmark_name=benchmark.codename) }}"
-                                       class="text-decoration-none">
-                                        <strong>{{ benchmark.displayname }}</strong>
-                                    </a>
-                                    <br><small class="text-muted font-monospace">{{ benchmark.codename }}</small>
-                                    <span class="badge text-bg-light border text-secondary">{{ tier_definitions[benchmark_tiers[benchmark.codename]].short_label }}</span>
-                                    {% if benchmark.description %}
-                                    <br><small class="text-muted">{{ benchmark.description[:80] }}...</small>
-                                    {% endif %}
-                                </td>
-                                {% for model in models %}
-                                <td class="text-center model-col"
-                                    data-model-type="{{ model.model_type }}"
-                                    data-model-level="{{ model.max_benchmark_tier }}">
-                                    {% if (benchmark.codename, model.codename) in scores %}
-                                    {% set score_data = scores[(benchmark.codename, model.codename)] %}
-                                    <a href="{{ url_for('runs.view_run', run_id=score_data.run_id) }}"
-                                       class="text-decoration-none">
-                                        <div class="score-badge mx-auto"
-                                             style="background-color: {{ score_data.color }};"
-                                             title="Score: {{ score_data.value }}/100, Median time: {{ '%.1f'|format(score_data.median_eval_time) }}ms, Avg cost: {{ '%.0f'|format(score_data.avg_cost_usd * 1000000) }}µ${% if score_data.outlier_count %}, Ignored latency outliers: {{ score_data.outlier_count }}{% endif %}{% if score_data.excluded_question_count %}, Excluded questions: {{ score_data.excluded_question_count }}{% endif %}{% if score_data.price_diagnostics.has_mismatch %}, Cost warning{% endif %}">
-                                            {{ score_data.value }}
-                                        </div>
-                                        <div class="small text-muted mt-1">
-                                            {{ '%.1f'|format(score_data.median_eval_time) }}ms median
-                                        </div>
-                                        <div class="small text-muted">
-                                            {{ '%.0f'|format(score_data.avg_cost_usd * 1000000) }}µ$
-                                        </div>
-                                        {% if score_data.outlier_count or score_data.price_diagnostics.has_mismatch or score_data.excluded_question_count %}
-                                        <div class="small text-warning-emphasis">
-                                            {% if score_data.outlier_count %}<span title="Incorrect long-tail latency outliers ignored">{{ score_data.outlier_count }} latency outlier{% if score_data.outlier_count != 1 %}s{% endif %}</span>{% endif %}
-                                            {% if score_data.outlier_count and (score_data.price_diagnostics.has_mismatch or score_data.excluded_question_count) %} · {% endif %}
-                                            {% if score_data.price_diagnostics.has_mismatch %}<span title="{{ score_data.price_diagnostics.message }}">cost warning</span>{% endif %}
-                                            {% if score_data.price_diagnostics.has_mismatch and score_data.excluded_question_count %} · {% endif %}
-                                            {% if score_data.excluded_question_count %}<span title="Question exclusions are removed from aggregate scores">{{ score_data.excluded_question_count }} excluded Q</span>{% endif %}
-                                        </div>
-                                        {% endif %}
-                                    </a>
-                                    {% elif not eligibility[(benchmark.codename, model.codename)] %}
-                                    <span class="badge text-bg-light border"
-                                          title="Excluded by model capability policy">N/A</span>
-                                    {% else %}
-                                    <span class="text-muted">-</span>
-                                    {% endif %}
-                                </td>
-                                {% endfor %}
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-
-<div id="noResults" class="alert alert-info mt-4" style="display: none;">
+<div id="noResults" class="alert alert-info mt-3" style="display: none;">
     No results found matching your filters.
 </div>
 

--- a/src/benchmarks/server/templates/models/view.html
+++ b/src/benchmarks/server/templates/models/view.html
@@ -30,7 +30,7 @@
         <div class="card">
             <div class="card-body">
                 <h6 class="text-muted">Total Runs</h6>
-                <h4>{{ runs|length }}</h4>
+                <h4>{{ run_entries|length }}</h4>
             </div>
         </div>
     </div>
@@ -60,7 +60,7 @@
                 <h5 class="card-title mb-0"><i class="bi bi-graph-up"></i> Benchmark Performance</h5>
             </div>
             <div class="card-body">
-                {% if runs %}
+                {% if run_entries %}
                 <div class="table-responsive">
                     <table class="table table-hover">
                         <thead class="table-light">
@@ -68,38 +68,41 @@
                                 <th>Benchmark</th>
                                 <th class="text-center">Score</th>
                                 <th class="text-center">Best Score</th>
+                                <th class="text-end">Median latency</th>
+                                <th class="text-end">Avg cost</th>
                                 <th>Run Date</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {% for run in runs %}
+                            {% for entry in run_entries %}
+                            {% set run = entry.run %}
+                            {% set metrics = entry.metrics %}
                             <tr>
                                 <td>
                                     <a href="{{ url_for('benchmarks.view_benchmark', benchmark_name=run.benchmark_name) }}"
                                        class="text-decoration-none">
                                         {{ run.benchmark_name }}
                                     </a>
+                                    {% if entry.warnings %}
+                                    <br><small class="text-warning-emphasis">{{ entry.warnings | join(' · ') }}</small>
+                                    {% endif %}
                                 </td>
                                 <td class="text-center">
-                                    <div class="score-badge mx-auto"
-                                         style="background-color:
-                                         {% if run.normed_score >= 90 %}#1b5e20
-                                         {% elif run.normed_score >= 75 %}#4caf50
-                                         {% elif run.normed_score >= 50 %}#ff9800
-                                         {% elif run.normed_score >= 25 %}#f44336
-                                         {% else %}#b71c1c{% endif %};">
-                                        {{ run.normed_score }}
+                                    <div class="score-badge mx-auto" style="background-color: {{ entry.score_color }};">
+                                        {{ metrics.effective_score }}
                                     </div>
                                 </td>
                                 <td class="text-center">
                                     {% if run.benchmark_name in best_scores %}
                                     <strong>{{ best_scores[run.benchmark_name] }}</strong>
-                                    {% if run.normed_score == best_scores[run.benchmark_name] %}
+                                    {% if metrics.effective_score == best_scores[run.benchmark_name] %}
                                     <i class="bi bi-star-fill text-warning" title="Personal best"></i>
                                     {% endif %}
                                     {% endif %}
                                 </td>
+                                <td class="text-end">{{ '%.0f'|format(metrics.median_time_msec) }}ms</td>
+                                <td class="text-end">{{ '%.0f'|format(entry.avg_cost_micro_usd) }}µ$</td>
                                 <td>
                                     <small>{{ run.run_ts.strftime('%Y-%m-%d %H:%M:%S') }}</small>
                                 </td>

--- a/src/tests/benchmarks/test_analysis_summaries.py
+++ b/src/tests/benchmarks/test_analysis_summaries.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+"""Unit tests for the shared benchmark UI summary helpers."""
+
+import pytest
+
+from benchmarks.server.analysis import (
+    PriceDiagnostics,
+    RunMetrics,
+    describe_run_warnings,
+    get_score_color,
+)
+
+
+def _metrics(
+    *,
+    outlier_count: int = 0,
+    excluded_question_count: int = 0,
+    has_mismatch: bool = False,
+) -> RunMetrics:
+    """Build a RunMetrics carrying only the fields the warning text reads."""
+    return RunMetrics(
+        effective_score=100,
+        included_question_count=10,
+        excluded_question_count=excluded_question_count,
+        correct_count=10,
+        incorrect_count=0,
+        avg_time_msec=100.0,
+        median_time_msec=100.0,
+        outlier_count=outlier_count,
+        total_cost_usd=0.001,
+        total_tokens=100,
+        price_diagnostics=PriceDiagnostics(
+            status="warning" if has_mismatch else "ok",
+            label="",
+            message="",
+            estimated_total_cost_usd=0.001,
+            stored_total_cost_usd=0.001,
+            coverage="verified",
+            has_mismatch=has_mismatch,
+        ),
+    )
+
+
+def test_no_warnings_when_run_is_clean() -> None:
+    assert describe_run_warnings(_metrics()) == []
+
+
+def test_outlier_count_is_pluralized() -> None:
+    assert describe_run_warnings(_metrics(outlier_count=1)) == ["1 latency outlier"]
+    assert describe_run_warnings(_metrics(outlier_count=3)) == ["3 latency outliers"]
+
+
+def test_cost_mismatch_alone() -> None:
+    assert describe_run_warnings(_metrics(has_mismatch=True)) == ["cost warning"]
+
+
+def test_all_three_warnings_keep_a_stable_order() -> None:
+    warnings = describe_run_warnings(
+        _metrics(outlier_count=2, excluded_question_count=4, has_mismatch=True)
+    )
+    assert warnings == ["2 latency outliers", "cost warning", "4 excluded Q"]
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (100, "#1b5e20"),
+        (90, "#1b5e20"),
+        (89, "#4caf50"),
+        (75, "#4caf50"),
+        (50, "#ff9800"),
+        (25, "#f44336"),
+        (0, "#b71c1c"),
+    ],
+)
+def test_score_color_thresholds(score: int, expected: str) -> None:
+    """These thresholds are mirrored in static/js/dashboard.js as SCORE_COLORS."""
+    assert get_score_color(score) == expected


### PR DESCRIPTION
Each dashboard cell stacked a score circle, a median latency line, a cost line, and an optional warning line, making rows ~120px tall so only about three benchmarks fit on screen. The tier legend and filter card consumed another third of the viewport above the grid.

Cells now show one metric, chosen by a Score/Latency/Cost switcher; all three values ride along as data attributes so switching is instant and the tooltip always carries the full set. Rows drop to ~40px. The tier legend collapses into a popover, the filter card becomes one toolbar row, and the header plus the first two columns are sticky.

Latency and cost have no absolute scale, so those are colored by rank within each visible row rather than by fixed thresholds.

Two consolidations along the way:

* models.view_model read Run.normed_score while the dashboard recomputes effective_score from RunDetail, so the two pages could disagree about the same run. It now uses analyze_run_details like everywhere else.
* The warning text was rebuilt with nested {% if %} chains in three templates and the score-color thresholds were inlined in two; both move to server/analysis.py as describe_run_warnings() and get_score_color().

benchmarks/view.html and models/view.html gain the cost and latency columns that left the grid, so no information is lost.