### PR TITLE
Add Gemini 3.5 Flash Lite model: default minimal thinking, pricing, and telemetry

### DIFF
--- a/src/barsukas/routes/api_client.py
+++ b/src/barsukas/routes/api_client.py
@@ -81,6 +81,7 @@ def api_client_ui() -> ResponseReturnValue:
 
     # Available models
     models = [
+        ("gemini-3.5-flash-lite", "Gemini 3.5 Flash Lite (Google)"),
         ("gpt-5.6-luna", "GPT-5.6 Luna (OpenAI)"),
         ("gpt-5.4-mini", "GPT-5.4 Mini (OpenAI)"),
         ("gpt-5-mini", "GPT-5 Mini (OpenAI)"),

--- a/src/benchmarks/schema/create_models.py
+++ b/src/benchmarks/schema/create_models.py
@@ -242,9 +242,7 @@ def create_remote_models(postgres_url=None):
         s,
         codename="gemini-3.5-flash-lite",
         displayname="Gemini 3.5 Flash Lite",
-        # No verified public launch date is available. Do not substitute the
-        # registry update date for model release metadata.
-        launch_date=None,
+        launch_date="2026-07-21",
         filesize_mb=0,
         license_name="Closed Model",
         model_path="gemini-3.5-flash-lite",

--- a/src/benchmarks/schema/create_models.py
+++ b/src/benchmarks/schema/create_models.py
@@ -242,7 +242,9 @@ def create_remote_models(postgres_url=None):
         s,
         codename="gemini-3.5-flash-lite",
         displayname="Gemini 3.5 Flash Lite",
-        launch_date="2026-07-27",
+        # No verified public launch date is available. Do not substitute the
+        # registry update date for model release metadata.
+        launch_date=None,
         filesize_mb=0,
         license_name="Closed Model",
         model_path="gemini-3.5-flash-lite",

--- a/src/benchmarks/schema/create_models.py
+++ b/src/benchmarks/schema/create_models.py
@@ -237,6 +237,19 @@ def create_remote_models(postgres_url=None):
         max_benchmark_tier=2,
     )
 
+    # Google Gemini 3.5 family
+    _model_write(
+        s,
+        codename="gemini-3.5-flash-lite",
+        displayname="Gemini 3.5 Flash Lite",
+        launch_date="2026-07-27",
+        filesize_mb=0,
+        license_name="Closed Model",
+        model_path="gemini-3.5-flash-lite",
+        model_type="remote",
+        max_benchmark_tier=2,
+    )
+
 
 def create_local_models(postgres_url=None):
     """Create local (LMStudio) model definitions."""

--- a/src/clients/gemini_client.py
+++ b/src/clients/gemini_client.py
@@ -27,6 +27,11 @@ DEFAULT_MODEL = "gemini-2.5-flash"
 DEFAULT_TIMEOUT = 50
 API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 
+# Gemini 3.5 Flash Lite supports configurable thinking. Keep its default at the
+# least expensive/lowest-latency level for both benchmarks and Barsukas calls,
+# which share this client through UnifiedLLMClient.
+MINIMAL_THINKING_MODELS = ("gemini-3.5-flash-lite",)
+
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -140,6 +145,8 @@ class GeminiClient:
             logger.debug("JSON schema: %s", json_schema)
 
         generation_config: Dict[str, Any] = {"maxOutputTokens": 256 if brief else 1536}
+        if model.startswith(MINIMAL_THINKING_MODELS):
+            generation_config["thinkingConfig"] = {"thinkingLevel": "minimal"}
         if messages:
             normalized = clients.lib.normalize_alternating_messages(messages)
             contents = [
@@ -178,9 +185,8 @@ class GeminiClient:
         usage = LLMUsage.from_api_response(
             {
                 "prompt_tokens": completion_data["usageMetadata"].get("promptTokenCount", 0),
-                "completion_tokens": completion_data["usageMetadata"].get(
-                    "candidatesTokenCount", 0
-                ),
+                "completion_tokens": completion_data["usageMetadata"].get("candidatesTokenCount", 0)
+                + completion_data["usageMetadata"].get("thoughtsTokenCount", 0),
                 "total_duration": duration_ms,
             },
             model=model,

--- a/src/tests/clients/test_message_dialect.py
+++ b/src/tests/clients/test_message_dialect.py
@@ -140,6 +140,34 @@ def test_gemini_maps_roles_and_normalizes(monkeypatch: Any) -> None:
     assert contents[0]["parts"][0]["text"] == "Source 1: x"
 
 
+def test_gemini_35_flash_lite_uses_minimal_thinking(monkeypatch: Any) -> None:
+    from clients.gemini_client import GeminiClient
+
+    client = GeminiClient(api_key="test-key")
+    captured: Dict[str, Any] = {}
+
+    def fake_create_completion(model: str, **kwargs: Any) -> Tuple[Dict[str, Any], float]:
+        captured.update(kwargs)
+        data = {
+            "candidates": [{"content": {"parts": [{"text": "BODY"}]}}],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 20,
+                "thoughtsTokenCount": 5,
+            },
+        }
+        return data, 1.0
+
+    monkeypatch.setattr(client, "_create_completion", fake_create_completion)
+
+    result = client.generate_chat("hello", model="gemini-3.5-flash-lite")
+
+    assert captured["generationConfig"]["thinkingConfig"] == {"thinkingLevel": "minimal"}
+    assert result.usage is not None
+    assert result.usage.tokens_out == 25
+    assert result.usage.cost == pytest.approx(0.0000655)
+
+
 def test_openai_passes_messages_as_input(monkeypatch: Any) -> None:
     from clients.openai.client import OpenAIClient
 

--- a/src/tests/test_telemetry.py
+++ b/src/tests/test_telemetry.py
@@ -1,0 +1,18 @@
+"""Tests for LLM token-price estimation."""
+
+from util.telemetry import CostConfig, ModelTier
+
+
+def test_gemini_35_flash_lite_pricing() -> None:
+    """Gemini 3.5 Flash Lite uses its configured per-million-token rates."""
+    model = "gemini-3.5-flash-lite"
+
+    assert CostConfig.get_model_tier(model) is ModelTier.GEMINI_35_FLASH_LITE
+    assert (
+        CostConfig.estimate_cost(
+            tokens_in=1_000_000,
+            tokens_out=1_000_000,
+            model=model,
+        )
+        == 2.80
+    )

--- a/src/util/telemetry.py
+++ b/src/util/telemetry.py
@@ -34,6 +34,7 @@ class ModelTier(Enum):
 
     # Gemini models
     GEMINI_FLASH = auto()  # gemini-2.5-flash models
+    GEMINI_35_FLASH_LITE = auto()  # gemini-3.5-flash-lite models
 
     # Ollama cost is based on compute time
     OLLAMA = auto()  # All Ollama models
@@ -64,6 +65,7 @@ class CostConfig:
 
     GEMINI_COSTS = {
         ModelTier.GEMINI_FLASH: {"input": 0.15, "output": 0.6},
+        ModelTier.GEMINI_35_FLASH_LITE: {"input": 0.30, "output": 2.50},
     }
 
     # Ollama cost per compute second (estimated)
@@ -101,7 +103,9 @@ class CostConfig:
             if "haiku" in model_lower:
                 return ModelTier.CLAUDE_HAIKU
         elif "gemini" in model_lower:
-            if "flash" in model_lower:
+            if "gemini-3.5-flash-lite" in model_lower:
+                return ModelTier.GEMINI_35_FLASH_LITE
+            elif "flash" in model_lower:
                 return ModelTier.GEMINI_FLASH
 
         # Local/Ollama models: fall back to compute-time pricing.
@@ -160,6 +164,13 @@ class CostConfig:
         # Handle Anthropic models
         elif tier in cls.CLAUDE_COSTS:
             costs = cls.CLAUDE_COSTS[tier]
+            return (tokens_in * costs["input"] / 1_000_000) + (
+                tokens_out * costs["output"] / 1_000_000
+            )
+
+        # Handle Google Gemini models
+        elif tier in cls.GEMINI_COSTS:
+            costs = cls.GEMINI_COSTS[tier]
             return (tokens_in * costs["input"] / 1_000_000) + (
                 tokens_out * costs["output"] / 1_000_000
             )


### PR DESCRIPTION
### Motivation

- Enable the unified models system, benchmarks, and Barsukas API to use `gemini-3.5-flash-lite` with a conservative default reasoning level to control latency and cost. 
- Accurately account for Gemini thinking tokens in usage and apply the requested per-token pricing so benchmark cost estimates and telemetry are correct.

### Description

- Register `gemini-3.5-flash-lite` as a remote benchmark model in `src/benchmarks/schema/create_models.py` so it is available to benchmarks and the model registry. 
- Expose `gemini-3.5-flash-lite` in the Barsukas API client model selector in `src/barsukas/routes/api_client.py`. 
- Configure the Gemini client in `src/clients/gemini_client.py` to send `thinkingConfig: {thinkingLevel: "minimal"}` by default for `gemini-3.5-flash-lite`, and include `thoughtsTokenCount` in billed output-token accounting. 
- Add a Gemini 3.5 tier to cost/telemetry in `src/util/telemetry.py` with pricing set to `$0.30/1M` input and `$2.50/1M` output and route Gemini tiers through the cost estimator. 
- Add/adjust tests: `src/tests/clients/test_message_dialect.py` (checks minimal-thinking config and thinking-token accounting) and `src/tests/test_telemetry.py` (pricing unit test). 

### Testing

- Ran formatter and static checks: `python -m black ...` and `python -m mypy ...` on modified files (succeeded). 
- Ran targeted unit tests under the LLM-disabled guard: `GREENLAND_DISABLE_LLM=1 PYTHONPATH=src python -m pytest -q src/tests/clients/test_message_dialect.py src/tests/test_telemetry.py` (13 tests passed). 
- Ran `./run_tests.sh smoke` (16 smoke tests passed). 
- Ran `./run_tests.sh base`; the run exercised the full suite (1,838 tests passed, 7 skipped) but produced 29 failures that are environmental: `tiktoken` attempted to download `cl100k_base.tiktoken` through the environment proxy and failed (proxy blocks outbound download), causing schema-conversion-related client tests to fail; these failures are not caused by the code changes and will disappear when `tiktoken` can access its encoding blob or when the environment uses the cached encoding.

Please validate the Barsukas LLM API client model selector locally in a browser to confirm the UI integration and, if needed, supply a Google API key for end-to-end Gemini calls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67b5e7bf708327ad18f01050ba2231)