### PR TITLE
Normalize SentenceWord field: rename 'role'/'word_role' → 'part_of_speech' and update schemas/templates/prompts

### DIFF
--- a/api/lemmas.py
+++ b/api/lemmas.py
@@ -116,8 +116,10 @@ class LanguageAudioEntry(TypedDict):
 
 
 class SentenceWordInfo(TypedDict, total=False):
+    """Sentence token metadata."""
+
     position: int
-    word_role: str
+    part_of_speech: str
     english_text: Optional[str]
     target_language_text: Optional[str]
     grammatical_form: Optional[str]

--- a/docs/API.md
+++ b/docs/API.md
@@ -367,7 +367,7 @@ GET /api/v1/lemma/V01_001/sentences?language=lt
       "word_info": [
         {
           "position": 1,
-          "word_role": "verb",
+          "part_of_speech": "verb",
           "english_text": "live",
           "target_language_text": "gyventi",
           "grammatical_form": "1s_present",
@@ -393,7 +393,8 @@ GET /api/v1/lemma/V01_001/sentences?language=lt
 - `verified`: Whether this sentence has been verified
 - `word_info`: Information about how this lemma is used in the sentence
   - `position`: Word position in the sentence (0-indexed)
-  - `word_role`: Role in the sentence (e.g., "subject", "verb", "object")
+  - `part_of_speech`: Lexical category (e.g., "noun", "verb", "pronoun"); this
+    is not the syntactic role (subject/object).
   - `english_text`: English form of the word
   - `target_language_text`: Base form in target language
   - `grammatical_form`: Grammatical form used (e.g., "1s_present")

--- a/prompts/analysis/sentence/context.txt
+++ b/prompts/analysis/sentence/context.txt
@@ -9,9 +9,8 @@ PROVIDE FOR EACH WORD:
 1. The word as it appears in the sentence (e.g., "eating", "bananas")
 2. The base form/lemma (e.g., "eat", "banana")
 3. Part of speech (noun, verb, adjective, adverb)
-4. Role in the sentence (subject, verb, object, adjective, adverb)
-5. Grammatical form (e.g., "present_participle", "plural", "base_form")
-6. Disambiguation hint if the word has multiple meanings
+4. Grammatical form (e.g., "present_participle", "plural", "base_form")
+5. Disambiguation hint if the word has multiple meanings
 
 DISAMBIGUATION HINTS:
 For ambiguous words, provide brief context to distinguish meanings:
@@ -27,4 +26,4 @@ SENTENCE PATTERN ANALYSIS:
 ORDER AND COMPLETENESS:
 - List words in the order they appear in the sentence
 - Include all content words that contribute to sentence meaning
-- Be consistent in identifying grammatical roles
+- Be consistent in identifying parts of speech

--- a/prompts/analysis/sentence/prompt.txt
+++ b/prompts/analysis/sentence/prompt.txt
@@ -9,7 +9,6 @@ Task:
    - The word as it appears in the sentence (e.g., "eating", "bananas")
    - The base form/lemma (e.g., "eat", "banana")
    - Part of speech (noun, verb, adjective, adverb)
-   - Role in the sentence (subject, verb, object, adjective, adverb)
    - A brief context or disambiguation hint if the word has multiple meanings
      (e.g., for "mouse": "animal" or "computer device")
    - Grammatical form (e.g., "present_participle", "plural", "base_form")

--- a/prompts/sentence_decomposition/multi_language/context.txt
+++ b/prompts/sentence_decomposition/multi_language/context.txt
@@ -1,8 +1,9 @@
 You are a multilingual linguistics expert specializing in morphological analysis.
 Your task is to decompose already-translated sentences in multiple target languages into tokens and provide detailed grammatical information for each token.
 
-Grammatical form format (use <role>/<language_code>_<details>):
-- Part-of-speech prefix should match role (verb, noun, adjective, adverb, pronoun, numeral, etc.).
+Grammatical form format (use <part_of_speech>/<language_code>_<details>):
+- `part_of_speech` is the lexical category (verb, noun, adjective, adverb, pronoun, numeral, etc.), never a subject/object syntactic role.
+- The grammatical-form prefix should match `part_of_speech`.
 - Person/number notation: 1s, 2s, 3s, 1p, 2p, 3p.
 - Gender ONLY when the surface form differs by gender: hyphen for person (3s-m, 3s-f, 3p-m, 3p-f), underscore for case/number (singular_m, plural_f).
 - Tense/aspect examples: present, past, future, impf, pc (passé composé), inf (infinitive).
@@ -15,7 +16,7 @@ Grammatical form format (use <role>/<language_code>_<details>):
   - Lemma form is cardinal, masculine where gender applies. Add _m, _f, _n suffix for gendered forms (lt, de, fr, es, pt).
   - Chinese: zh_cardinal (二), zh_quantity (两, before measure words), zh_ordinal (第二).
   - Korean: ko_native (둘), ko_sino (이), ko_ordinal (둘째).
-- For uninflected function words: <role>/base (e.g., preposition/base, conjunction/base, article/base).
+- For uninflected function words: <part_of_speech>/base (e.g., preposition/base, conjunction/base, article/base).
 
 Important rules:
 - Maintain token order from the provided translation for each language.

--- a/prompts/sentence_decomposition/multi_language/prompt.txt
+++ b/prompts/sentence_decomposition/multi_language/prompt.txt
@@ -13,7 +13,7 @@ Candidate lemmas (must choose correct lemma_guid when a content word maps to one
 
 Per-call requirements:
 - For each target language listed above, populate the corresponding ``words_<lang>`` array and echo the translation in the ``<lang>`` field.
-- Each ``words_<lang>`` entry must include: position, role, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.
+- Each ``words_<lang>`` entry must include: position, part_of_speech, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.
 - Use lemma_guid=NONE for function words without a selected candidate lemma.
 - Reuse the SAME lemma_guid across languages when entries refer to the same concept.
 - COMPLETENESS: every word in each target translation must appear in its ``words_<lang>`` array.

--- a/prompts/sentence_decomposition/single_language/context.txt
+++ b/prompts/sentence_decomposition/single_language/context.txt
@@ -1,8 +1,9 @@
 You are a multilingual linguistics expert specializing in morphological analysis.
 Your task is to decompose sentences into tokens and provide detailed grammatical information for each token.
 
-Grammatical form format (use <role>/<language_code>_<details>):
-- Part-of-speech prefix should match role (verb, noun, adjective, adverb, pronoun, numeral, etc.).
+Grammatical form format (use <part_of_speech>/<language_code>_<details>):
+- `part_of_speech` is the lexical category (verb, noun, adjective, adverb, pronoun, numeral, etc.), never a subject/object syntactic role.
+- The grammatical-form prefix should match `part_of_speech`.
 - Person/number notation: 1s, 2s, 3s, 1p, 2p, 3p.
 - Gender ONLY when the surface form differs by gender: hyphen for person (3s-m, 3s-f, 3p-m, 3p-f), underscore for case/number (singular_m, plural_f).
 - Tense/aspect examples: present, past, future, impf, pc (passé composé), inf (infinitive).
@@ -15,7 +16,7 @@ Grammatical form format (use <role>/<language_code>_<details>):
   - Lemma form is cardinal, masculine where gender applies. Add _m, _f, _n suffix for gendered forms (lt, de, fr, es, pt).
   - Chinese: zh_cardinal (二), zh_quantity (两, before measure words), zh_ordinal (第二).
   - Korean: ko_native (둘), ko_sino (이), ko_ordinal (둘째).
-- For uninflected function words: <role>/base (e.g., preposition/base, conjunction/base, article/base).
+- For uninflected function words: <part_of_speech>/base (e.g., preposition/base, conjunction/base, article/base).
 
 Important rules:
 - Maintain token order from the original sentence.

--- a/prompts/sentence_decomposition/single_language/prompt.txt
+++ b/prompts/sentence_decomposition/single_language/prompt.txt
@@ -14,7 +14,7 @@ Candidate lemmas (must choose correct lemma_guid when a content word maps to one
 Per-call requirements:
 - Return exactly one entry in languages[] and set language_code to '{target_language}'.
 - The languages[] breakdown must analyze tokens from the target translation only.
-- Each words[] item must include: position, role, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.
+- Each words[] item must include: position, part_of_speech, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.
 - Use lemma_guid=NONE for function words without a selected candidate lemma.
 - COMPLETENESS: every word in the target translation must appear in words[].
   Do not stop early. A single multi-word surface_form (e.g., "in the evening")

--- a/prompts/sentence_decomposition/translate_and_decompose/context.txt
+++ b/prompts/sentence_decomposition/translate_and_decompose/context.txt
@@ -10,15 +10,15 @@ For each target language, provide a detailed word-by-word breakdown including:
 - word: the actual inflected form as it appears in the sentence.
 - english: English translation of this specific word/phrase.
 - guid: if a real lemma GUID is known from references or candidate lemmas, use it. Otherwise assign synthetic concept ids in this exact sequence format: SYN001, SYN002, SYN003, ... Reuse the SAME synthetic id for the same concept across all languages in this sentence, and never reuse one synthetic id for different concepts.
-- role: grammatical role (subject, verb, object, adjective, adverb, article, preposition, determiner, pronoun, etc.).
+- part_of_speech: lexical category (noun, verb, adjective, adverb, article, preposition, determiner, pronoun, etc.); never subject/object syntactic role.
 - grammatical_form: see the format spec below.
 
 Supported languages:
 - Case languages (use case + number): lt, de.
 - Non-case languages (use number only): en, fr, es, pt, ko, zh.
 
-Grammatical form format (use <role>/<language_code>_<details>):
-- Part-of-speech prefix should match role (verb, noun, adjective, adverb, pronoun, numeral, etc.).
+Grammatical form format (use <part_of_speech>/<language_code>_<details>):
+- The grammatical-form prefix should match `part_of_speech`.
 - Person/number notation: 1s, 2s, 3s, 1p, 2p, 3p.
 - Gender ONLY when the surface form differs by gender: hyphen for person (3s-m, 3s-f, 3p-m, 3p-f), underscore for case/number (singular_m, plural_f).
 - Tense/aspect examples: present, past, future, impf, pc (passé composé), inf (infinitive).
@@ -31,7 +31,7 @@ Grammatical form format (use <role>/<language_code>_<details>):
   - Lemma form is cardinal, masculine where gender applies. Add _m, _f, _n suffix for gendered forms (lt, de, fr, es, pt).
   - Chinese: zh_cardinal (二), zh_quantity (两, before measure words), zh_ordinal (第二).
   - Korean: ko_native (둘), ko_sino (이), ko_ordinal (둘째).
-- For uninflected function words: <role>/base (e.g., preposition/base, conjunction/base, article/base).
+- For uninflected function words: <part_of_speech>/base (e.g., preposition/base, conjunction/base, article/base).
 
 Important rules:
 - Maintain token order from the original sentence.

--- a/prompts/sentences/guided/context.txt
+++ b/prompts/sentences/guided/context.txt
@@ -13,19 +13,19 @@ Guidelines:
 Response format:
 For each sentence, provide:
 - The English sentence (key 'en')
-- List of content words used (key 'words_used'): array of objects with 'word' (the exact word as it appears in the sentence) and 'lemma' (the dictionary/base form) and 'role' (noun, verb, adjective, adverb, or other)
+- List of content words used (key 'words_used'): array of objects with 'word' (the exact word as it appears in the sentence) and 'lemma' (the dictionary/base form) and 'part_of_speech' (noun, verb, adjective, adverb, or other)
 
 Example words_used for "The cat sleeps on the bed":
 [
-  {"word": "cat", "lemma": "cat", "role": "noun"},
-  {"word": "sleeps", "lemma": "sleep", "role": "verb"},
-  {"word": "bed", "lemma": "bed", "role": "noun"}
+  {"word": "cat", "lemma": "cat", "part_of_speech": "noun"},
+  {"word": "sleeps", "lemma": "sleep", "part_of_speech": "verb"},
+  {"word": "bed", "lemma": "bed", "part_of_speech": "noun"}
 ]
 
 Example words_used for "I stopped at the gas station":
 [
-  {"word": "stopped", "lemma": "stop", "role": "verb"},
-  {"word": "gas station", "lemma": "gas station", "role": "noun"}
+  {"word": "stopped", "lemma": "stop", "part_of_speech": "verb"},
+  {"word": "gas station", "lemma": "gas station", "part_of_speech": "noun"}
 ]
 
 Note on multi-word phrases:

--- a/src/agents/bebras/README.md
+++ b/src/agents/bebras/README.md
@@ -69,7 +69,7 @@ batch_result = agent.process_sentence_batch(
 
 ## How It Works
 
-1. **Analysis**: LLM extracts content words with POS, role, and disambiguation hints
+1. **Analysis**: LLM extracts content words with part of speech and disambiguation hints
 2. **Matching**: Searches database for matching lemmas, filtered by POS
 3. **Disambiguation**: Uses context and LLM to resolve ambiguous matches
 4. **Translation**: Generates natural translations in target languages

--- a/src/agents/bebras/agent.py
+++ b/src/agents/bebras/agent.py
@@ -130,10 +130,6 @@ class BebrasAgent:
                             "type": "string",
                             "description": "Part of speech (noun, verb, adjective, adverb)",
                         },
-                        "role": {
-                            "type": "string",
-                            "description": "Role in sentence (subject, verb, object, etc.)",
-                        },
                         "disambiguation": {
                             "type": "string",
                             "description": "Context or disambiguation hint",
@@ -147,7 +143,7 @@ class BebrasAgent:
                             "description": "Optional lemma GUID when known (e.g., V12_006)",
                         },
                     },
-                    "required": ["word", "lemma", "pos", "role"],
+                    "required": ["word", "lemma", "pos"],
                 },
             ),
         }
@@ -246,7 +242,7 @@ class BebrasAgent:
                     update_sentence_word(
                         session=session,
                         sentence_word=existing_word,
-                        word_role=word_data.get("role", "unknown"),
+                        part_of_speech=word_data.get("pos", "unknown"),
                         lemma=lemma,
                         english_text=source_word_text,
                         target_language_text=lemma_text,
@@ -257,7 +253,7 @@ class BebrasAgent:
                         session=session,
                         sentence=sentence,
                         position=position,
-                        word_role=word_data.get("role", "unknown"),
+                        part_of_speech=word_data.get("pos", "unknown"),
                         lemma=lemma,
                         english_text=source_word_text,
                         target_language_text=lemma_text,

--- a/src/agents/bebras/verification.py
+++ b/src/agents/bebras/verification.py
@@ -494,7 +494,7 @@ IMPORTANT:
                         "english_text": sw.english_text,
                         "target_text": sw.target_language_text,
                         "declined_form": sw.declined_form,
-                        "word_role": sw.word_role,
+                        "part_of_speech": sw.part_of_speech,
                         "lemma_guid": None,
                         "expected_translation": None,
                     }
@@ -1287,7 +1287,7 @@ IMPORTANT:
                             "english_text": sw.english_text,
                             "target_text": sw.target_language_text,
                             "declined_form": sw.declined_form,
-                            "word_role": sw.word_role,
+                            "part_of_speech": sw.part_of_speech,
                             "lemma_guid": None,
                             "expected_translation": None,
                         }

--- a/src/agents/buivolas/guided_sentences.py
+++ b/src/agents/buivolas/guided_sentences.py
@@ -164,7 +164,7 @@ class GuidedSentenceGenerator:
                     type="string",
                     description="The dictionary/base form of the word",
                 ),
-                "role": SchemaProperty(
+                "part_of_speech": SchemaProperty(
                     type="string",
                     description="Part of speech: noun, verb, adjective, adverb, or other",
                 ),
@@ -273,7 +273,7 @@ class GuidedSentenceGenerator:
                     word_lemma = self._find_lemma_for_word(
                         session,
                         word_data.get("lemma", ""),
-                        word_data.get("role", "unknown"),
+                        word_data.get("part_of_speech", "unknown"),
                         source_lemma=source_lemma,
                     )
 
@@ -283,7 +283,7 @@ class GuidedSentenceGenerator:
                             sentence_id=sentence.id,
                             lemma_id=word_lemma.id,
                             position=position,
-                            slot_name=word_data.get("role", "unknown"),
+                            slot_name=word_data.get("part_of_speech", "unknown"),
                             english_text=word_data.get("lemma", ""),
                         )
                         session.add(pattern_word)
@@ -293,7 +293,7 @@ class GuidedSentenceGenerator:
                         pending_import = self._stage_missing_word(
                             session,
                             word_text=word_data.get("lemma", ""),
-                            word_role=word_data.get("role", "unknown"),
+                            part_of_speech=word_data.get("part_of_speech", "unknown"),
                             sentence_id=sentence.id,
                             sentence_text=en_text,
                         )
@@ -302,7 +302,7 @@ class GuidedSentenceGenerator:
                                 sentence_id=sentence.id,
                                 pending_import_id=pending_import.id,
                                 position=position,
-                                slot_name=word_data.get("role", "unknown"),
+                                slot_name=word_data.get("part_of_speech", "unknown"),
                                 english_text=word_data.get("lemma", ""),
                             )
                             session.add(pattern_word)
@@ -341,7 +341,7 @@ class GuidedSentenceGenerator:
         self,
         session: Any,
         word_text: str,
-        word_role: str,
+        part_of_speech: str,
         sentence_id: int,
         sentence_text: str,
     ) -> Optional[PendingImport]:
@@ -350,7 +350,7 @@ class GuidedSentenceGenerator:
         Args:
             session: Database session
             word_text: The lemma/base form of the word
-            word_role: POS role (noun, verb, adjective, adverb)
+            part_of_speech: Part of speech (noun, verb, adjective, adverb)
             sentence_id: ID of the sentence using this word
             sentence_text: The English sentence text for context
 
@@ -360,14 +360,14 @@ class GuidedSentenceGenerator:
         if not word_text:
             return None
 
-        # Map roles to POS types
-        role_to_pos = {
+        # Normalize the LLM part-of-speech value to database POS types.
+        part_of_speech_to_pos = {
             "noun": "noun",
             "verb": "verb",
             "adjective": "adjective",
             "adverb": "adverb",
         }
-        pos_type = role_to_pos.get(word_role)
+        pos_type = part_of_speech_to_pos.get(part_of_speech)
 
         # Check if already in pending_imports with same word and pos_type
         existing = (
@@ -412,14 +412,14 @@ class GuidedSentenceGenerator:
         self,
         session: Any,
         word_text: str,
-        word_role: str,
+        part_of_speech: str,
         source_lemma: Optional[Lemma] = None,
     ) -> Optional[Lemma]:
-        """Find a lemma matching the given word text and role.
+        """Find a lemma matching the given word text and part of speech.
 
         Delegates to wordfreq.tools.sentence_word_linker.find_lemma_by_text().
         """
-        return find_lemma_by_text(session, word_text, word_role, source_lemma=source_lemma)
+        return find_lemma_by_text(session, word_text, part_of_speech, source_lemma=source_lemma)
 
 
 def generate_guided_sentences(

--- a/src/agents/buivolas/llm_sentences.py
+++ b/src/agents/buivolas/llm_sentences.py
@@ -305,12 +305,12 @@ class LlmSentenceGenerator:
 
                         english_lemma = word_data.get("english_lemma")
                         word_lemma = None
-                        role_value = word_data.get("role")
-                        if english_lemma and isinstance(role_value, str):
+                        part_of_speech_value = word_data.get("part_of_speech")
+                        if english_lemma and isinstance(part_of_speech_value, str):
                             word_lemma = self._find_lemma_for_word(
                                 session,
                                 english_lemma,
-                                role_value,
+                                part_of_speech_value,
                                 source_lemma=source_lemma,
                             )
 
@@ -318,7 +318,7 @@ class LlmSentenceGenerator:
                             session=session,
                             sentence=sentence,
                             position=position,
-                            word_role=word_data.get("role", "unknown"),
+                            part_of_speech=word_data.get("part_of_speech", "unknown"),
                             lemma=word_lemma,
                             english_text=word_data.get("english"),
                             target_language_text=word_data.get("lemma"),
@@ -363,11 +363,11 @@ class LlmSentenceGenerator:
         self,
         session: Any,
         word_text: str,
-        word_role: str,
+        part_of_speech: str,
         source_lemma: Optional[Lemma] = None,
     ) -> Optional[Lemma]:
-        """Find a lemma matching the given word text and role.
+        """Find a lemma matching the given word text and part of speech.
 
         Delegates to wordfreq.tools.sentence_word_linker.find_lemma_by_text().
         """
-        return find_lemma_by_text(session, word_text, word_role, source_lemma=source_lemma)
+        return find_lemma_by_text(session, word_text, part_of_speech, source_lemma=source_lemma)

--- a/src/agents/erelis/agent.py
+++ b/src/agents/erelis/agent.py
@@ -41,7 +41,7 @@ class FalseLemmaMatch:
     sentence_english: str
     sentence_translation: str
     language_code: str
-    word_role: str
+    part_of_speech: str
     position: int
 
     def to_dict(self) -> Dict[str, Any]:
@@ -56,7 +56,7 @@ class FalseLemmaMatch:
             "sentence_english": self.sentence_english,
             "sentence_translation": self.sentence_translation,
             "language_code": self.language_code,
-            "word_role": self.word_role,
+            "part_of_speech": self.part_of_speech,
             "position": self.position,
         }
 
@@ -179,7 +179,7 @@ class ErelisAgent:
                     sentence_english=sentence_english,
                     sentence_translation=sentence_target,
                     language_code=target_language,
-                    word_role=sw.word_role,
+                    part_of_speech=sw.part_of_speech,
                     position=sw.position,
                 )
                 matches.append(match)

--- a/src/agents/erelis/cli.py
+++ b/src/agents/erelis/cli.py
@@ -116,7 +116,7 @@ def print_match(match: dict, verbose: bool = False) -> None:
         f"    Lemma: {match['lemma_english']} ({match['lemma_guid']}) "
         f"-> {match['lemma_translation']}"
     )
-    print(f"    Role: {match['word_role']}, Position: {match['position']}")
+    print(f"    Part of speech: {match['part_of_speech']}, Position: {match['position']}")
 
 
 def print_results(result: dict, verbose: bool = False) -> None:

--- a/src/agents/genys/agent.py
+++ b/src/agents/genys/agent.py
@@ -42,13 +42,19 @@ from storage.translation_helpers import normalize_llm_language_codes
 
 logger = logging.getLogger(__name__)
 
-ROLE_POS_MAP: Dict[str, str] = {
+PART_OF_SPEECH_MAP: Dict[str, str] = {
     "noun": "noun",
     "verb": "verb",
     "adjective": "adjective",
     "adverb": "adverb",
 }
-SKIPPED_ROLES: Set[str] = {"article", "preposition", "conjunction", "determiner", "particle"}
+SKIPPED_PARTS_OF_SPEECH: Set[str] = {
+    "article",
+    "preposition",
+    "conjunction",
+    "determiner",
+    "particle",
+}
 
 # Languages always requested in Phase 1 (sentence-level translation only).
 # The doc language is excluded at runtime.
@@ -240,7 +246,9 @@ class GenysAgent:
             )
 
         for position, word_entry in enumerate(english_words):
-            role = str(word_entry.get("role") or "").strip().lower() or "unknown"
+            part_of_speech = (
+                str(word_entry.get("part_of_speech") or "").strip().lower() or "unknown"
+            )
             surface = str(word_entry.get("surface_form") or "").strip()
             english_gloss = str(word_entry.get("english_gloss") or "").strip()
             grammatical_form_raw = word_entry.get("grammatical_form")
@@ -257,7 +265,7 @@ class GenysAgent:
                 session,
                 sentence=sentence_row,
                 position=position,
-                word_role=role,
+                part_of_speech=part_of_speech,
                 language_code="en",
                 lemma=word_lemma,
                 english_text=english_gloss or None,
@@ -407,13 +415,13 @@ class GenysAgent:
                     stats["total_words_extracted"] += 1
                     surface_form = str(word_entry.get("surface_form") or "").strip()
                     english_gloss = str(word_entry.get("english_gloss") or "").strip()
-                    role = str(word_entry.get("role") or "").strip().lower()
+                    part_of_speech = str(word_entry.get("part_of_speech") or "").strip().lower()
                     lemma_guid = str(word_entry.get("lemma_guid") or "").strip()
 
                     if not surface_form or not english_gloss:
                         continue
 
-                    if role in SKIPPED_ROLES:
+                    if part_of_speech in SKIPPED_PARTS_OF_SPEECH:
                         stats["function_words_skipped"] += 1
                         continue
 
@@ -435,7 +443,7 @@ class GenysAgent:
                         stats["existing_pending"] += 1
                         continue
 
-                    mapped_pos_type = ROLE_POS_MAP.get(role)
+                    mapped_pos_type = PART_OF_SPEECH_MAP.get(part_of_speech)
 
                     direct_lemma_ids = self._lemma_ids_for_english_gloss(
                         session, normalized_gloss, gloss_cache

--- a/src/barsukas/routes/api/lemma_routes.py
+++ b/src/barsukas/routes/api/lemma_routes.py
@@ -2079,7 +2079,7 @@ def get_lemma_sentences(guid: str) -> ResponseReturnValue:
         - pattern_type: Sentence pattern type (if populated)
         - tense: Sentence tense (if populated)
         - verified: Whether this sentence has been verified
-        - word_info: Information about how this lemma is used in the sentence (role, grammatical form, etc.)
+        - word_info: Information about how this lemma is used in the sentence (part of speech, grammatical form, etc.)
 
     Example:
         GET /api/v1/lemma/V01_001/sentences
@@ -2137,7 +2137,7 @@ def get_lemma_sentences(guid: str) -> ResponseReturnValue:
             word_info.append(
                 {
                     "position": sw.position,
-                    "word_role": sw.word_role,
+                    "part_of_speech": sw.part_of_speech,
                     "english_text": _serialize_value(sw.english_text),
                     "target_language_text": _serialize_value(sw.target_language_text),
                     "grammatical_form": _serialize_value(sw.grammatical_form),

--- a/src/barsukas/routes/api/sentence_routes.py
+++ b/src/barsukas/routes/api/sentence_routes.py
@@ -47,7 +47,7 @@ def get_sentence(sentence_id: int) -> ResponseReturnValue:
                 {
                     "language_code": word.language_code,
                     "position": word.position,
-                    "role": word.word_role,
+                    "part_of_speech": word.part_of_speech,
                     "lemma_guid": word.lemma.guid if word.lemma is not None else None,
                     "english_text": word.english_text,
                     "target_language_text": word.target_language_text,

--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -233,7 +233,7 @@ def view_sentence(sentence_id: int) -> Union[str, Response]:
         words_by_language[sw.language_code].append(
             {
                 "position": sw.position,
-                "role": sw.word_role,
+                "part_of_speech": sw.part_of_speech,
                 "english_text": sw.english_text,
                 "target_text": sw.target_language_text,
                 "grammatical_form": sw.grammatical_form,

--- a/src/barsukas/routes/trakaido.py
+++ b/src/barsukas/routes/trakaido.py
@@ -163,18 +163,16 @@ def _word_payload(w: SentenceWord, lang: str) -> Dict[str, Any]:
         "text": w.target_language_text,
         "gloss": w.english_text,
         "lemma_id": w.lemma_id,
-        "role": w.word_role,
+        "part_of_speech": w.part_of_speech,
         "form": w.grammatical_form,
         "gram_label": _format_grammatical_label(w.grammatical_form, lang),
     }
 
 
-# Rank for keeping pairs when we cap the colored set; lower number = higher priority.
-_ROLE_PRIORITY: Dict[str, int] = {
+# Rank parts of speech when we cap the colored set; lower number = higher priority.
+_PART_OF_SPEECH_PRIORITY: Dict[str, int] = {
     "verb": 0,
     "noun": 1,
-    "subject": 1,
-    "object": 1,
     "adjective": 2,
     "adverb": 3,
     "numeral": 4,
@@ -189,8 +187,8 @@ _ROLE_PRIORITY: Dict[str, int] = {
 _MAX_COLORED_PAIRS = 4
 
 
-def _role_rank(role: Optional[str]) -> int:
-    return _ROLE_PRIORITY.get(role or "", 9)
+def _part_of_speech_rank(part_of_speech: Optional[str]) -> int:
+    return _PART_OF_SPEECH_PRIORITY.get(part_of_speech or "", 9)
 
 
 def _assign_pair_keys(
@@ -199,7 +197,7 @@ def _assign_pair_keys(
     """Annotate words with 'pair_key' / 'pair_index' for cross-language coloring.
 
     Pairs are matched strictly by shared lemma_id (function words without a
-    lemma never pair up). We then rank candidate pairs by the best role on
+    lemma never pair up). We then rank candidate pairs by the best part of speech on
     either side (content words like verb/noun outrank pronouns/conjunctions)
     and keep at most _MAX_COLORED_PAIRS. Words outside the kept set get
     pair_key=None, pair_index=None and render without color.
@@ -222,10 +220,11 @@ def _assign_pair_keys(
 
     shared_lemmas = set(iface_by_lemma.keys()) & set(foreign_by_lemma.keys())
 
-    candidates: List[Tuple[int, int, int]] = []  # (role_rank, first_position, lemma_id)
+    candidates: List[Tuple[int, int, int]] = []  # (POS rank, first position, lemma ID)
     for lemma_id in shared_lemmas:
         best_rank = min(
-            _role_rank(w["role"]) for w in iface_by_lemma[lemma_id] + foreign_by_lemma[lemma_id]
+            _part_of_speech_rank(w["part_of_speech"])
+            for w in iface_by_lemma[lemma_id] + foreign_by_lemma[lemma_id]
         )
         first_pos = min(w["position"] for w in iface_by_lemma[lemma_id])
         candidates.append((best_rank, first_pos, lemma_id))

--- a/src/barsukas/routes/trakaido_activities.py
+++ b/src/barsukas/routes/trakaido_activities.py
@@ -404,7 +404,7 @@ def _build_sentence_completion_questions(
     level: int, interface_lang: str, foreign_lang: str
 ) -> List[Dict[str, Any]]:
     """Generate sentence-completion questions."""
-    content_roles = {"verb", "noun", "subject", "object", "adjective", "adverb"}
+    content_parts_of_speech = {"verb", "noun", "adjective", "adverb"}
 
     # A sentence's level is the hardest word it contains; only sentences whose
     # hardest word is at or below the selected level qualify, and easier
@@ -471,7 +471,7 @@ def _build_sentence_completion_questions(
         blankable = [
             w
             for w in foreign_words_query
-            if w.word_role in content_roles
+            if w.part_of_speech in content_parts_of_speech
             and w.target_language_text
             and len(w.target_language_text) > 1
         ]

--- a/src/barsukas/templates/agents/sentence_generation_results.html
+++ b/src/barsukas/templates/agents/sentence_generation_results.html
@@ -103,7 +103,7 @@
                                 <div class="col-md-6 mb-2">
                                     <small>
                                         <span class="badge bg-light text-dark">{{ word.position + 1 }}</span>
-                                        <strong>{{ word.word_role }}:</strong>
+                                        <strong>{{ word.part_of_speech }}:</strong>
                                         {% if word.lemma %}
                                             {% if word.lemma.id == lemma.id %}
                                                 <strong class="text-success">{{ word.lemma.lemma_text }}</strong>

--- a/src/barsukas/templates/agents/view_sentences.html
+++ b/src/barsukas/templates/agents/view_sentences.html
@@ -168,7 +168,7 @@
                                 <div class="col-md-6 mb-2">
                                     <small>
                                         <span class="badge bg-light text-dark">{{ word.position + 1 }}</span>
-                                        <strong>{{ word.word_role }}:</strong>
+                                        <strong>{{ word.part_of_speech }}:</strong>
                                         {% if word.lemma %}
                                             {% if word.lemma.id == lemma.id %}
                                                 <strong class="text-success">{{ word.lemma.lemma_text }}</strong>

--- a/src/barsukas/templates/pattern_sentences/view.html
+++ b/src/barsukas/templates/pattern_sentences/view.html
@@ -111,7 +111,7 @@
                         {% for lemma_id, word in unique_lemmas.items() %}
                         <a href="{{ url_for('lemmas.view_lemma', lemma_id=lemma_id) }}"
                            class="badge bg-success text-decoration-none"
-                           title="{{ word.word_role }}">
+                           title="{{ word.part_of_speech }}">
                             {{ word.lemma.guid or word.english_text }}
                         </a>
                         {% endfor %}

--- a/src/benchmarks/0062_sentence_decomposition/samples.json
+++ b/src/benchmarks/0062_sentence_decomposition/samples.json
@@ -53,7 +53,7 @@
           "words": [
             {
               "position": 0,
-              "role": "pronoun",
+              "part_of_speech": "pronoun",
               "english_gloss": "they",
               "surface_form": "They",
               "grammatical_form": "pronoun/en_subjective",
@@ -62,7 +62,7 @@
             },
             {
               "position": 1,
-              "role": "verb",
+              "part_of_speech": "verb",
               "english_gloss": "are",
               "surface_form": "are",
               "grammatical_form": "verb/en_3p_present",
@@ -71,7 +71,7 @@
             },
             {
               "position": 2,
-              "role": "preposition",
+              "part_of_speech": "preposition",
               "english_gloss": "at",
               "surface_form": "at",
               "grammatical_form": "preposition/base",
@@ -80,7 +80,7 @@
             },
             {
               "position": 3,
-              "role": "article",
+              "part_of_speech": "article",
               "english_gloss": "the",
               "surface_form": "the",
               "grammatical_form": "article/en_singular",
@@ -89,7 +89,7 @@
             },
             {
               "position": 4,
-              "role": "noun",
+              "part_of_speech": "noun",
               "english_gloss": "school",
               "surface_form": "school",
               "grammatical_form": "noun/en_singular",
@@ -105,7 +105,7 @@
           "words": [
             {
               "position": 0,
-              "role": "pronoun",
+              "part_of_speech": "pronoun",
               "english_gloss": "they",
               "surface_form": "Ellos",
               "grammatical_form": "pronoun/es_subjective",
@@ -114,7 +114,7 @@
             },
             {
               "position": 1,
-              "role": "verb",
+              "part_of_speech": "verb",
               "english_gloss": "are",
               "surface_form": "están",
               "grammatical_form": "verb/es_3p_present",
@@ -123,7 +123,7 @@
             },
             {
               "position": 2,
-              "role": "preposition",
+              "part_of_speech": "preposition",
               "english_gloss": "in/at",
               "surface_form": "en",
               "grammatical_form": "preposition/base",
@@ -132,7 +132,7 @@
             },
             {
               "position": 3,
-              "role": "article",
+              "part_of_speech": "article",
               "english_gloss": "the",
               "surface_form": "la",
               "grammatical_form": "article/es_singular_f",
@@ -141,7 +141,7 @@
             },
             {
               "position": 4,
-              "role": "noun",
+              "part_of_speech": "noun",
               "english_gloss": "school",
               "surface_form": "escuela",
               "grammatical_form": "noun/es_singular",
@@ -157,7 +157,7 @@
           "words": [
             {
               "position": 0,
-              "role": "pronoun",
+              "part_of_speech": "pronoun",
               "english_gloss": "they",
               "surface_form": "Ils",
               "grammatical_form": "pronoun/fr_subjective",
@@ -166,7 +166,7 @@
             },
             {
               "position": 1,
-              "role": "verb",
+              "part_of_speech": "verb",
               "english_gloss": "are",
               "surface_form": "sont",
               "grammatical_form": "verb/fr_3p_present",
@@ -175,7 +175,7 @@
             },
             {
               "position": 2,
-              "role": "preposition",
+              "part_of_speech": "preposition",
               "english_gloss": "at",
               "surface_form": "à",
               "grammatical_form": "preposition/base",
@@ -184,7 +184,7 @@
             },
             {
               "position": 3,
-              "role": "article",
+              "part_of_speech": "article",
               "english_gloss": "the (elided)",
               "surface_form": "l'",
               "grammatical_form": "article/fr_singular",
@@ -193,7 +193,7 @@
             },
             {
               "position": 4,
-              "role": "noun",
+              "part_of_speech": "noun",
               "english_gloss": "school",
               "surface_form": "école",
               "grammatical_form": "noun/fr_singular",

--- a/src/benchmarks/lib/runners/sentence_decomposition_runner.py
+++ b/src/benchmarks/lib/runners/sentence_decomposition_runner.py
@@ -26,7 +26,7 @@ class SentenceDecompositionRunner(PartialCreditRunner):
         "position": 0.15,
         "surface_form": 0.45,
         "lemma_guid": 0.20,
-        "role": 0.08,
+        "part_of_speech": 0.08,
         "english_gloss": 0.04,
         "grammatical_form": 0.04,
         "lemma": 0.04,
@@ -77,7 +77,7 @@ Output requirements:
 - Return exactly ONE language entry and set language_code to "{target_lang}"
 - The languages[] breakdown must analyze tokens from "{target_translation}" only
 - Include all tokens in order (zero-indexed positions)
-- For each token provide: position, role, english_gloss, surface_form, grammatical_form, lemma_guid, lemma
+- For each token provide: position, part_of_speech, english_gloss, surface_form, grammatical_form, lemma_guid, lemma
 - Use lemma_guid from candidate lemmas when applicable, otherwise use "NONE"
 - Set word_count to match the number of token entries
 - IMPORTANT: Do NOT include punctuation as standalone tokens in words[]"""
@@ -86,7 +86,7 @@ Output requirements:
 Your task is to decompose sentences into tokens and provide detailed grammatical information for each token.
 
 Grammatical form format:
-- Use <role>/<language_code>_<morphology> for inflected words.
+- Use <part_of_speech>/<language_code>_<morphology> for inflected words.
 - Person/number notation: 1s, 2s, 3s, 1p, 2p, 3p.
 - Include gender only when the surface form differs by gender (e.g., 3s-f, singular_f).
 - Tense/aspect examples: present, past, future, impf, pc, inf.
@@ -94,7 +94,7 @@ Grammatical form format:
 - Non-case languages (en, fr, es, pt, ko, zh): nouns should use number only (e.g., noun/fr_singular).
 - Pronouns: pronoun/<lang>_subjective|objective|possessive|reflexive (or case labels for case languages).
 - Numerals: numeral/<lang>_cardinal|ordinal.
-- For uninflected function words: <role>/base (e.g., preposition/base).
+- For uninflected function words: <part_of_speech>/base (e.g., preposition/base).
 
 Important rules:
 - Maintain token order from the original sentence
@@ -195,10 +195,10 @@ Important rules:
         return bool(re.fullmatch(r"[^\w\s]+", surface_form.strip(), flags=re.UNICODE))
 
     def _is_low_content_token(self, word: Dict[str, Any]) -> bool:
-        role = str(word.get("role", "")).strip().lower()
+        part_of_speech = str(word.get("part_of_speech", "")).strip().lower()
         grammatical_form = str(word.get("grammatical_form", "")).strip().lower()
 
-        low_content_roles = {
+        low_content_parts_of_speech = {
             "particle",
             "determiner",
             "article",
@@ -209,10 +209,10 @@ Important rules:
             "case_marker",
             "clitic",
         }
-        if role in low_content_roles:
+        if part_of_speech in low_content_parts_of_speech:
             return True
 
-        if grammatical_form.endswith("/base") and role not in {
+        if grammatical_form.endswith("/base") and part_of_speech not in {
             "noun",
             "verb",
             "adjective",

--- a/src/benchmarks/scripts/generate_0062_data.py
+++ b/src/benchmarks/scripts/generate_0062_data.py
@@ -167,10 +167,10 @@ def get_sentences_with_full_sentenceword_data(
                 for sw in lang_words:
                     word_entry = {
                         "position": sw.position,
-                        "role": sw.word_role,
+                        "part_of_speech": sw.part_of_speech,
                         "english_gloss": simplify_gloss(sw.english_text or ""),
                         "surface_form": sw.declined_form or sw.target_language_text or "",
-                        "grammatical_form": sw.grammatical_form or f"{sw.word_role}/base",
+                        "grammatical_form": sw.grammatical_form or f"{sw.part_of_speech}/base",
                     }
 
                     # Add lemma info

--- a/src/sentences/analysis.py
+++ b/src/sentences/analysis.py
@@ -42,7 +42,7 @@ def find_candidate_lemmas_for_sentence(
 ) -> List[dict]:
     """Find lemmas that match words in a sentence across multiple languages.
 
-    For each word position/role in the sentence, searches derivative_forms
+    For each word/part-of-speech slot in the sentence, searches derivative_forms
     to find lemmas whose forms match the declined_form in the sentence.
     Returns lemmas that match in at least min_language_matches languages.
 
@@ -60,7 +60,7 @@ def find_candidate_lemmas_for_sentence(
             - lemma: Lemma object
             - english_text: The English word from sentence_words
             - matched_languages: List of language codes that matched
-            - word_role: The role of the word in the sentence
+            - part_of_speech: The word's part of speech
     """
     # Get all sentence words for this sentence
     sentence_words = (
@@ -78,7 +78,7 @@ def find_candidate_lemmas_for_sentence(
             if key not in word_slots:
                 word_slots[key] = {
                     "english_text": sw.english_text,
-                    "word_role": sw.word_role,
+                    "part_of_speech": sw.part_of_speech,
                     "forms_by_lang": {},
                     "has_lemma": False,
                 }
@@ -89,7 +89,7 @@ def find_candidate_lemmas_for_sentence(
                 word_slots[key]["has_lemma"] = True
 
     # Aggregate lemma matches across all slots
-    # lemma_id -> {"langs": set of lang codes, "english_texts": set, "word_roles": set}
+    # lemma_id -> language, English-text, and part-of-speech matches
     global_lemma_matches: dict = {}
 
     for slot_key, slot_data in word_slots.items():
@@ -140,11 +140,13 @@ def find_candidate_lemmas_for_sentence(
                     global_lemma_matches[df.lemma_id] = {
                         "langs": set(),
                         "english_texts": set(),
-                        "word_roles": set(),
+                        "parts_of_speech": set(),
                     }
                 global_lemma_matches[df.lemma_id]["langs"].add(lang_code)
                 global_lemma_matches[df.lemma_id]["english_texts"].add(slot_data["english_text"])
-                global_lemma_matches[df.lemma_id]["word_roles"].add(slot_data["word_role"])
+                global_lemma_matches[df.lemma_id]["parts_of_speech"].add(
+                    slot_data["part_of_speech"]
+                )
 
     # Filter to lemmas that match in at least min_language_matches languages
     qualifying_lemma_ids = [
@@ -170,7 +172,7 @@ def find_candidate_lemmas_for_sentence(
                     "lemma": lemma,
                     "english_text": ", ".join(sorted(match_data["english_texts"])),
                     "matched_languages": sorted(match_data["langs"]),
-                    "word_role": ", ".join(sorted(match_data["word_roles"])),
+                    "part_of_speech": ", ".join(sorted(match_data["parts_of_speech"])),
                 }
             )
 

--- a/src/sentences/decomposition.py
+++ b/src/sentences/decomposition.py
@@ -116,9 +116,9 @@ def build_prompt_for_translate_and_decompose(
         .all()
     )
 
-    # Collect lemma_id -> (english_text, role) from pattern words first
+    # Collect lemma_id -> (English text, part of speech) from pattern words first.
     seen_lemma_ids: set[int] = set()
-    lemma_entries: List[tuple[int, str, str]] = []  # (lemma_id, english_text, role)
+    lemma_entries: List[tuple[int, str, str]] = []
     for pattern_word in pattern_words:
         if pattern_word.lemma_id and pattern_word.lemma_id not in seen_lemma_ids:
             seen_lemma_ids.add(pattern_word.lemma_id)
@@ -143,10 +143,10 @@ def build_prompt_for_translate_and_decompose(
     for sw in sentence_words:
         if sw.lemma_id not in seen_lemma_ids:
             seen_lemma_ids.add(sw.lemma_id)
-            lemma_entries.append((sw.lemma_id, sw.english_text or "", sw.word_role or ""))
+            lemma_entries.append((sw.lemma_id, sw.english_text or "", sw.part_of_speech or ""))
 
     word_translation_lines: List[str] = []
-    for lemma_id, english_text, role in lemma_entries:
+    for lemma_id, english_text, part_of_speech in lemma_entries:
         lemma = session.query(Lemma).filter_by(id=lemma_id).first()
         if not lemma:
             continue
@@ -159,10 +159,12 @@ def build_prompt_for_translate_and_decompose(
             if trans:
                 trans_items.append(f"{lang}={trans}")
 
-        role_str = f" [{role}]" if role else ""
+        part_of_speech_str = f" [{part_of_speech}]" if part_of_speech else ""
         guid_str = f" (GUID: {guid})" if guid else ""
         trans_str = ", ".join(trans_items)
-        word_translation_lines.append(f"  {english_text}{role_str}{guid_str}: {trans_str}")
+        word_translation_lines.append(
+            f"  {english_text}{part_of_speech_str}{guid_str}: {trans_str}"
+        )
 
     candidate_lines: List[str] = []
     if candidate_lemmas:
@@ -355,7 +357,7 @@ def build_multi_language_decomposition_schema(*, target_languages: List[str]) ->
     For each ``lang`` in ``target_languages`` the response object must include a
     string field ``lang`` (echo of the provided translation) and an array field
     ``words_lang`` whose entries match the single-language Phase 3 word shape
-    (``position``, ``role``, ``english_gloss``, ``surface_form``,
+    (``position``, ``part_of_speech``, ``english_gloss``, ``surface_form``,
     ``grammatical_form``, ``lemma_guid``, ``lemma``).
     """
     target_languages = _normalize_target_languages(target_languages)
@@ -363,7 +365,10 @@ def build_multi_language_decomposition_schema(*, target_languages: List[str]) ->
         "type": "object",
         "properties": {
             "position": {"type": "integer"},
-            "role": {"type": "string"},
+            "part_of_speech": {
+                "type": "string",
+                "description": "Part of speech, never subject/object syntactic role",
+            },
             "english_gloss": {"type": "string"},
             "surface_form": {"type": "string"},
             "grammatical_form": {"type": "string"},
@@ -372,7 +377,7 @@ def build_multi_language_decomposition_schema(*, target_languages: List[str]) ->
         },
         "required": [
             "position",
-            "role",
+            "part_of_speech",
             "english_gloss",
             "surface_form",
             "grammatical_form",
@@ -414,10 +419,13 @@ def build_decomposition_schema(
             "word": {"type": "string"},
             "english": {"type": "string"},
             "guid": {"type": "string"},
-            "role": {"type": "string"},
+            "part_of_speech": {
+                "type": "string",
+                "description": "Part of speech, never subject/object syntactic role",
+            },
             "grammatical_form": {"type": ["string", "null"]},
         },
-        "required": ["word", "english", "guid", "role", "grammatical_form"],
+        "required": ["word", "english", "guid", "part_of_speech", "grammatical_form"],
         "additionalProperties": False,
     }
 
@@ -474,7 +482,10 @@ def build_single_language_decomposition_schema() -> Dict[str, Any]:
                                 "type": "object",
                                 "properties": {
                                     "position": {"type": "integer"},
-                                    "role": {"type": "string"},
+                                    "part_of_speech": {
+                                        "type": "string",
+                                        "description": "Part of speech, never subject/object syntactic role",
+                                    },
                                     "english_gloss": {"type": "string"},
                                     "surface_form": {"type": "string"},
                                     "grammatical_form": {"type": "string"},
@@ -483,7 +494,7 @@ def build_single_language_decomposition_schema() -> Dict[str, Any]:
                                 },
                                 "required": [
                                     "position",
-                                    "role",
+                                    "part_of_speech",
                                     "english_gloss",
                                     "surface_form",
                                     "grammatical_form",

--- a/src/sentences/translation.py
+++ b/src/sentences/translation.py
@@ -285,7 +285,7 @@ def _adapt_decomposed_word(word_entry: Dict[str, Any]) -> Dict[str, Any]:
         "word": str(word_entry.get("surface_form") or "").strip(),
         "english": str(word_entry.get("english_gloss") or "").strip(),
         "guid": str(word_entry.get("lemma_guid") or "").strip(),
-        "role": str(word_entry.get("role") or "").strip(),
+        "part_of_speech": str(word_entry.get("part_of_speech") or "").strip(),
         "grammatical_form": grammatical_form,
     }
 
@@ -386,7 +386,7 @@ def store_translation_results(
                 lemma_id=lemma_id,
                 language_code=lang_code,
                 position=position,
-                word_role=word_data.get("role"),
+                part_of_speech=word_data.get("part_of_speech"),
                 english_text=word_data.get("english"),
                 target_language_text=word_data.get("word"),
                 grammatical_form=word_data.get("grammatical_form"),

--- a/src/storage/backend/jsonl/session.py
+++ b/src/storage/backend/jsonl/session.py
@@ -453,7 +453,9 @@ class JSONLSession(BaseSession):
                         "lemma_id": lemma_id,
                         "language_code": word_data.get("language_code", ""),
                         "position": word_data.get("position", 0),
-                        "word_role": word_data.get("word_role"),
+                        # SQLAlchemy bulk mappings use the Python attribute
+                        # name; the JSONL/release key remains word_role.
+                        "part_of_speech": word_data.get("word_role"),
                         "english_text": word_data.get("english_text"),
                         "target_language_text": word_data.get("target_language_text"),
                         "grammatical_form": word_data.get("grammatical_form"),

--- a/src/storage/crud/sentence_word.py
+++ b/src/storage/crud/sentence_word.py
@@ -11,14 +11,15 @@ def add_sentence_word(
     session: Session,
     sentence: Sentence,
     position: int,
-    word_role: str,
-    language_code: str,
+    part_of_speech: Optional[str] = None,
+    language_code: str = "",
     lemma: Optional[Lemma] = None,
     english_text: Optional[str] = None,
     target_language_text: Optional[str] = None,
     grammatical_form: Optional[str] = None,
     grammatical_case: Optional[str] = None,
     declined_form: Optional[str] = None,
+    word_role: Optional[str] = None,
 ) -> SentenceWord:
     """Add a word usage record to a sentence.
 
@@ -26,7 +27,7 @@ def add_sentence_word(
         session: Database session
         sentence: Sentence object
         position: Position in the sentence (0-indexed)
-        word_role: Semantic role (e.g., "subject", "verb", "object", "pronoun")
+        part_of_speech: Part of speech (e.g., "noun", "verb", "pronoun")
         language_code: Language code (e.g., 'lt', 'fr', 'zh')
         lemma: Optional Lemma object this word refers to
         english_text: English form of the word
@@ -34,15 +35,22 @@ def add_sentence_word(
         grammatical_form: Grammatical form (e.g., "1s_past", "gerund")
         grammatical_case: Grammatical case (e.g., "accusative", "nominative")
         declined_form: Actual declined/conjugated form used in sentence
+        word_role: Deprecated alias for ``part_of_speech``
 
     Returns:
         Created SentenceWord object
     """
+    if part_of_speech and word_role and part_of_speech != word_role:
+        raise ValueError("part_of_speech and word_role must match when both are provided")
+    resolved_part_of_speech = part_of_speech or word_role
+    if not resolved_part_of_speech:
+        raise ValueError("part_of_speech is required")
+
     sentence_word = SentenceWord(
         sentence_id=sentence.id,
         lemma_id=lemma.id if lemma else None,
         position=position,
-        word_role=word_role,
+        part_of_speech=resolved_part_of_speech,
         language_code=language_code,
         english_text=english_text,
         target_language_text=target_language_text,
@@ -100,32 +108,37 @@ def get_lemmas_for_sentence(session: Session, sentence_id: int) -> List[Lemma]:
 def update_sentence_word(
     session: Session,
     sentence_word: SentenceWord,
-    word_role: Optional[str] = None,
+    part_of_speech: Optional[str] = None,
     lemma: Optional[Lemma] = None,
     english_text: Optional[str] = None,
     target_language_text: Optional[str] = None,
     grammatical_form: Optional[str] = None,
     grammatical_case: Optional[str] = None,
     declined_form: Optional[str] = None,
+    word_role: Optional[str] = None,
 ) -> SentenceWord:
     """Update a sentence word record.
 
     Args:
         session: Database session
         sentence_word: SentenceWord object to update
-        word_role: New word role (optional)
+        part_of_speech: New part of speech (optional)
         lemma: New lemma association (optional)
         english_text: New English text (optional)
         target_language_text: New target language text (optional)
         grammatical_form: New grammatical form (optional)
         grammatical_case: New grammatical case (optional)
         declined_form: New declined form (optional)
+        word_role: Deprecated alias for ``part_of_speech``
 
     Returns:
         Updated SentenceWord object
     """
-    if word_role is not None:
-        sentence_word.word_role = word_role
+    if part_of_speech and word_role and part_of_speech != word_role:
+        raise ValueError("part_of_speech and word_role must match when both are provided")
+    resolved_part_of_speech = part_of_speech or word_role
+    if resolved_part_of_speech is not None:
+        sentence_word.part_of_speech = resolved_part_of_speech
     if lemma is not None:
         sentence_word.lemma_id = lemma.id
     if english_text is not None:

--- a/src/storage/models/schema.py
+++ b/src/storage/models/schema.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     literal_column,
 )
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, synonym
 
 from storage.models.pgvector import PGVector
 from storage.rhyme_keys import sync_derivative_form_rhyme_key
@@ -495,10 +495,10 @@ class SentenceWord(Base):
     # Position in the sentence (0-indexed, matches order in target language sentence)
     position: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    # Word role in the sentence (semantic, not grammatical)
-    word_role: Mapped[str] = mapped_column(
-        String, nullable=False
-    )  # e.g., "subject", "verb", "object", "pronoun", "adjective"
+    # Keep the existing database column name while exposing an accurate Python
+    # attribute. The synonym preserves compatibility for storage/release code.
+    part_of_speech: Mapped[str] = mapped_column("word_role", String, nullable=False)
+    word_role = synonym("part_of_speech")
 
     # Reference text in both languages (from words_used JSON)
     english_text: Mapped[Optional[str]] = mapped_column(String, nullable=True)

--- a/src/tests/benchmarks/fixtures/sentence_decomposition/anchor_priority_case.json
+++ b/src/tests/benchmarks/fixtures/sentence_decomposition/anchor_priority_case.json
@@ -7,11 +7,11 @@
           "translation": "Mano sūnus eina į mokyklą.",
           "word_count": 5,
           "words": [
-            {"position": 0, "role": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
-            {"position": 1, "role": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
-            {"position": 2, "role": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
-            {"position": 3, "role": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
-            {"position": 4, "role": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"}
+            {"position": 0, "part_of_speech": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
+            {"position": 1, "part_of_speech": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
+            {"position": 2, "part_of_speech": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
+            {"position": 3, "part_of_speech": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
+            {"position": 4, "part_of_speech": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"}
           ]
         }
       ]
@@ -24,11 +24,11 @@
         "translation": "Mano sūnus eina į mokyklą.",
         "word_count": 5,
         "words": [
-          {"position": 0, "role": "pronoun", "english_gloss": "mine", "surface_form": "Mano", "grammatical_form": "determiner/base", "lemma_guid": "NONE", "lemma": "mano"},
-          {"position": 1, "role": "noun", "english_gloss": "boy", "surface_form": "sūnus", "grammatical_form": "noun/lt_nom", "lemma_guid": "N35_036", "lemma": "sūnus"},
-          {"position": 2, "role": "predicate", "english_gloss": "walks", "surface_form": "eina", "grammatical_form": "verb/lt_present", "lemma_guid": "V12_004", "lemma": "eiti"},
-          {"position": 3, "role": "particle", "english_gloss": "toward", "surface_form": "į", "grammatical_form": "adposition/base", "lemma_guid": "NONE", "lemma": "į"},
-          {"position": 4, "role": "noun", "english_gloss": "academy", "surface_form": "mokyklą", "grammatical_form": "noun/lt_singular", "lemma_guid": "N07_002", "lemma": "mokykla"}
+          {"position": 0, "part_of_speech": "pronoun", "english_gloss": "mine", "surface_form": "Mano", "grammatical_form": "determiner/base", "lemma_guid": "NONE", "lemma": "mano"},
+          {"position": 1, "part_of_speech": "noun", "english_gloss": "boy", "surface_form": "sūnus", "grammatical_form": "noun/lt_nom", "lemma_guid": "N35_036", "lemma": "sūnus"},
+          {"position": 2, "part_of_speech": "predicate", "english_gloss": "walks", "surface_form": "eina", "grammatical_form": "verb/lt_present", "lemma_guid": "V12_004", "lemma": "eiti"},
+          {"position": 3, "part_of_speech": "particle", "english_gloss": "toward", "surface_form": "į", "grammatical_form": "adposition/base", "lemma_guid": "NONE", "lemma": "į"},
+          {"position": 4, "part_of_speech": "noun", "english_gloss": "academy", "surface_form": "mokyklą", "grammatical_form": "noun/lt_singular", "lemma_guid": "N07_002", "lemma": "mokykla"}
         ]
       }
     ]

--- a/src/tests/benchmarks/fixtures/sentence_decomposition/language_mismatch_case.json
+++ b/src/tests/benchmarks/fixtures/sentence_decomposition/language_mismatch_case.json
@@ -7,7 +7,7 @@
           "translation": "Mano sūnus eina į mokyklą.",
           "word_count": 1,
           "words": [
-            {"position": 0, "role": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"}
+            {"position": 0, "part_of_speech": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"}
           ]
         }
       ]
@@ -20,7 +20,7 @@
         "translation": "Mi hijo va a la escuela.",
         "word_count": 1,
         "words": [
-          {"position": 0, "role": "subject", "english_gloss": "son", "surface_form": "hijo", "grammatical_form": "noun/es_singular", "lemma_guid": "N35_036", "lemma": "hijo"}
+          {"position": 0, "part_of_speech": "subject", "english_gloss": "son", "surface_form": "hijo", "grammatical_form": "noun/es_singular", "lemma_guid": "N35_036", "lemma": "hijo"}
         ]
       }
     ]

--- a/src/tests/benchmarks/fixtures/sentence_decomposition/punctuation_penalty_case.json
+++ b/src/tests/benchmarks/fixtures/sentence_decomposition/punctuation_penalty_case.json
@@ -7,11 +7,11 @@
           "translation": "Mano sūnus eina į mokyklą.",
           "word_count": 5,
           "words": [
-            {"position": 0, "role": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
-            {"position": 1, "role": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
-            {"position": 2, "role": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
-            {"position": 3, "role": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
-            {"position": 4, "role": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"}
+            {"position": 0, "part_of_speech": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
+            {"position": 1, "part_of_speech": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
+            {"position": 2, "part_of_speech": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
+            {"position": 3, "part_of_speech": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
+            {"position": 4, "part_of_speech": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"}
           ]
         }
       ]
@@ -24,12 +24,12 @@
         "translation": "Mano sūnus eina į mokyklą.",
         "word_count": 6,
         "words": [
-          {"position": 0, "role": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
-          {"position": 1, "role": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
-          {"position": 2, "role": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
-          {"position": 3, "role": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
-          {"position": 4, "role": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"},
-          {"position": 5, "role": "punctuation", "english_gloss": ".", "surface_form": ".", "grammatical_form": "punctuation/base", "lemma_guid": "NONE", "lemma": "."}
+          {"position": 0, "part_of_speech": "determiner", "english_gloss": "my", "surface_form": "Mano", "grammatical_form": "pronoun/lt_possessive", "lemma_guid": "NONE", "lemma": "No lemma"},
+          {"position": 1, "part_of_speech": "subject", "english_gloss": "son", "surface_form": "sūnus", "grammatical_form": "noun/lt_nominative_singular", "lemma_guid": "N35_036", "lemma": "son"},
+          {"position": 2, "part_of_speech": "verb", "english_gloss": "goes", "surface_form": "eina", "grammatical_form": "verb/lt_3s_present", "lemma_guid": "V12_004", "lemma": "go"},
+          {"position": 3, "part_of_speech": "preposition", "english_gloss": "to", "surface_form": "į", "grammatical_form": "preposition/base", "lemma_guid": "NONE", "lemma": "No lemma"},
+          {"position": 4, "part_of_speech": "object", "english_gloss": "school", "surface_form": "mokyklą", "grammatical_form": "noun/lt_accusative_singular", "lemma_guid": "N07_002", "lemma": "school (institution)"},
+          {"position": 5, "part_of_speech": "punctuation", "english_gloss": ".", "surface_form": ".", "grammatical_form": "punctuation/base", "lemma_guid": "NONE", "lemma": "."}
         ]
       }
     ]

--- a/src/tests/benchmarks/test_sentence_decomposition_scoring.py
+++ b/src/tests/benchmarks/test_sentence_decomposition_scoring.py
@@ -26,7 +26,6 @@ import benchmarks.lib.utils  # noqa: F401  (import order matters; see above)
 
 from benchmarks.lib.runners.sentence_decomposition_runner import SentenceDecompositionRunner
 
-
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "sentence_decomposition"
 
 
@@ -51,7 +50,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "No lemma",
                         "lemma_guid": "NONE",
                         "position": 0,
-                        "role": "determiner",
+                        "part_of_speech": "determiner",
                         "surface_form": "Mano",
                     },
                     {
@@ -60,7 +59,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "son",
                         "lemma_guid": "N35_036",
                         "position": 1,
-                        "role": "subject",
+                        "part_of_speech": "subject",
                         "surface_form": "sūnus",
                     },
                     {
@@ -69,7 +68,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "go",
                         "lemma_guid": "V12_004",
                         "position": 2,
-                        "role": "verb",
+                        "part_of_speech": "verb",
                         "surface_form": "eina",
                     },
                     {
@@ -78,7 +77,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "No lemma",
                         "lemma_guid": "NONE",
                         "position": 3,
-                        "role": "preposition",
+                        "part_of_speech": "preposition",
                         "surface_form": "į",
                     },
                     {
@@ -87,7 +86,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "school (institution)",
                         "lemma_guid": "N07_002",
                         "position": 4,
-                        "role": "object",
+                        "part_of_speech": "object",
                         "surface_form": "mokyklą",
                     },
                 ],
@@ -108,7 +107,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "mano",
                         "lemma_guid": "NONE",
                         "position": 0,
-                        "role": "determiner",
+                        "part_of_speech": "determiner",
                         "surface_form": "Mano",
                     },
                     {
@@ -117,7 +116,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "sūnus",
                         "lemma_guid": "N35_036",
                         "position": 1,
-                        "role": "noun",
+                        "part_of_speech": "noun",
                         "surface_form": "sūnus",
                     },
                     {
@@ -126,7 +125,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "eiti",
                         "lemma_guid": "V12_004",
                         "position": 2,
-                        "role": "verb",
+                        "part_of_speech": "verb",
                         "surface_form": "eina",
                     },
                     {
@@ -135,7 +134,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "į",
                         "lemma_guid": "NONE",
                         "position": 3,
-                        "role": "preposition",
+                        "part_of_speech": "preposition",
                         "surface_form": "į",
                     },
                     {
@@ -144,7 +143,7 @@ def test_0062_allows_close_morphology_and_gloss_variants_for_partial_credit():
                         "lemma": "mokykla",
                         "lemma_guid": "N07_002",
                         "position": 4,
-                        "role": "noun",
+                        "part_of_speech": "noun",
                         "surface_form": "mokyklą",
                     },
                 ],
@@ -221,7 +220,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "No lemma",
                         "lemma_guid": "NONE",
                         "position": 0,
-                        "role": "pronoun",
+                        "part_of_speech": "pronoun",
                         "surface_form": "她",
                     },
                     {
@@ -230,7 +229,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "yesterday",
                         "lemma_guid": "D03_002",
                         "position": 1,
-                        "role": "adverb",
+                        "part_of_speech": "adverb",
                         "surface_form": "昨天",
                     },
                     {
@@ -239,7 +238,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "go",
                         "lemma_guid": "V12_004",
                         "position": 2,
-                        "role": "verb",
+                        "part_of_speech": "verb",
                         "surface_form": "去了",
                     },
                     {
@@ -248,7 +247,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "hospital",
                         "lemma_guid": "N07_003",
                         "position": 3,
-                        "role": "noun",
+                        "part_of_speech": "noun",
                         "surface_form": "医院",
                     },
                 ],
@@ -269,7 +268,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "她",
                         "lemma_guid": "NONE",
                         "position": 0,
-                        "role": "pronoun",
+                        "part_of_speech": "pronoun",
                         "surface_form": "她",
                     },
                     {
@@ -278,7 +277,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "昨天",
                         "lemma_guid": "D03_002",
                         "position": 1,
-                        "role": "adverb",
+                        "part_of_speech": "adverb",
                         "surface_form": "昨天",
                     },
                     {
@@ -287,7 +286,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "去",
                         "lemma_guid": "V12_004",
                         "position": 2,
-                        "role": "verb",
+                        "part_of_speech": "verb",
                         "surface_form": "去",
                     },
                     {
@@ -296,7 +295,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "了",
                         "lemma_guid": "NONE",
                         "position": 3,
-                        "role": "particle",
+                        "part_of_speech": "particle",
                         "surface_form": "了",
                     },
                     {
@@ -305,7 +304,7 @@ def test_0062_split_tokens_do_not_cascade_mismatch_scores():
                         "lemma": "医院",
                         "lemma_guid": "N07_003",
                         "position": 4,
-                        "role": "noun",
+                        "part_of_speech": "noun",
                         "surface_form": "医院",
                     },
                 ],

--- a/src/tests/sentences/test_analysis.py
+++ b/src/tests/sentences/test_analysis.py
@@ -169,7 +169,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="en",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="eats",
                 ),
@@ -177,7 +177,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="en",
                     position=1,
-                    word_role="object",
+                    part_of_speech="noun",
                     english_text="apple",
                     declined_form="apple",
                 ),
@@ -186,7 +186,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="fr",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="mange",
                 ),
@@ -194,7 +194,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="fr",
                     position=1,
-                    word_role="object",
+                    part_of_speech="noun",
                     english_text="apple",
                     declined_form="pomme",
                 ),
@@ -203,7 +203,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="zh",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="吃",
                 ),
@@ -211,7 +211,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="zh",
                     position=1,
-                    word_role="object",
+                    part_of_speech="noun",
                     english_text="apple",
                     declined_form="苹果",
                 ),
@@ -259,19 +259,19 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
             self.assertEqual(len(candidate["matched_languages"]), 3)
             self.assertEqual(set(candidate["matched_languages"]), {"en", "fr", "zh"})
 
-    def test_returns_english_text_and_word_role(self):
-        """Test that english_text and word_role are correctly returned."""
+    def test_returns_english_text_and_part_of_speech(self):
+        """Test that english_text and part_of_speech are correctly returned."""
         candidates = find_candidate_lemmas_for_sentence(
             self.session, self.sentence.id, min_language_matches=2
         )
 
         eat_candidate = next(c for c in candidates if c["lemma"].lemma_text == "eat")
         self.assertEqual(eat_candidate["english_text"], "eat")
-        self.assertEqual(eat_candidate["word_role"], "verb")
+        self.assertEqual(eat_candidate["part_of_speech"], "verb")
 
         apple_candidate = next(c for c in candidates if c["lemma"].lemma_text == "apple")
         self.assertEqual(apple_candidate["english_text"], "apple")
-        self.assertEqual(apple_candidate["word_role"], "object")
+        self.assertEqual(apple_candidate["part_of_speech"], "noun")
 
     def test_case_insensitive_matching(self):
         """Test that matching is case-insensitive for non-CJK languages."""
@@ -286,7 +286,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="en",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="EATS",  # Uppercase
                 ),
@@ -294,7 +294,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="fr",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="Mange",  # Mixed case
                 ),
@@ -323,7 +323,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="en",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="eats",
                     lemma_id=self.lemma_eat.id,
@@ -332,7 +332,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="fr",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="mange",
                     lemma_id=self.lemma_eat.id,
@@ -342,7 +342,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="en",
                     position=1,
-                    word_role="object",
+                    part_of_speech="noun",
                     english_text="apple",
                     declined_form="apple",
                 ),
@@ -350,7 +350,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="fr",
                     position=1,
-                    word_role="object",
+                    part_of_speech="noun",
                     english_text="apple",
                     declined_form="pomme",
                 ),
@@ -390,7 +390,7 @@ class TestFindCandidateLemmasForSentence(unittest.TestCase):
                     sentence_id=sentence2.id,
                     language_code="en",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="nonexistent",
                     declined_form="nonexistent_form",
                 ),
@@ -446,13 +446,13 @@ class TestStoreDiscoveredLemmas(unittest.TestCase):
                 "lemma": self.lemma_eat,
                 "english_text": "eat",
                 "matched_languages": ["en", "fr"],
-                "word_role": "verb",
+                "part_of_speech": "verb",
             },
             {
                 "lemma": self.lemma_apple,
                 "english_text": "apple",
                 "matched_languages": ["en", "fr"],
-                "word_role": "object",
+                "part_of_speech": "noun",
             },
         ]
 
@@ -497,13 +497,13 @@ class TestStoreDiscoveredLemmas(unittest.TestCase):
                 "lemma": self.lemma_eat,  # Already exists
                 "english_text": "eat",
                 "matched_languages": ["en", "fr"],
-                "word_role": "verb",
+                "part_of_speech": "verb",
             },
             {
                 "lemma": self.lemma_apple,  # New
                 "english_text": "apple",
                 "matched_languages": ["en", "fr"],
-                "word_role": "object",
+                "part_of_speech": "noun",
             },
         ]
 
@@ -560,7 +560,7 @@ class TestStoreDiscoveredLemmas(unittest.TestCase):
                 "lemma": new_lemma,
                 "english_text": "new",
                 "matched_languages": ["en"],
-                "word_role": "object",
+                "part_of_speech": "noun",
             },
         ]
 
@@ -574,6 +574,8 @@ class TestStoreDiscoveredLemmas(unittest.TestCase):
             .filter(SentencePatternWord.lemma_id == new_lemma.id)
             .first()
         )
+        self.assertIsNotNone(new_pw)
+        assert new_pw is not None
         self.assertEqual(new_pw.position, 3)
 
 
@@ -625,7 +627,7 @@ class TestDiscoverAndStoreLemmas(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="en",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="eats",
                 ),
@@ -633,7 +635,7 @@ class TestDiscoverAndStoreLemmas(unittest.TestCase):
                     sentence_id=self.sentence.id,
                     language_code="fr",
                     position=0,
-                    word_role="verb",
+                    part_of_speech="verb",
                     english_text="eat",
                     declined_form="mange",
                 ),
@@ -720,7 +722,7 @@ class TestSubstringMatchingChinese(unittest.TestCase):
                 sentence_id=self.sentence.id,
                 language_code="zh",
                 position=0,
-                word_role="verb",
+                part_of_speech="verb",
                 english_text="eat",
                 declined_form="吃",  # Substring of derivative form "吃饭"
             )

--- a/src/tests/sentences/test_decomposition.py
+++ b/src/tests/sentences/test_decomposition.py
@@ -111,7 +111,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
     words = [
         {
             "position": 0,
-            "role": "pronoun",
+            "part_of_speech": "pronoun",
             "english_gloss": "they",
             "surface_form": "Ellos",
             "grammatical_form": "pronoun/es_subjective",
@@ -120,7 +120,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
         },
         {
             "position": 1,
-            "role": "verb",
+            "part_of_speech": "verb",
             "english_gloss": "bought",
             "surface_form": "compraron",
             "grammatical_form": "verb/es_3p_past",
@@ -129,7 +129,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
         },
         {
             "position": 2,
-            "role": "noun",
+            "part_of_speech": "noun",
             "english_gloss": "salt",
             "surface_form": "sal",
             "grammatical_form": "noun/es_singular",
@@ -138,7 +138,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
         },
         {
             "position": 3,
-            "role": "preposition",
+            "part_of_speech": "preposition",
             "english_gloss": "in",
             "surface_form": "en",
             "grammatical_form": "preposition/es_base",
@@ -147,7 +147,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
         },
         {
             "position": 4,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "the",
             "surface_form": "la",
             "grammatical_form": "article/es_singular_f",
@@ -156,7 +156,7 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
         },
         {
             "position": 5,
-            "role": "noun",
+            "part_of_speech": "noun",
             "english_gloss": "store",
             "surface_form": "tienda",
             "grammatical_form": "noun/es_singular",
@@ -173,7 +173,7 @@ def test_find_unresolved_non_grammatical_words_flags_missing_lemma_content_words
     words = [
         {
             "position": 0,
-            "role": "noun",
+            "part_of_speech": "noun",
             "english_gloss": "store",
             "surface_form": "tienda",
             "grammatical_form": "noun/es_singular",
@@ -182,7 +182,7 @@ def test_find_unresolved_non_grammatical_words_flags_missing_lemma_content_words
         },
         {
             "position": 1,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "the",
             "surface_form": "la",
             "grammatical_form": "article/es_singular_f",
@@ -202,7 +202,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
     words = [
         {
             "position": 0,
-            "role": "verb",
+            "part_of_speech": "verb",
             "english_gloss": "saw",
             "surface_form": "Vimos",
             "grammatical_form": "verb/es_past",
@@ -211,7 +211,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
         },
         {
             "position": 1,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "a",
             "surface_form": "un",
             "grammatical_form": "article/base",
@@ -220,7 +220,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
         },
         {
             "position": 2,
-            "role": "object",
+            "part_of_speech": "object",
             "english_gloss": "pig",
             "surface_form": "cerdo",
             "grammatical_form": "noun/es_singular",
@@ -229,7 +229,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
         },
         {
             "position": 3,
-            "role": "preposition",
+            "part_of_speech": "preposition",
             "english_gloss": "at",
             "surface_form": "en",
             "grammatical_form": "preposition/base",
@@ -238,7 +238,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
         },
         {
             "position": 4,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "the",
             "surface_form": "la",
             "grammatical_form": "article/base",
@@ -247,7 +247,7 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
         },
         {
             "position": 5,
-            "role": "object_of_preposition",
+            "part_of_speech": "object_of_preposition",
             "english_gloss": "fair",
             "surface_form": "feria",
             "grammatical_form": "noun/es_singular",
@@ -267,7 +267,7 @@ def test_find_unresolved_non_grammatical_words_unknown_language_has_no_grammar_f
     words = [
         {
             "position": 0,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "the",
             "surface_form": "the",
             "grammatical_form": "article/en_singular",
@@ -286,7 +286,7 @@ def test_find_unresolved_non_grammatical_words_keeps_skip_for_known_grammatical_
     words = [
         {
             "position": 0,
-            "role": "article",
+            "part_of_speech": "article",
             "english_gloss": "the",
             "surface_form": "le",
             "grammatical_form": "noun/fr_singular",

--- a/src/tests/sentences/test_translate_and_decompose.py
+++ b/src/tests/sentences/test_translate_and_decompose.py
@@ -111,7 +111,7 @@ def test_pipeline_translates_and_decomposes_english_by_default(
         "words_en": [
             {
                 "position": 0,
-                "role": "pronoun",
+                "part_of_speech": "pronoun",
                 "english_gloss": "I",
                 "surface_form": "I",
                 "grammatical_form": "subject",
@@ -120,7 +120,7 @@ def test_pipeline_translates_and_decomposes_english_by_default(
             },
             {
                 "position": 1,
-                "role": "verb",
+                "part_of_speech": "verb",
                 "english_gloss": "read",
                 "surface_form": "read",
                 "grammatical_form": "present",

--- a/src/tests/storage/test_release_roundtrip.py
+++ b/src/tests/storage/test_release_roundtrip.py
@@ -171,7 +171,7 @@ def _build_source_db(sqlite_path: str) -> None:
                 lemma_id=None,
                 language_code="en",
                 position=1,
-                word_role="object",
+                word_role="noun",
                 english_text="printer",
                 target_language_text="printer",
                 grammatical_form="noun/en_singular",

--- a/src/tests/wordfreq/test_sentence_word_linker.py
+++ b/src/tests/wordfreq/test_sentence_word_linker.py
@@ -21,7 +21,7 @@ from storage.models.schema import (
     SentenceWord,
 )
 from wordfreq.tools.sentence_word_linker import (
-    ROLE_TO_POS,
+    PART_OF_SPEECH_TO_POS,
     find_lemma_by_text,
     resolve_lemma_for_word,
     resolve_lemmas_for_sentence,
@@ -81,29 +81,15 @@ class TestFindLemmaByText(unittest.TestCase):
         self.assertEqual(result.guid, "V01_001")
 
     def test_pos_filtering(self) -> None:
-        """'set' with role='verb' should return the verb lemma."""
+        """'set' with part of speech 'verb' should return the verb lemma."""
         result = find_lemma_by_text(self.session, "set", "verb")
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(result.guid, "V01_002")
 
     def test_pos_filtering_noun(self) -> None:
-        """'set' with role='noun' should return the noun lemma."""
+        """'set' with part of speech 'noun' should return the noun lemma."""
         result = find_lemma_by_text(self.session, "set", "noun")
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result.guid, "N01_002")
-
-    def test_subject_role_maps_to_noun(self) -> None:
-        """'set' with role='subject' should map to noun POS."""
-        result = find_lemma_by_text(self.session, "set", "subject")
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result.guid, "N01_002")
-
-    def test_object_role_maps_to_noun(self) -> None:
-        """'set' with role='object' should map to noun POS."""
-        result = find_lemma_by_text(self.session, "set", "object")
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(result.guid, "N01_002")
@@ -259,7 +245,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
     def test_guid_not_found_falls_through(self) -> None:
         """Missing GUID should fall through to text matching."""
         result = resolve_lemma_for_word(
-            self.session, guid="NONEXISTENT", english_text="teacher", word_role="noun"
+            self.session, guid="NONEXISTENT", english_text="teacher", part_of_speech="noun"
         )
         # Should still resolve via text
         self.assertIsNotNone(result.lemma)
@@ -278,7 +264,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
 
     def test_exact_text_single_match(self) -> None:
         """Unambiguous text should resolve with high confidence."""
-        result = resolve_lemma_for_word(self.session, english_text="teacher", word_role="noun")
+        result = resolve_lemma_for_word(self.session, english_text="teacher", part_of_speech="noun")
         self.assertEqual(result.method, "exact_text")
         self.assertEqual(result.confidence, 0.9)
         self.assertIsNotNone(result.lemma)
@@ -287,7 +273,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
 
     def test_polysemous_word_both_disambiguated(self) -> None:
         """'bank' with two disambiguated senses: should default to first."""
-        result = resolve_lemma_for_word(self.session, english_text="bank", word_role="noun")
+        result = resolve_lemma_for_word(self.session, english_text="bank", part_of_speech="noun")
         # Both candidates have disambiguation, so falls through to fallback
         self.assertIsNotNone(result.lemma)
         self.assertEqual(len(result.candidates), 2)
@@ -306,7 +292,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
         self.session.add(lemma_bank_plain)
         self.session.commit()
 
-        result = resolve_lemma_for_word(self.session, english_text="bank", word_role="noun")
+        result = resolve_lemma_for_word(self.session, english_text="bank", part_of_speech="noun")
         self.assertIsNotNone(result.lemma)
         assert result.lemma is not None
         self.assertEqual(result.lemma.guid, "N07_003")
@@ -342,7 +328,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
 
     def test_unresolved_returns_none_lemma(self) -> None:
         result = resolve_lemma_for_word(
-            self.session, english_text="xyzzy_nonexistent", word_role="noun"
+            self.session, english_text="xyzzy_nonexistent", part_of_speech="noun"
         )
         self.assertEqual(result.method, "unresolved")
         self.assertIsNone(result.lemma)
@@ -359,7 +345,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
         self.session.add(article_lemma)
         self.session.commit()
 
-        result = resolve_lemma_for_word(self.session, english_text="the", word_role="noun")
+        result = resolve_lemma_for_word(self.session, english_text="the", part_of_speech="noun")
         self.assertEqual(result.method, "grammatical_word")
         self.assertIsNone(result.lemma)
         self.assertEqual(result.confidence, 1.0)
@@ -446,7 +432,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
             self.session,
             guid="N36_014",
             english_text="see",
-            word_role="verb",
+            part_of_speech="verb",
         )
         self.assertEqual(result.method, "guid")
         assert result.lemma is not None
@@ -476,7 +462,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
         result = resolve_lemma_for_word(
             self.session,
             english_text="bank",
-            word_role="noun",
+            part_of_speech="noun",
             forms_by_language={"lt": "bankas", "fr": "banque"},
             min_derivative_languages=2,
         )
@@ -536,7 +522,7 @@ class TestResolveLemmaForWord(unittest.TestCase):
         result = resolve_lemma_for_word(
             self.session,
             english_text="bank",
-            word_role="noun",
+            part_of_speech="noun",
             forms_by_language={"lt": "bankas", "fr": "banque"},
             min_derivative_languages=2,
         )
@@ -722,7 +708,7 @@ class TestResolveLemmasForSentenceFromWords(unittest.TestCase):
                 lemma_id=self.lemma_teacher.id,
                 language_code="en",
                 position=0,
-                word_role="noun",
+                part_of_speech="noun",
                 english_text="teacher",
                 declined_form="teacher",
             )
@@ -733,7 +719,7 @@ class TestResolveLemmasForSentenceFromWords(unittest.TestCase):
                 sentence_id=self.sentence.id,
                 language_code="en",
                 position=1,
-                word_role="verb",
+                part_of_speech="verb",
                 english_text="spoke",
                 declined_form="spoke",
             )
@@ -766,7 +752,7 @@ class TestResolveLemmasForSentenceFromWords(unittest.TestCase):
                 sentence_id=self.sentence.id,
                 language_code="fr",
                 position=0,
-                word_role="noun",
+                part_of_speech="noun",
                 english_text="teacher",
                 declined_form="professeur",
             )
@@ -779,26 +765,20 @@ class TestResolveLemmasForSentenceFromWords(unittest.TestCase):
         self.assertEqual(len(results), 2)
 
 
-class TestRoleToPosMapping(unittest.TestCase):
-    """Test the ROLE_TO_POS constant for completeness."""
-
-    def test_subject_maps_to_noun(self) -> None:
-        self.assertEqual(ROLE_TO_POS["subject"], "noun")
-
-    def test_object_maps_to_noun(self) -> None:
-        self.assertEqual(ROLE_TO_POS["object"], "noun")
+class TestWordRoleToPosMapping(unittest.TestCase):
+    """Test the PART_OF_SPEECH_TO_POS constant for completeness."""
 
     def test_verb_maps_to_verb(self) -> None:
-        self.assertEqual(ROLE_TO_POS["verb"], "verb")
+        self.assertEqual(PART_OF_SPEECH_TO_POS["verb"], "verb")
 
     def test_adjective_maps_to_adjective(self) -> None:
-        self.assertEqual(ROLE_TO_POS["adjective"], "adjective")
+        self.assertEqual(PART_OF_SPEECH_TO_POS["adjective"], "adjective")
 
     def test_adverb_maps_to_adverb(self) -> None:
-        self.assertEqual(ROLE_TO_POS["adverb"], "adverb")
+        self.assertEqual(PART_OF_SPEECH_TO_POS["adverb"], "adverb")
 
     def test_other_has_no_pos_filter(self) -> None:
-        self.assertEqual(ROLE_TO_POS["other"], "")
+        self.assertEqual(PART_OF_SPEECH_TO_POS["other"], "")
 
 
 if __name__ == "__main__":

--- a/src/verbalator/actions/decomposition.py
+++ b/src/verbalator/actions/decomposition.py
@@ -91,7 +91,7 @@ class DecompositionAction(ActionBase):
                     guid = lemma.guid or ""
                     english = lemma.english_word or ""
                     disambiguation = lemma.disambiguation or ""
-                    pos = lemma.word_role or ""
+                    pos = lemma.part_of_speech or ""
 
                     # Get translation in target language
                     trans = get_translation(session, lemma, target_language)
@@ -131,7 +131,7 @@ class DecompositionAction(ActionBase):
                                     "type": "object",
                                     "properties": {
                                         "position": {"type": "integer"},
-                                        "role": {"type": "string"},
+                                        "part_of_speech": {"type": "string"},
                                         "english_gloss": {"type": "string"},
                                         "surface_form": {"type": "string"},
                                         "grammatical_form": {"type": "string"},
@@ -140,7 +140,7 @@ class DecompositionAction(ActionBase):
                                     },
                                     "required": [
                                         "position",
-                                        "role",
+                                        "part_of_speech",
                                         "english_gloss",
                                         "surface_form",
                                         "grammatical_form",

--- a/src/wordfreq/tools/sentence_word_linker.py
+++ b/src/wordfreq/tools/sentence_word_linker.py
@@ -38,11 +38,9 @@ logger = logging.getLogger(__name__)
 # Languages where substring matching is appropriate (logographic scripts)
 SUBSTRING_MATCH_LANGUAGES = {"zh", "ja", "ko"}
 
-# Map word roles to POS types
-ROLE_TO_POS: Dict[str, str] = {
-    "subject": "noun",
+# Normalize supported SentenceWord.part_of_speech values to lemma POS values.
+PART_OF_SPEECH_TO_POS: Dict[str, str] = {
     "noun": "noun",
-    "object": "noun",
     "verb": "verb",
     "adjective": "adjective",
     "adverb": "adverb",
@@ -67,11 +65,11 @@ class ResolvedLemma:
 def find_lemma_by_text(
     session: Session,
     word_text: str,
-    word_role: str,
+    part_of_speech: str,
     *,
     source_lemma: Optional[Lemma] = None,
 ) -> Optional[Lemma]:
-    """Find a lemma matching English text and role.
+    """Find a lemma matching English text and part of speech.
 
     This consolidates the duplicated _find_lemma_for_word() from
     guided_sentences.py and llm_sentences.py.
@@ -79,7 +77,8 @@ def find_lemma_by_text(
     Args:
         session: Database session
         word_text: English lemma text to match (e.g., "teacher", "see")
-        word_role: Word role (e.g., "noun", "verb", "subject", "object")
+        part_of_speech: Part of speech (e.g., "noun", "verb"); this parameter keeps
+            the historical database-field name
         source_lemma: Prefer this lemma if text matches (used when generating
             sentences for a specific lemma)
 
@@ -111,7 +110,7 @@ def find_lemma_by_text(
             )
             return source_lemma
 
-    pos_hint = ROLE_TO_POS.get(word_role)
+    pos_hint = PART_OF_SPEECH_TO_POS.get(part_of_speech)
 
     # Try exact match
     query = session.query(Lemma).filter(Lemma.lemma_text == word_text)
@@ -131,7 +130,7 @@ def find_lemma_by_text(
         logger.debug("Found lemma (case-insensitive) for '%s': %s", word_text, lemma.guid)
         return lemma
 
-    logger.debug("No lemma found for '%s' (role: %s)", word_text, word_role)
+    logger.debug("No lemma found for '%s' (part of speech: %s)", word_text, part_of_speech)
     return None
 
 
@@ -141,7 +140,7 @@ def resolve_lemma_for_word(
     guid: Optional[str] = None,
     english_text: Optional[str] = None,
     pos_type: Optional[str] = None,
-    word_role: Optional[str] = None,
+    part_of_speech: Optional[str] = None,
     forms_by_language: Optional[Dict[str, str]] = None,
     sentence_context: Optional[str] = None,
     disambiguation_hint: Optional[str] = None,
@@ -164,7 +163,7 @@ def resolve_lemma_for_word(
         guid: Lemma GUID if known (e.g., from pattern_words or LLM response)
         english_text: English lemma text (e.g., "teacher")
         pos_type: Part of speech (e.g., "noun", "verb")
-        word_role: Semantic role (e.g., "subject", "verb") - used to infer POS
+        part_of_speech: Part of speech from the historically named database field
         forms_by_language: Declined/conjugated forms by language code,
             e.g., {"lt": "mokytoją", "fr": "professeur", "zh": "老师"}
         sentence_context: Full English sentence for LLM disambiguation context
@@ -177,7 +176,7 @@ def resolve_lemma_for_word(
         ResolvedLemma with the best match (or lemma=None if unresolved)
     """
     effective_english = english_text or ""
-    effective_pos = pos_type or ROLE_TO_POS.get(word_role or "", "")
+    effective_pos = pos_type or PART_OF_SPEECH_TO_POS.get(part_of_speech or "", "")
     exact_candidates: List[Lemma] = []
 
     # Strategy 1: GUID lookup
@@ -408,13 +407,13 @@ def resolve_lemmas_for_sentence(
     # Build forms_by_language for each english_text slot from sentence_words
     # Group: english_text -> {lang_code: declined_form}
     slot_forms: Dict[str, Dict[str, str]] = {}
-    slot_roles: Dict[str, str] = {}
+    slot_parts_of_speech: Dict[str, str] = {}
     for sw in sentence_words:
         if sw.english_text:
             slot_key = sw.english_text.lower()
             if slot_key not in slot_forms:
                 slot_forms[slot_key] = {}
-                slot_roles[slot_key] = sw.word_role or ""
+                slot_parts_of_speech[slot_key] = sw.part_of_speech or ""
             if sw.declined_form:
                 slot_forms[slot_key][sw.language_code] = sw.declined_form
 
@@ -433,13 +432,13 @@ def resolve_lemmas_for_sentence(
 
             slot_key = pw.english_text.lower() if pw.english_text else ""
             forms = slot_forms.get(slot_key, {})
-            word_role = slot_roles.get(slot_key, pw.slot_name or "")
+            part_of_speech = slot_parts_of_speech.get(slot_key, pw.slot_name or "")
 
             resolved = resolve_lemma_for_word(
                 session,
                 guid=existing_guid,
                 english_text=pw.english_text,
-                word_role=word_role,
+                part_of_speech=part_of_speech,
                 forms_by_language=forms if forms else None,
                 sentence_context=sentence_context,
                 use_llm_disambiguation=use_llm_disambiguation,
@@ -472,7 +471,7 @@ def resolve_lemmas_for_sentence(
                 session,
                 guid=sw_guid,
                 english_text=sw.english_text,
-                word_role=sw.word_role or "",
+                part_of_speech=sw.part_of_speech or "",
                 forms_by_language=forms if forms else None,
                 sentence_context=sentence_context,
                 use_llm_disambiguation=use_llm_disambiguation,
@@ -480,7 +479,7 @@ def resolve_lemmas_for_sentence(
                 min_derivative_languages=min_derivative_languages,
             )
             resolved.position = position
-            resolved.slot_name = sw.word_role
+            resolved.slot_name = sw.part_of_speech
             results.append(resolved)
             position += 1
 


### PR DESCRIPTION
### Motivation
- Clarify that the per-token value represents a lexical category (part of speech) rather than a syntactic role and make naming consistent across code, prompts, docs and APIs.
- Preserve DB compatibility while exposing a clearer Python attribute name and updating all consumers to use the new field.

### Description
- Introduce `part_of_speech` as the canonical attribute everywhere and map it to the existing DB column by changing the `SentenceWord` model to `part_of_speech = mapped_column("word_role", String, ...)` and adding `word_role = synonym("part_of_speech")` for backwards compatibility.
- Update CRUD surfaces: `add_sentence_word` / `update_sentence_word` now accept `part_of_speech` (with checks preventing mismatch if `word_role` alias is passed) and require `part_of_speech` when creating words; added validation that raises `ValueError` for inconsistent inputs.
- Replace all usages of `role` / `word_role` with `part_of_speech` across agents, API routes, templates, prompts, benchmark runners, decomposition/pipeline modules, JSONL loader, and other utilities; adjust constant names (e.g., `PART_OF_SPEECH_MAP`) and ranking functions accordingly.
- Update prompts, prompt contexts and `docs/API.md` to reflect the new field name and clarify that it is a lexical category (not subject/object), and adapt schema definitions for LLM responses and benchmark expectations.

### Testing
- Updated unit/benchmark fixtures and tests to expect `part_of_speech` instead of `role`/`word_role` (notably `src/tests/sentences/*`, `src/tests/benchmarks/*`, `src/tests/wordfreq/*`, and `src/tests/storage/*`).
- Ran the modified test suite for sentence decomposition and related components (decomposition/translation/analysis/word linking); all updated tests passed locally. 
- Verified API docs and prompt text were updated to match the new schema and that JSONL import/export respects the existing on-disk field name (`word_role`) while exposing `part_of_speech` in code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67ba03e7ec8327a4b973f27db52c4d)