### PR TITLE
Persist UD relation/head through release import and hide empty UD columns on sentence view

### DIFF
--- a/src/barsukas/routes/sentences.py
+++ b/src/barsukas/routes/sentences.py
@@ -331,7 +331,13 @@ def view_sentence(sentence_id: int) -> Union[str, Response]:
     # the flat table. Built here rather than in the template because nesting is
     # data, not presentation.
     dependency_trees_by_language: dict[str, list[dict[str, Any]]] = {}
+    ud_languages: set[str] = set()
     for language_code, language_words in words_by_language.items():
+        if any(
+            word["ud_relation"] is not None or word["ud_head_position"] is not None
+            for word in language_words
+        ):
+            ud_languages.add(language_code)
         tree = _build_dependency_tree(language_words)
         if tree:
             dependency_trees_by_language[language_code] = tree
@@ -513,6 +519,7 @@ def view_sentence(sentence_id: int) -> Union[str, Response]:
         language_names=language_names,
         words_by_language=words_by_language,
         dependency_trees_by_language=dependency_trees_by_language,
+        ud_languages=ud_languages,
         lemmas_used=lemmas_used,
         n_decomposed_languages=n_decomposed,
         pattern_words=pattern_words_data,

--- a/src/barsukas/routes/sync/sync_sentence_release.py
+++ b/src/barsukas/routes/sync/sync_sentence_release.py
@@ -237,13 +237,14 @@ def _find_sentence_additions(
         release_data = release_sentences[guid]
         english_text = _get_release_sentence_english(release_data)
         pattern_words = release_data.get("pattern_words", [])
+        sentence_words = release_data.get("words", [])
 
         # Check for missing lemma GUIDs
-        missing_lemma_guids = []
-        for pw in pattern_words:
-            lemma_guid = pw.get("lemma_guid")
+        missing_lemma_guids: Set[str] = set()
+        for release_word in [*pattern_words, *sentence_words]:
+            lemma_guid = release_word.get("lemma_guid")
             if lemma_guid and lemma_guid not in all_lemma_guids:
-                missing_lemma_guids.append(lemma_guid)
+                missing_lemma_guids.add(lemma_guid)
 
         item: Dict[str, Any] = {
             "guid": guid,
@@ -257,7 +258,7 @@ def _find_sentence_additions(
         }
 
         if missing_lemma_guids:
-            item["missing_lemma_guids"] = missing_lemma_guids
+            item["missing_lemma_guids"] = sorted(missing_lemma_guids)
             blocked.append(item)
         else:
             importable.append(item)
@@ -324,13 +325,18 @@ def apply_additions() -> ResponseReturnValue:
             continue
 
         try:
-            # Validate all pattern word lemma GUIDs exist
+            # Validate all referenced lemma GUIDs exist. Skipping an unresolved
+            # decomposition word would silently corrupt the JSONL round trip.
             pattern_words = release_data.get("pattern_words", [])
-            missing_guids = [
-                pw.get("lemma_guid")
-                for pw in pattern_words
-                if pw.get("lemma_guid") and pw["lemma_guid"] not in lemma_guid_to_id
-            ]
+            sentence_words = release_data.get("words", [])
+            missing_guids = sorted(
+                {
+                    release_word["lemma_guid"]
+                    for release_word in [*pattern_words, *sentence_words]
+                    if release_word.get("lemma_guid")
+                    and release_word["lemma_guid"] not in lemma_guid_to_id
+                }
+            )
             if missing_guids:
                 flash(
                     f"Skipped {guid}: missing lemma GUIDs: {', '.join(missing_guids)}",
@@ -379,6 +385,28 @@ def apply_additions() -> ResponseReturnValue:
                 )
                 g.db.add(pattern_word)
 
+            # Add the full per-language decomposition, including Universal
+            # Dependencies fields. The release serializer already writes these
+            # fields; importing them here completes the Barsukas sync round trip.
+            for word_data in sentence_words:
+                lemma_guid = word_data.get("lemma_guid")
+                lemma_id = lemma_guid_to_id.get(lemma_guid) if lemma_guid else None
+                sentence_word = SentenceWord(
+                    sentence_id=sentence.id,
+                    lemma_id=lemma_id,
+                    language_code=word_data.get("language_code", ""),
+                    position=word_data.get("position", 0),
+                    part_of_speech=word_data.get("word_role", ""),
+                    english_text=word_data.get("english_text"),
+                    target_language_text=word_data.get("target_language_text"),
+                    grammatical_form=word_data.get("grammatical_form"),
+                    grammatical_case=word_data.get("grammatical_case"),
+                    declined_form=word_data.get("declined_form"),
+                    ud_relation=word_data.get("ud_relation"),
+                    ud_head_position=word_data.get("ud_head_position"),
+                )
+                g.db.add(sentence_word)
+
             log_operation(
                 session=g.db,
                 source="sync-release",
@@ -388,6 +416,7 @@ def apply_additions() -> ResponseReturnValue:
                     "english_text": _get_release_sentence_english(release_data)[:80],
                     "translation_count": len(translations),
                     "pattern_word_count": len(pattern_words),
+                    "word_count": len(sentence_words),
                 },
             )
 

--- a/src/barsukas/templates/sentences/view.html
+++ b/src/barsukas/templates/sentences/view.html
@@ -578,8 +578,10 @@
                             <tr>
                                 <th>{{ STRINGS.sentences.position }}</th>
                                 <th>{{ STRINGS.sentences.part_of_speech }}</th>
-                                <th>{{ STRINGS.sentences.ud_relation }}</th>
-                                <th>{{ STRINGS.sentences.ud_head }}</th>
+                                {% if lang_code in ud_languages %}
+                                    <th>{{ STRINGS.sentences.ud_relation }}</th>
+                                    <th>{{ STRINGS.sentences.ud_head }}</th>
+                                {% endif %}
                                 <th>{{ STRINGS.sentences.english }}</th>
                                 <th>{{ lang_name }}</th>
                                 <th>{{ STRINGS.sentences.grammatical_form }}</th>
@@ -591,25 +593,27 @@
                                 <tr>
                                     <td>{{ word.position }}</td>
                                     <td><code>{{ word.part_of_speech }}</code></td>
-                                    <td>
-                                        {% if word.ud_relation %}
-                                            <code>{{ word.ud_relation }}</code>
-                                        {% else %}
-                                            <span class="text-muted">-</span>
-                                        {% endif %}
-                                    </td>
-                                    <td>
-                                        {% if word.ud_head_position is not none %}
-                                            {% if word.ud_head_position < 0 %}
-                                                <em>{{ word.ud_head_text }}</em>
+                                    {% if lang_code in ud_languages %}
+                                        <td>
+                                            {% if word.ud_relation %}
+                                                <code>{{ word.ud_relation }}</code>
                                             {% else %}
-                                                <span class="text-muted">{{ word.ud_head_position }}</span>
-                                                {{ word.ud_head_text or '' }}
+                                                <span class="text-muted">-</span>
                                             {% endif %}
-                                        {% else %}
-                                            <span class="text-muted">-</span>
-                                        {% endif %}
-                                    </td>
+                                        </td>
+                                        <td>
+                                            {% if word.ud_head_position is not none %}
+                                                {% if word.ud_head_position < 0 %}
+                                                    <em>{{ word.ud_head_text }}</em>
+                                                {% else %}
+                                                    <span class="text-muted">{{ word.ud_head_position }}</span>
+                                                    {{ word.ud_head_text or '' }}
+                                                {% endif %}
+                                            {% else %}
+                                                <span class="text-muted">-</span>
+                                            {% endif %}
+                                        </td>
+                                    {% endif %}
                                     <td>{{ word.english_text or '-' }}</td>
                                     <td>
                                         {% if word.target_text %}

--- a/src/tests/barsukas/test_sentence_ud_jsonl.py
+++ b/src/tests/barsukas/test_sentence_ud_jsonl.py
@@ -1,0 +1,100 @@
+"""Regression tests for UD data in sentence release sync and display."""
+
+import json
+from pathlib import Path
+
+from flask.testing import FlaskClient
+from sqlalchemy.orm import Session
+
+from storage.models.schema import Sentence, SentenceWord
+
+
+def test_sentence_release_import_preserves_ud_fields(
+    client: FlaskClient, db_engine, tmp_path: Path, monkeypatch
+) -> None:
+    """Barsukas additions import restores decomposition and its UD annotation."""
+    release_dir = tmp_path / "sentences"
+    release_file = release_dir / "general" / "verbs" / "transitive" / "base.jsonl"
+    release_file.parent.mkdir(parents=True)
+    record = {
+        "guid": "S_UD_IMPORT",
+        "translations": {"en": "I eat"},
+        "words": [
+            {
+                "language_code": "en",
+                "position": 0,
+                "word_role": "verb",
+                "lemma_guid": "V01_001",
+                "english_text": "eat",
+                "target_language_text": "eat",
+                "grammatical_form": "verb/en_base",
+                "grammatical_case": None,
+                "declined_form": "eat",
+                "ud_relation": "root",
+                "ud_head_position": -1,
+            }
+        ],
+    }
+    release_file.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "barsukas.routes.sync.sync_sentence_release.DEFAULT_SENTENCE_RELEASE_DIR",
+        release_dir,
+    )
+    response = client.post(
+        "/sync/sentences/additions/apply",
+        data={"selected_guids": "S_UD_IMPORT"},
+    )
+    assert response.status_code == 302
+
+    with Session(db_engine) as db:
+        sentence = db.query(Sentence).filter_by(guid="S_UD_IMPORT").one()
+        word = db.query(SentenceWord).filter_by(sentence_id=sentence.id).one()
+        assert word.lemma_id == 1
+        assert word.ud_relation == "root"
+        assert word.ud_head_position == -1
+        assert word.target_language_text == "eat"
+
+
+def test_sentence_view_hides_ud_columns_for_unannotated_language(
+    client: FlaskClient, db_engine
+) -> None:
+    with Session(db_engine) as db:
+        db.add(
+            SentenceWord(
+                sentence_id=1,
+                language_code="lt",
+                position=0,
+                part_of_speech="pronoun",
+                target_language_text="Aš",
+            )
+        )
+        db.commit()
+
+    response = client.get("/sentences/1")
+    assert response.status_code == 200
+    assert b"UD Relation" not in response.data
+    assert b"UD Head" not in response.data
+
+
+def test_sentence_view_shows_ud_columns_for_annotated_language(
+    client: FlaskClient, db_engine
+) -> None:
+    with Session(db_engine) as db:
+        db.add(
+            SentenceWord(
+                sentence_id=1,
+                language_code="en",
+                position=0,
+                part_of_speech="verb",
+                target_language_text="eat",
+                ud_relation="root",
+                ud_head_position=-1,
+            )
+        )
+        db.commit()
+
+    response = client.get("/sentences/1")
+    assert response.status_code == 200
+    assert b"UD Relation" in response.data
+    assert b"UD Head" in response.data


### PR DESCRIPTION
### Motivation
- Ensure Universal Dependencies (UD) annotation (relation + head) added in the recent Phase‑4 pass is fully round‑trippable via data/release JSONL import/export so UD is not lost when importing released sentences. 
- Prevent silent corruption of release imports by validating lemma GUID references that appear in both pattern words and per‑language decomposed words. 
- Improve UI clarity by hiding the UD Relation/Head columns on the sentence detail page for languages that have no UD annotation.

### Description
- Import per‑language decomposition rows during the sync/additions import so `SentenceWord` rows (including `ud_relation` and `ud_head_position`) are written from release JSONL into SQLite; changes in `src/barsukas/routes/sync/sync_sentence_release.py` add that logic and pre‑import validation of lemma GUIDs referenced by both `pattern_words` and `words`.
- Make sentence view render UD columns only for languages that actually contain UD annotation by detecting languages with any `ud_relation`/`ud_head_position` and passing `ud_languages` into the template; changes in `src/barsukas/routes/sentences.py` and `src/barsukas/templates/sentences/view.html` implement this conditional rendering.
- Add regression tests exercising the round trip and UI behavior in `src/tests/barsukas/test_sentence_ud_jsonl.py`, and rely on the existing dependency‑tree tests for malformed graphs.
- Minor changes: normalized blocked import reporting sorts GUID lists and log details now include the imported `word_count` for visibility.

### Testing
- Ran targeted pytest: `PYTHONPATH=src pytest -q src/tests/barsukas/test_sentence_ud_jsonl.py src/tests/barsukas/test_dependency_tree.py src/tests/storage/test_release_roundtrip.py` — all selected tests passed (20 passed).
- Ran repository smoke suite: `./run_tests.sh smoke` — passed (16 passed, 1887 deselected).
- Ran formatting/type checks: `black --check` on modified files passed; `mypy` on the modified files reported no new errors, while repository‑wide mypy showed preexisting issues in unrelated modules.
- The new tests validate that UD fields persist through JSONL imports and that the sentence page hides/shows UD columns per language as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68b3166ba08327974346756ff1cd5b)