### PR TITLE
Require release-backed lemmas for function words in decomposition checks

### DIFF
--- a/src/sentences/decomposition.py
+++ b/src/sentences/decomposition.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from clients.unified_client import UnifiedLLMClient
 from langtools.dialect_overrides import get_dialect_display_name, get_llm_prompt_note
 from langtools.directions import get_language_direction_note
-from langtools.grammatical_words import is_function_word, is_grammatical_word
+from langtools.grammatical_words import is_grammatical_word
 from storage.models.schema import (
     Lemma,
     Sentence,
@@ -38,7 +38,7 @@ _NO_LEMMA_TEXT_MARKERS = {"", "no lemma", "none", "null"}
 def find_unresolved_non_grammatical_words(
     words: List[Dict[str, Any]], language_code: str
 ) -> List[Dict[str, Any]]:
-    """Return decomposition words that have no lemma and are not grammatical/function words."""
+    """Return words missing lemmas, excluding tokens that never have release lemmas."""
 
     unresolved_words: List[Dict[str, Any]] = []
     normalized_language_code = language_code.strip().lower()
@@ -58,9 +58,7 @@ def find_unresolved_non_grammatical_words(
             unresolved_words.append(word_row)
             continue
 
-        is_grammatical = is_grammatical_word(surface_form, normalized_language_code)
-        is_function = is_function_word(surface_form, normalized_language_code)
-        if is_grammatical or is_function:
+        if is_grammatical_word(surface_form, normalized_language_code):
             continue
 
         unresolved_words.append(word_row)
@@ -69,7 +67,7 @@ def find_unresolved_non_grammatical_words(
 
 
 def all_words_are_lemmas_or_grammatical(words: List[Dict[str, Any]], language_code: str) -> bool:
-    """Return True when every word has a lemma or is a grammatical/function word."""
+    """Return True when every word has a lemma or never has a release lemma."""
 
     unresolved_words = find_unresolved_non_grammatical_words(words, language_code)
     return len(unresolved_words) == 0

--- a/src/tests/sentences/test_decomposition.py
+++ b/src/tests/sentences/test_decomposition.py
@@ -184,8 +184,8 @@ def test_all_words_are_lemmas_or_grammatical_handles_spanish_example() -> None:
             "english_gloss": "in",
             "surface_form": "en",
             "grammatical_form": "preposition/es_base",
-            "lemma_guid": "NONE",
-            "lemma": "No lemma",
+            "lemma_guid": "P01_001",
+            "lemma": "in",
         },
         {
             "position": 4,
@@ -275,8 +275,8 @@ def test_negative_case_spanish_fair_without_lemma_fails_check() -> None:
             "english_gloss": "at",
             "surface_form": "en",
             "grammatical_form": "preposition/base",
-            "lemma_guid": "NONE",
-            "lemma": "No lemma",
+            "lemma_guid": "P01_001",
+            "lemma": "in",
         },
         {
             "position": 4,
@@ -341,3 +341,42 @@ def test_find_unresolved_non_grammatical_words_keeps_skip_for_known_grammatical_
 
     assert unresolved == []
     assert all_words_are_lemmas_or_grammatical(words, "fr")
+
+
+def test_find_unresolved_non_grammatical_words_requires_release_backed_function_lemmas() -> None:
+    words = [
+        {
+            "position": position,
+            "part_of_speech": part_of_speech,
+            "english_gloss": surface_form,
+            "surface_form": surface_form,
+            "grammatical_form": f"{part_of_speech}/base",
+            "lemma_guid": "NONE",
+            "lemma": "No lemma",
+        }
+        for position, (surface_form, part_of_speech) in enumerate(
+            [("if", "conjunction"), ("in", "preposition"), ("who", "pronoun")]
+        )
+    ]
+
+    unresolved = find_unresolved_non_grammatical_words(words, "en")
+
+    assert [word["surface_form"] for word in unresolved] == ["if", "in", "who"]
+    assert not all_words_are_lemmas_or_grammatical(words, "en")
+
+
+def test_find_unresolved_non_grammatical_words_accepts_resolved_function_lemma() -> None:
+    words = [
+        {
+            "position": 0,
+            "part_of_speech": "conjunction",
+            "english_gloss": "if",
+            "surface_form": "if",
+            "grammatical_form": "conjunction/base",
+            "lemma_guid": "C01_001",
+            "lemma": "if",
+        }
+    ]
+
+    assert find_unresolved_non_grammatical_words(words, "en") == []
+    assert all_words_are_lemmas_or_grammatical(words, "en")


### PR DESCRIPTION
### Motivation

- Ensure decomposition validation does not automatically exempt function words that lack released lemmas, improving data quality for downstream uses.
- Align behavior so only tokens that truly never have release lemmas (grammatical tokens) are skipped by validation.

### Description

- Remove the unused import `is_function_word` and update `find_unresolved_non_grammatical_words` to only consult `is_grammatical_word` when deciding to skip tokens.  
- Update docstrings to reflect that the check now excludes only tokens that never have release lemmas rather than both grammatical and function words.  
- Adjust example test fixtures in `src/tests/sentences/test_decomposition.py` to reflect that some function words now require release-backed lemmas (update lemma values where appropriate).  
- Add two unit tests `test_find_unresolved_non_grammatical_words_requires_release_backed_function_lemmas` and `test_find_unresolved_non_grammatical_words_accepts_resolved_function_lemma` to cover the new behavior.

### Testing

- Ran the sentence decomposition unit tests in `src/tests/sentences/test_decomposition.py` with `pytest` and they passed.  
- The two new tests validate that function words without release-backed lemmas are reported as unresolved and that resolved function words are accepted.  
- Existing decomposition tests (including updated Spanish examples) continue to pass after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68b4254e848327818c577fbaf1a652)