### PR TITLE
Add Spanish to genys Phase-1 target languages

### DIFF
--- a/src/agents/genys/agent.py
+++ b/src/agents/genys/agent.py
@@ -58,8 +58,12 @@ SKIPPED_PARTS_OF_SPEECH: Set[str] = {
 }
 
 # Languages always requested in Phase 1 (sentence-level translation only).
-# The doc language is excluded at runtime.
-_PHASE1_LANGUAGES: List[str] = ["en", "fr", "zh", "lt"]
+# The doc language is excluded at runtime, leaving MAX_PHASE1_TARGETS of them.
+_PHASE1_LANGUAGES: List[str] = ["en", "es", "fr", "zh", "lt"]
+
+# One fewer than _PHASE1_LANGUAGES, so dropping the document language leaves
+# every remaining language rather than silently truncating the tail.
+MAX_PHASE1_TARGETS: int = len(_PHASE1_LANGUAGES) - 1
 
 _PUNCTUATION_STRIP = ".,!?;:\"'()[]{}—-"
 
@@ -104,11 +108,11 @@ class GenysAgent:
 
     @staticmethod
     def choose_target_languages(document_language: str) -> List[str]:
-        """Pick up to 3 target languages: [en, fr, zh, lt] minus the doc language."""
+        """Return the Phase-1 target languages minus the document's own language."""
         normalized = document_language.strip().lower()
         selected = [lang for lang in _PHASE1_LANGUAGES if lang != normalized]
         return normalize_llm_language_codes(
-            selected[:3],
+            selected[:MAX_PHASE1_TARGETS],
             operation_name="Genys Phase 1 translation",
         )
 


### PR DESCRIPTION
An English document was translated into fr/zh/lt only. Add es, and replace the hardcoded [:3] cap with MAX_PHASE1_TARGETS (one fewer than the language list) so removing the document's own language leaves every remaining language instead of silently truncating the tail -- with es appended and the old cap, es would have been dropped for English input.

No extra LLM calls: Phase 1 is a single call regardless of how many languages it requests.