### PR TITLE
Detect and prevent truncated sentence-pipeline responses

### DIFF
--- a/prompts/sentence_decomposition/multi_language/prompt.txt
+++ b/prompts/sentence_decomposition/multi_language/prompt.txt
@@ -8,10 +8,23 @@ Target translations to decompose (do NOT retranslate; analyze the provided text)
 Additional translations for disambiguation (helper languages, not to be decomposed):
 {helper_translations}
 
-Candidate lemmas (must choose correct lemma_guid when a content word maps to one):
+Candidate lemmas. Each line is "GUID - ENGLISH LEMMA (disambiguation) | POS | Definition | Translations".
+The English lemma and its definition are what the GUID means; the translations are only how that
+same meaning is written elsewhere. Choose a GUID only when the word in the sentence means the same
+thing as that English lemma:
 {candidate_lemmas}
 
 Per-call requirements:
+- LEMMA MATCHING: a candidate must name the same CONCEPT, not merely a related one.
+  "captain" is not "pirate", "procedure" is not "program", "statute" is not "law".
+  A broader lemma that genuinely covers the word is fine ("backyard" -> "yard"); a
+  neighbouring but distinct concept is not. If the exact sense is not in the candidate list, use
+  lemma_guid=NONE. NONE is the correct answer for a near-miss and is always better
+  than a wrong GUID: an unmatched word can be added later, while a wrong link is
+  silently taken as fact.
+- A candidate matching only one language's translation is weak evidence, especially
+  when that language's word is a homograph. Check it against the English lemma and
+  definition before adopting it, and prefer NONE when they disagree.
 - For each target language listed above, populate the corresponding ``words_<lang>`` array and echo the translation in the ``<lang>`` field.
 - Each ``words_<lang>`` entry must include: position, part_of_speech, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.
 - Use lemma_guid=NONE for function words without a selected candidate lemma.

--- a/prompts/sentence_decomposition/single_language/prompt.txt
+++ b/prompts/sentence_decomposition/single_language/prompt.txt
@@ -8,10 +8,23 @@ Additional translations for disambiguation (1-3 helper languages):
 
 Lemma translation context: include source, target, and at most 3 helper languages.
 
-Candidate lemmas (must choose correct lemma_guid when a content word maps to one):
+Candidate lemmas. Each line is "GUID - ENGLISH LEMMA (disambiguation) | POS | Definition | Translations".
+The English lemma and its definition are what the GUID means; the translations are only how that
+same meaning is written elsewhere. Choose a GUID only when the word in the sentence means the same
+thing as that English lemma:
 {candidate_lemmas}
 
 Per-call requirements:
+- LEMMA MATCHING: a candidate must name the same CONCEPT, not merely a related one.
+  "captain" is not "pirate", "procedure" is not "program", "statute" is not "law".
+  A broader lemma that genuinely covers the word is fine ("backyard" -> "yard"); a
+  neighbouring but distinct concept is not. If the exact sense is not in the candidate list, use
+  lemma_guid=NONE. NONE is the correct answer for a near-miss and is always better
+  than a wrong GUID: an unmatched word can be added later, while a wrong link is
+  silently taken as fact.
+- A candidate matching only one language's translation is weak evidence, especially
+  when that language's word is a homograph. Check it against the English lemma and
+  definition before adopting it, and prefer NONE when they disagree.
 - Return exactly one entry in languages[] and set language_code to '{target_language}'.
 - The languages[] breakdown must analyze tokens from the target translation only.
 - Each words[] item must include: position, part_of_speech, english_gloss, surface_form, grammatical_form, lemma_guid, lemma.

--- a/prompts/sentence_decomposition/translate_and_decompose/context.txt
+++ b/prompts/sentence_decomposition/translate_and_decompose/context.txt
@@ -10,7 +10,7 @@ For each target language, provide a detailed word-by-word breakdown including:
 - position: 0-indexed token position within the sentence.
 - surface_form: the actual inflected form as it appears in the sentence.
 - english_gloss: English translation of this specific word/phrase.
-- lemma_guid: if a real lemma GUID is known from references or candidate lemmas, use it. Otherwise assign synthetic concept ids in this exact sequence format: SYN001, SYN002, SYN003, ... Reuse the SAME synthetic id for the same concept across all languages in this sentence, and never reuse one synthetic id for different concepts.
+- lemma_guid: if a real lemma GUID is known from references or candidate lemmas, use it. Otherwise use NONE. Reuse the SAME real GUID for the same concept across all languages in this sentence.
 - lemma: the dictionary (base) form of this word.
 - part_of_speech: lexical category (noun, verb, adjective, adverb, article, preposition, determiner, pronoun, etc.); never subject/object syntactic role.
 - grammatical_form: see the format spec below.
@@ -47,5 +47,5 @@ Candidate lemma selection:
 - Prefer the listed GUID when a word in the sentence corresponds to one of
   these meanings. The same GUID should be reused across all target
   languages for the same concept.
-- If no candidate matches the intended meaning, fall back to a synthetic
-  SYN### id as described above rather than forcing a wrong GUID match.
+- If no candidate matches the intended meaning, use NONE rather than forcing
+  a wrong GUID match.

--- a/prompts/sentence_decomposition/translate_and_decompose/prompt.txt
+++ b/prompts/sentence_decomposition/translate_and_decompose/prompt.txt
@@ -3,7 +3,10 @@ Template sentence: {template_sentence}
 Word translations for reference:
 {word_translations}
 
-Candidate lemmas (prefer these GUIDs when a word in the sentence matches one of these meanings):
+Candidate lemmas. Each line is "GUID - ENGLISH LEMMA (disambiguation) | POS | Definition | Translations".
+The English lemma and its definition are what the GUID means; the translations are only how that
+same meaning is written elsewhere. Choose a GUID only when the word in the sentence means the same
+thing as that English lemma:
 {candidate_lemmas}
 
 Translate this sentence naturally into each of these languages:
@@ -14,4 +17,14 @@ Translate this sentence naturally into each of these languages:
 
 Per-call requirements:
 - Use the provided word translations where appropriate, but prioritize natural translations. If the target language expresses the concept differently, use natural phrasing and map words to their actual meanings, not the English lemmas.
-- Only include real GUIDs for words that genuinely correspond to referenced lemma meanings. When no real GUID is available, fall back to synthetic SYN### ids per the context rules.
+- Only include real GUIDs for words that genuinely correspond to referenced lemma meanings. When no real GUID is available, use lemma_guid=NONE.
+- LEMMA MATCHING: a candidate must name the same CONCEPT, not merely a related one.
+  "captain" is not "pirate", "procedure" is not "program", "statute" is not "law".
+  A broader lemma that genuinely covers the word is fine ("backyard" -> "yard"); a
+  neighbouring but distinct concept is not. If the exact sense is not in the candidate list, use
+  lemma_guid=NONE. NONE is the correct answer for a near-miss and is always better
+  than a wrong GUID: an unmatched word can be added later, while a wrong link is
+  silently taken as fact.
+- A candidate matching only one language's translation is weak evidence, especially
+  when that language's word is a homograph. Check it against the English lemma and
+  definition before adopting it, and prefer NONE when they disagree.

--- a/src/agents/genys/agent.py
+++ b/src/agents/genys/agent.py
@@ -199,6 +199,14 @@ class GenysAgent:
 
     @staticmethod
     def _is_real_guid(lemma_guid: str) -> bool:
+        """True when the LLM named an actual database lemma.
+
+        The SYN### branch is deprecated and should no longer fire: no prompt
+        asks for synthetic ids any more, and every path now uses NONE for "no
+        lemma matched". It is kept because a model can still emit the old format
+        from memory, and treating SYN001 as a real GUID would look up a lemma
+        that cannot exist. A run that trips it is worth investigating.
+        """
         if not lemma_guid:
             return False
         lowered = lemma_guid.lower()
@@ -208,6 +216,12 @@ class GenysAgent:
             lemma_guid.startswith(SYNTHETIC_GUID_PREFIX)
             and lemma_guid[len(SYNTHETIC_GUID_PREFIX) :].isdigit()
         )
+        if synthetic:
+            logger.warning(
+                "Deprecated synthetic lemma_guid %r from the LLM; prompts ask for "
+                "NONE. Treating as unmatched.",
+                lemma_guid,
+            )
         return not synthetic
 
     @staticmethod

--- a/src/clients/anthropic/client.py
+++ b/src/clients/anthropic/client.py
@@ -121,6 +121,7 @@ class AnthropicClient:
         json_schema: Optional[Any] = None,
         context: Optional[str] = None,
         messages: Optional[List[clients.lib.ChatMessage]] = None,
+        max_tokens: Optional[int] = None,
     ) -> Response:
         """
         Generate chat completion using Anthropic API.
@@ -129,6 +130,9 @@ class AnthropicClient:
             prompt: The main prompt/question (ignored if ``messages`` is given)
             model: Model to use for generation
             brief: Whether to limit response length
+            max_tokens: Explicit output-token limit, normally from
+                ``clients.lib.limit_from_estimate()``. When None the backend
+                default applies.
             json_schema: Schema for structured response (if provided, returns JSON)
             context: Optional context.
             messages: Optional provider-neutral message list. Consecutive same-role
@@ -160,7 +164,9 @@ class AnthropicClient:
 
         request_kwargs: Dict[str, Any] = {
             "model": model,
-            "max_tokens": 512 if brief else 3192,
+            "max_tokens": clients.lib.resolve_output_tokens(
+                model, brief=brief, requested=max_tokens, backend_default=3192
+            ),
             "messages": [],
         }
 
@@ -234,6 +240,23 @@ class AnthropicClient:
 
         completion_data, duration_ms = self._create_message(**request_kwargs)
 
+        # Ran out of room rather than finishing: the tool input is cut mid-JSON,
+        # so treat it as a failed call instead of returning a partial answer.
+        # Spending the whole budget is the signal that does not depend on the
+        # provider setting a flag -- a response that ended on its own terms stops
+        # short of the cap.
+        stop_reason = completion_data.get("stop_reason")
+        token_limit = request_kwargs["max_tokens"]
+        output_tokens = (completion_data.get("usage") or {}).get("output_tokens", 0)
+        if stop_reason == "max_tokens" or (
+            isinstance(output_tokens, int) and output_tokens >= token_limit
+        ):
+            raise clients.lib.TruncatedResponseError(
+                f"Anthropic stopped generating at the {token_limit}-token output limit "
+                f"(model={model}, output_tokens={output_tokens}, "
+                f"stop_reason={stop_reason!r}). Raise the limit or split the request."
+            )
+
         # Extract text or tool output from response
         structured_data = {}
         response_text = ""
@@ -299,7 +322,12 @@ class AnthropicClient:
                 logger.debug("No response text or structured data")
             logger.debug("Usage metrics: %s", usage.to_dict())
 
-        return Response(response_text=response_text, structured_data=structured_data, usage=usage)
+        return Response(
+            response_text=response_text,
+            structured_data=structured_data,
+            usage=usage,
+            finish_reason=stop_reason,
+        )
 
 
 # Lazy client instance - only created when first accessed

--- a/src/clients/gemini_client.py
+++ b/src/clients/gemini_client.py
@@ -111,6 +111,7 @@ class GeminiClient:
         json_schema: Optional[Any] = None,
         context: Optional[str] = None,
         messages: Optional[List[clients.lib.ChatMessage]] = None,
+        max_tokens: Optional[int] = None,
     ) -> Response:
         """
         Generate chat completion using Gemini API.
@@ -119,6 +120,9 @@ class GeminiClient:
             prompt: The main prompt/question (ignored if ``messages`` is given)
             model: Model to use for generation
             brief: Whether to limit response length
+            max_tokens: Explicit output-token limit, normally from
+                ``clients.lib.limit_from_estimate()``. When None the backend
+                default applies.
             json_schema: Schema for structured response (if provided, returns JSON)
             context: Optional context to include before the prompt
             messages: Optional provider-neutral message list. Consecutive same-role
@@ -144,7 +148,10 @@ class GeminiClient:
             logger.debug("Context: %s", context)
             logger.debug("JSON schema: %s", json_schema)
 
-        generation_config: Dict[str, Any] = {"maxOutputTokens": 256 if brief else 1536}
+        output_token_limit = clients.lib.resolve_output_tokens(
+            model, brief=brief, requested=max_tokens, backend_default=1536, brief_default=256
+        )
+        generation_config: Dict[str, Any] = {"maxOutputTokens": output_token_limit}
         if model.startswith(MINIMAL_THINKING_MODELS):
             generation_config["thinkingConfig"] = {"thinkingLevel": "minimal"}
         if messages:
@@ -181,6 +188,26 @@ class GeminiClient:
 
         completion_data, duration_ms = self._create_completion(model=model, **request_kwargs)
 
+        # Check this before touching content: a MAX_TOKENS candidate can carry no
+        # "parts" at all, so extracting text first raises KeyError / IndexError
+        # and hides the real cause. Spending the whole budget is the signal that
+        # does not depend on finishReason being set -- thinking tokens draw from
+        # maxOutputTokens too, so they count toward the total.
+        candidates = completion_data.get("candidates") or [{}]
+        finish_reason = candidates[0].get("finishReason")
+        usage_metadata = completion_data.get("usageMetadata") or {}
+        output_tokens = usage_metadata.get("candidatesTokenCount", 0) + usage_metadata.get(
+            "thoughtsTokenCount", 0
+        )
+        if finish_reason == "MAX_TOKENS" or (
+            isinstance(output_tokens, int) and output_tokens >= output_token_limit
+        ):
+            raise clients.lib.TruncatedResponseError(
+                f"Gemini stopped generating at the {output_token_limit}-token output "
+                f"limit (model={model}, output_tokens={output_tokens}, "
+                f"finish_reason={finish_reason!r}). Raise the limit or split the request."
+            )
+
         response_content = completion_data["candidates"][0]["content"]["parts"][0]["text"]
         usage = LLMUsage.from_api_response(
             {
@@ -216,7 +243,12 @@ class GeminiClient:
                 logger.debug("No response text or structured data")
             logger.debug("Usage metrics: %s", usage.to_dict())
 
-        return Response(response_text=response_text, structured_data=structured_data, usage=usage)
+        return Response(
+            response_text=response_text,
+            structured_data=structured_data,
+            usage=usage,
+            finish_reason=finish_reason,
+        )
 
 
 # Lazy client instance - only created when first accessed

--- a/src/clients/lib.py
+++ b/src/clients/lib.py
@@ -14,7 +14,7 @@ import copy
 import json
 import logging
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from clients.types import Schema, SchemaProperty
 
@@ -38,6 +38,34 @@ ALTERNATION_ACK: str = "Understood."
 # prompt and drop the enum.
 MAX_SCHEMA_TOKENS = 2048
 
+# Default output-token limit when the caller asks for nothing in particular.
+# Each backend passes its own historical value as ``backend_default`` so that
+# omitting ``max_tokens`` reproduces exactly what that backend did before.
+DEFAULT_BRIEF_TOKENS: int = 512
+
+# Per-model-family ceiling on output tokens. This is not the model's true API
+# maximum; it is the largest single response this project is willing to pay for.
+# Prefix-keyed and deliberately coarse so a new point release does not need an
+# entry -- an unmatched model falls back to DEFAULT_OUTPUT_CEILING.
+MODEL_OUTPUT_CEILINGS: Dict[str, int] = {
+    "gpt-5": 32768,
+    "gpt-4o": 16384,
+    "claude": 16384,
+    "gemini": 8192,
+}
+DEFAULT_OUTPUT_CEILING: int = 4096
+
+# Headroom applied to a caller's estimate of its own response size, by
+# limit_from_estimate(). An estimate is a guess, and the cost of guessing low is
+# a truncated response that fails the whole call; the cost of guessing high is
+# nothing, since output tokens are billed as generated, not as reserved. The
+# additive term covers fixed per-response overhead (envelope punctuation, a
+# trailing object) that does not scale with the estimate, and the floor keeps
+# very small requests from being sized absurdly tight.
+ESTIMATE_SAFETY_FACTOR: float = 1.35
+ESTIMATE_SAFETY_OVERHEAD_TOKENS: int = 100
+MIN_ESTIMATED_LIMIT_TOKENS: int = 512
+
 
 class SchemaTooLargeError(ValueError):
     """Raised when a serialized schema exceeds MAX_SCHEMA_TOKENS."""
@@ -45,6 +73,87 @@ class SchemaTooLargeError(ValueError):
 
 class LLMCallsDisabledError(RuntimeError):
     """Raised when GREENLAND_DISABLE_LLM blocks an outbound LLM request."""
+
+
+class TruncatedResponseError(RuntimeError):
+    """Raised when a backend stopped generating because it hit the token limit.
+
+    Distinct from a malformed response: the model was answering correctly and
+    ran out of room. Callers that can resize and retry should catch this
+    specifically; callers that cannot should let it propagate rather than
+    persisting the partial answer.
+    """
+
+
+def limit_from_estimate(estimated_tokens: int) -> int:
+    """Turn a caller's estimate of its response size into a token limit.
+
+    The single place the estimate-to-limit policy lives, so it can be tuned
+    globally rather than per call site. Callers estimate how large their own
+    response should be (which they know: word counts, item counts) and this
+    adds the safety margin.
+
+    Args:
+        estimated_tokens: The caller's estimate of its response size, in tokens.
+
+    Returns:
+        A token limit at least MIN_ESTIMATED_LIMIT_TOKENS. Still subject to the
+        model ceiling, which resolve_output_tokens() applies.
+    """
+    if estimated_tokens < 0:
+        estimated_tokens = 0
+    padded = int(estimated_tokens * ESTIMATE_SAFETY_FACTOR) + ESTIMATE_SAFETY_OVERHEAD_TOKENS
+    return max(padded, MIN_ESTIMATED_LIMIT_TOKENS)
+
+
+def ceiling_for_model(model: str) -> int:
+    """Largest output-token limit allowed for a model, by name prefix."""
+    for prefix, ceiling in MODEL_OUTPUT_CEILINGS.items():
+        if model.startswith(prefix):
+            return ceiling
+    return DEFAULT_OUTPUT_CEILING
+
+
+def resolve_output_tokens(
+    model: str,
+    *,
+    brief: bool,
+    requested: Optional[int],
+    backend_default: int,
+    brief_default: int = DEFAULT_BRIEF_TOKENS,
+) -> int:
+    """Decide the output-token limit for one request.
+
+    Shared by every backend so the policy is one testable function rather than a
+    hardcoded literal per client.
+
+    Args:
+        model: Model name, used to pick the ceiling.
+        brief: The caller's coarse "keep it short" flag.
+        requested: An explicit limit, normally from limit_from_estimate(). When
+            None, the result is exactly what this backend used before max_tokens
+            existed, so callers that do not pass one are unaffected.
+        backend_default: This backend's historical non-brief default.
+        brief_default: This backend's historical brief default.
+
+    Returns:
+        The token limit to send, clamped to the model ceiling.
+    """
+    if requested is None:
+        return brief_default if brief else backend_default
+
+    ceiling = ceiling_for_model(model)
+    if requested > ceiling:
+        logger.warning(
+            "Requested output limit %d exceeds the %d-token ceiling for model %s; "
+            "clamping. A response that needs more than this should be split by the "
+            "caller rather than truncated.",
+            requested,
+            ceiling,
+            model,
+        )
+        return ceiling
+    return requested
 
 
 def assert_llm_calls_enabled(backend: str) -> None:

--- a/src/clients/openai/batch_client.py
+++ b/src/clients/openai/batch_client.py
@@ -82,13 +82,19 @@ class OpenAIBatchClient:
             {
                 "custom_id": "request-1",
                 "method": "POST",
-                "url": "/v1/responses",
+                "url": "/v1/chat/completions",
                 "body": {
                     "model": "gpt-5-nano",
-                    "input": "Translate 'hello' to Spanish",
-                    "max_output_tokens": 512
+                    "messages": [{"role": "user", "content": "Translate 'hello'"}],
+                    "max_completion_tokens": 512
                 }
             }
+
+        Size ``max_completion_tokens`` to the response you expect rather than
+        leaving it at a fixed value -- see ``clients.lib.limit_from_estimate()``.
+        A batch result is applied hours after submission, so a request truncated
+        at the limit wastes the entire round trip, and the truncation is only
+        visible as ``finish_reason == "length"`` on the returned choice.
         """
         # Check if API key is available
         if not self.api_key:

--- a/src/clients/openai/client.py
+++ b/src/clients/openai/client.py
@@ -178,6 +178,7 @@ class OpenAIClient:
         json_schema: Optional[Any] = None,
         context: Optional[str] = None,
         messages: Optional[List[clients.lib.ChatMessage]] = None,
+        max_tokens: Optional[int] = None,
     ) -> Response:
         """
         Generate chat response using OpenAI Responses API.
@@ -185,6 +186,10 @@ class OpenAIClient:
         Args:
             prompt: The main prompt/question (ignored if ``messages`` is given)
             model: Model to use for generation
+            max_tokens: Explicit output-token limit, normally from
+                ``clients.lib.limit_from_estimate()``. When None the backend
+                default applies, which is what every caller got before this
+                parameter existed.
             brief: Whether to limit response length
             json_schema: Schema for structured response (if provided, returns JSON)
             context: Optional context to include before the prompt
@@ -210,16 +215,13 @@ class OpenAIClient:
             logger.debug("Context: %s", context)
             logger.debug("JSON schema: %s", json_schema)
 
-        # Determine which token limit parameter to use based on model
-        # Newer reasoning models (o1, gpt-5, o3) require max_output_tokens
-        reasoning_models = ["o1-", "gpt-5", "o3-"]
-        uses_output_tokens = any(model.startswith(prefix) for prefix in reasoning_models)
-
         # gpt-5 models don't support custom temperature (only default value of 1)
         is_gpt5_model = model.startswith("gpt-5")
         is_gpt5_nano_or_mini = is_gpt5_nano_or_mini_model(model)
 
-        token_limit = 512 if brief else 4096
+        token_limit = clients.lib.resolve_output_tokens(
+            model, brief=brief, requested=max_tokens, backend_default=4096
+        )
         request_kwargs: Dict[str, Any] = {
             "model": model,
             # The Responses API accepts either a string or a list of role/content
@@ -235,12 +237,9 @@ class OpenAIClient:
         if not is_gpt5_model:
             request_kwargs["temperature"] = 0.35
 
-        # Set token limit parameter
-        if uses_output_tokens:
-            request_kwargs["max_output_tokens"] = token_limit
-        else:
-            # For non-reasoning models, we still use max_output_tokens in Responses API
-            request_kwargs["max_output_tokens"] = token_limit
+        # The Responses API takes max_output_tokens for every model, reasoning
+        # or not.
+        request_kwargs["max_output_tokens"] = token_limit
 
         # Set reasoning and text parameters for GPT-5 nano and mini variants
         if is_gpt5_nano_or_mini:
@@ -309,25 +308,59 @@ class OpenAIClient:
 
         # Calculate token usage
         usage_data = response_data.get("usage", {})
+        output_tokens = usage_data.get("output_tokens", 0)
         usage = LLMUsage.from_api_response(
             {
                 "prompt_tokens": usage_data.get("input_tokens", 0),
-                "completion_tokens": usage_data.get("output_tokens", 0),
+                "completion_tokens": output_tokens,
                 "total_duration": duration_ms,
             },
             model=model,
         )
+
+        # Did generation stop because it ran out of room?
+        #
+        # Spending the entire budget is the surest signal, and the only one that
+        # needs no cooperation from the provider: a response that ended on its
+        # own terms stops short of the cap, so landing exactly on it means the
+        # cap did the stopping. The status flags are checked too because they
+        # name the reason, but they can be absent or unset while the token count
+        # cannot lie.
+        response_status = response_data.get("status")
+        incomplete_details = response_data.get("incomplete_details") or {}
+        incomplete_reason = incomplete_details.get("reason")
+        hit_token_limit = isinstance(output_tokens, int) and output_tokens >= token_limit
+        # With reasoning models the envelope can come back "incomplete" carrying
+        # only a reasoning item and no message content at all.
+        status_says_truncated = response_status == "incomplete" and (
+            incomplete_reason == "max_output_tokens" or not response_content
+        )
+        truncated = hit_token_limit or status_says_truncated
+
+        # A truncated response is a failed call, not a short one: the JSON is cut
+        # mid-array and any prefix that happens to parse is missing data the
+        # caller asked for. Raise rather than returning it -- callers merge a
+        # returned dict into a success result and would persist the fragment.
+        if truncated:
+            raise clients.lib.TruncatedResponseError(
+                f"OpenAI stopped generating at the {token_limit}-token output limit "
+                f"(model={model}, output_tokens={output_tokens}, "
+                f"status={response_status!r}, reason={incomplete_reason!r}). "
+                f"Raise the limit or split the request."
+            )
 
         # Parse JSON response if schema was provided
         if json_schema:
             try:
                 structured_data = json.loads(response_content)
                 response_text = ""
-            except json.JSONDecodeError:
-                error_msg = f"Failed to parse JSON response: {response_content}"
-                logger.error(error_msg)
-                structured_data = {"error": error_msg}
-                response_text = ""
+            except json.JSONDecodeError as exc:
+                # Do not return {"error": ...} here: structured_data is merged
+                # into the caller's result dict, so an error payload reads as a
+                # successful response with odd keys.
+                raise ValueError(
+                    f"Failed to parse JSON response from {model}: {response_content!r}"
+                ) from exc
         else:
             response_text = response_content
             structured_data = {}

--- a/src/clients/types.py
+++ b/src/clients/types.py
@@ -120,3 +120,9 @@ class Response:
     structured_data: Dict[str, Any]
     usage: Optional[LLMUsage]
     additional_thought: Optional[str] = None
+    # Provider-native reason generation stopped ("max_output_tokens",
+    # "max_tokens", "MAX_TOKENS", "stop", ...), for logs. Backends that hit the
+    # token limit raise TruncatedResponseError rather than returning a partial
+    # response, so a returned Response is normally complete; this is kept for
+    # callers that want to see how a successful call ended.
+    finish_reason: Optional[str] = None

--- a/src/clients/unified_client.py
+++ b/src/clients/unified_client.py
@@ -322,6 +322,7 @@ class UnifiedLLMClient:
         context: Optional[str] = None,
         timeout: Optional[float] = None,
         messages: Optional[List[clients.lib.ChatMessage]] = None,
+        max_tokens: Optional[int] = None,
     ) -> Response:
         """
         Generate chat completion using appropriate backend.
@@ -330,6 +331,10 @@ class UnifiedLLMClient:
             prompt: The main prompt/question (ignored if ``messages`` is given)
             model: Model name (determines backend). If not provided, uses default_model from config.
             brief: Whether to limit response length
+            max_tokens: Explicit output-token limit, normally from
+                ``clients.lib.limit_from_estimate()``. Honored by the cloud
+                backends and ignored by the local ones. When None each backend
+                uses its own default.
             json_schema: Schema for structured response (if provided, returns JSON) - either a dict (old) or a types.Schema
             context: Optional context to include before the prompt
             timeout: Optional timeout override in seconds
@@ -395,20 +400,26 @@ class UnifiedLLMClient:
                 "json_schema": json_schema,
                 "context": context,
             }
+            cloud_clients = (
+                openai_client.OpenAIClient,
+                anthropic_client.AnthropicClient,
+                gemini_client.GeminiClient,
+            )
             if messages is not None:
                 # Multi-message conversations are only implemented for the remote
                 # cloud backends, which know how to map/normalize roles.
-                cloud_clients = (
-                    openai_client.OpenAIClient,
-                    anthropic_client.AnthropicClient,
-                    gemini_client.GeminiClient,
-                )
                 if not isinstance(client, cloud_clients):
                     raise NotImplementedError(
                         f"messages= is not supported for backend {backend_name!r}; "
                         "use a remote OpenAI/Anthropic/Gemini model."
                     )
                 generate_kwargs["messages"] = messages
+            if max_tokens is not None and isinstance(client, cloud_clients):
+                # Only the cloud backends take an explicit limit. Drop it silently
+                # for local backends rather than raising as messages= does: a
+                # token limit is an optimization, not a semantic requirement, and
+                # the local backends are already effectively unlimited.
+                generate_kwargs["max_tokens"] = max_tokens
             if isinstance(client, lmstudio_client.LMStudioClient):
                 generate_kwargs["expected_response_model"] = expected_response_model
 
@@ -523,6 +534,7 @@ def generate_chat(
     context: Optional[str] = None,
     timeout: Optional[float] = None,
     messages: Optional[List[clients.lib.ChatMessage]] = None,
+    max_tokens: Optional[int] = None,
 ) -> Response:
     """
     Generate a chat response using appropriate backend based on model name.
@@ -533,6 +545,15 @@ def generate_chat(
         For JSON responses, response_text will be empty string
     """
     _assert_not_under_test("generate_chat")
+    # Passed by keyword: this signature and the method's have diverged before,
+    # and a positional call silently shifts arguments when either one changes.
     return _get_client().generate_chat(
-        prompt, model, brief, json_schema, context, timeout, messages
+        prompt=prompt,
+        model=model,
+        brief=brief,
+        json_schema=json_schema,
+        context=context,
+        timeout=timeout,
+        messages=messages,
+        max_tokens=max_tokens,
     )

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -18,6 +18,11 @@ PYTHONPATH=src python src/scripts/<script>.py --help
   language/voice directory layout
 - `update_prominence.py` — set `sense_prominence` from Trakaido difficulty
   levels
+- `trace_sentence_pipeline.py` — run one sentence through all four
+  translate-and-decompose phases, printing every LLM result, lemma link, and
+  database write, plus estimated vs. actual output tokens per phase. Makes
+  real LLM calls; use `--dry-run` to skip persistence and
+  `GREENLAND_DISABLE_LLM=1` to block the calls entirely
 
 For repo-level checks and deployment helpers, see the top-level `scripts/`
 directory instead.

--- a/src/scripts/trace_sentence_pipeline.py
+++ b/src/scripts/trace_sentence_pipeline.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Run one sentence through the translate-and-decompose pipeline, out loud.
+
+Every phase prints what it sent, what came back, and what was written to the
+database. The pipeline normally reports only a summary, which is fine in bulk
+but useless when a single sentence comes out wrong: a mis-linked lemma or a
+dropped word is invisible until someone reads ``sentence_words`` by hand.
+
+The token accounting is the other reason this exists. Phases 3 and 4 size their
+requests from an estimate of the response (see ``sentences.token_estimates``),
+and an estimate nobody checks is a guess. Each phase prints estimated vs. actual
+output tokens and the ratio, so the constants can be tuned against real
+responses rather than arithmetic:
+
+    Phase 3   estimated 22300  requested 30205  actual 4182  (est/actual 5.33x)
+
+A ratio far above 1 means the estimate is wasteful; below 1 means it is
+dangerous, since the request would have been truncated. Numbers land in the
+"Token accounting" summary at the end of the run.
+
+This makes real LLM calls and costs real money. It writes to the database by
+default because the point is to exercise the storage path -- column types,
+coercion, NULL handling -- that a print-and-exit script leaves untested. Use
+--dry-run to skip persistence, and GREENLAND_DISABLE_LLM=1 to block the calls
+entirely (the run then fails loudly rather than reaching a paid backend).
+
+Examples:
+    PYTHONPATH=src python src/scripts/trace_sentence_pipeline.py \\
+        --sentence "The probate court has jurisdiction." --language en
+
+    PYTHONPATH=src python src/scripts/trace_sentence_pipeline.py \\
+        --sentence "..." --language en \\
+        --decompose-languages en,fr,es --annotate-dependencies
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+if str(Path(__file__).parent.parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agents.common.common_args import (
+    add_backend_args,
+    add_common_args,
+    add_llm_args,
+    get_data_source_config,
+)
+from clients.lib import limit_from_estimate
+from clients.unified_client import UnifiedLLMClient
+from sentences.token_estimates import (
+    estimate_decomposition_output_tokens,
+    estimate_dependency_output_tokens,
+    estimate_translation_output_tokens,
+)
+from sentences.translate_and_decompose import (
+    DEFAULT_MODEL,
+    TranslateAndDecomposeResult,
+    annotate_dependencies_for_result,
+    decompose_with_existing_translations,
+    lookup_candidate_lemmas,
+    translate_sentence_text,
+)
+from sentences.translation import store_translation_results
+from storage.backend.factory import create_session
+from storage.crud.sentence import add_sentence
+from storage.models.schema import SentenceTranslation, SentenceWord
+
+_RULE = "=" * 78
+_THIN = "-" * 78
+
+
+class RecordingClient(UnifiedLLMClient):
+    """A real client that also records what each call requested and got back.
+
+    The pipeline does not surface per-call usage to its callers, and the whole
+    point here is comparing the estimate against the actual response size, so
+    the numbers are captured at the one place every phase passes through.
+    Subclasses rather than wraps so the pipeline's type expectations hold and
+    every other method behaves exactly as in production.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.calls: List[Dict[str, Any]] = []
+
+    def generate_chat(self, *args: Any, **kwargs: Any) -> Any:
+        response = super().generate_chat(*args, **kwargs)
+        usage = getattr(response, "usage", None)
+        self.calls.append(
+            {
+                "max_tokens": kwargs.get("max_tokens"),
+                "tokens_in": getattr(usage, "tokens_in", None),
+                "tokens_out": getattr(usage, "tokens_out", None),
+            }
+        )
+        return response
+
+    def tokens_out_since(self, index: int) -> Optional[int]:
+        """Total output tokens across calls made after ``index``."""
+        recent = [
+            call["tokens_out"] for call in self.calls[index:] if isinstance(call["tokens_out"], int)
+        ]
+        return sum(recent) if recent else None
+
+
+class TokenLedger:
+    """Records estimated vs. actual output tokens for each phase."""
+
+    def __init__(self) -> None:
+        self.rows: List[Dict[str, Any]] = []
+
+    def record(
+        self, phase: str, estimated: Optional[int], requested: Optional[int], actual: Optional[int]
+    ) -> None:
+        self.rows.append(
+            {"phase": phase, "estimated": estimated, "requested": requested, "actual": actual}
+        )
+
+    def report(self) -> None:
+        print()
+        print(_RULE)
+        print("Token accounting")
+        print(_RULE)
+        if not self.rows:
+            print("  (no phases ran)")
+            return
+        print(f"  {'phase':<24}{'estimated':>11}{'requested':>11}{'actual':>9}  ratio")
+        for row in self.rows:
+            estimated = row["estimated"]
+            actual = row["actual"]
+            if estimated is not None and isinstance(actual, int) and actual > 0:
+                ratio = f"{estimated / actual:.2f}x"
+            else:
+                ratio = "-"
+            print(
+                f"  {row['phase']:<24}"
+                f"{_fmt(estimated):>11}{_fmt(row['requested']):>11}{_fmt(actual):>9}  {ratio}"
+            )
+        print()
+        print(
+            "  ratio = estimated / actual. Well above 1.0 means the estimate is\n"
+            "  wasteful; below 1.0 means the request would have been truncated."
+        )
+
+
+def _fmt(value: Optional[int]) -> str:
+    return "-" if value is None else str(value)
+
+
+def _heading(text: str) -> None:
+    print()
+    print(_RULE)
+    print(text)
+    print(_RULE)
+
+
+def _print_words(words: Sequence[Dict[str, Any]]) -> None:
+    if not words:
+        print("    (no words returned)")
+        return
+    header = f"    {'pos':>3}  {'surface':<18}{'lemma_guid':<12}{'part_of_speech':<16}gloss"
+    print(header)
+    for word in words:
+        guid = str(word.get("lemma_guid", ""))
+        # A synthetic id means the model found no matching lemma in the DB; a
+        # real GUID is a claim about an existing one and is what goes wrong
+        # silently, so flag it for the reader.
+        marker = " " if guid.startswith("SYN") or not guid else "*"
+        print(
+            f"  {marker} {str(word.get('position', '')):>3}  "
+            f"{str(word.get('surface_form', '')):<18}"
+            f"{guid:<12}"
+            f"{str(word.get('part_of_speech', '')):<16}"
+            f"{word.get('english_gloss', '')}"
+        )
+    print("    (* = linked to an existing database lemma; verify these)")
+
+
+def trace_pipeline(args: argparse.Namespace) -> int:
+    config = get_data_source_config(args, default_model=args.model)
+    session = create_session(config)
+    client = RecordingClient(
+        debug=args.debug,
+        openai_api_key=config.openai_api_key,
+        anthropic_api_key=config.anthropic_api_key,
+        google_api_key=config.google_api_key,
+    )
+    ledger = TokenLedger()
+
+    source_text = args.sentence.strip()
+    source_language = args.language
+    target_languages = [lang.strip() for lang in args.target_languages.split(",") if lang.strip()]
+    decompose_languages = [
+        lang.strip() for lang in args.decompose_languages.split(",") if lang.strip()
+    ]
+
+    _heading("Input")
+    print(f"  sentence          : {source_text!r}")
+    print(f"  source language   : {source_language}")
+    print(f"  target languages  : {', '.join(target_languages)}")
+    print(f"  decompose         : {', '.join(decompose_languages)}")
+    print(f"  model             : {args.model}")
+    print(f"  persist to db     : {not args.dry_run}")
+
+    result = TranslateAndDecomposeResult(
+        source_sentence=source_text, source_language=source_language
+    )
+
+    # ----------------------------------------------------------------- Phase 1
+    _heading("Phase 1 - sentence translation (LLM)")
+    phase1_estimate = estimate_translation_output_tokens(
+        source_text=source_text,
+        source_language=source_language,
+        target_languages=target_languages,
+    )
+    print(f"  estimated output tokens : {phase1_estimate}")
+    print(f"  requested max_tokens    : {limit_from_estimate(phase1_estimate)}")
+
+    phase1_mark = len(client.calls)
+    translations = translate_sentence_text(
+        sentence_text=source_text,
+        source_language=source_language,
+        target_languages=target_languages,
+        client=client,
+        model=args.model,
+    )
+    if not translations:
+        print("  FAILED: Phase 1 returned no translations; nothing further to do.")
+        ledger.report()
+        return 1
+    result.translations = dict(translations)
+    ledger.record(
+        "Phase 1 translate",
+        phase1_estimate,
+        limit_from_estimate(phase1_estimate),
+        client.tokens_out_since(phase1_mark),
+    )
+
+    print()
+    for language_code, text in translations.items():
+        print(f"  {language_code:<4} {text}")
+
+    # ----------------------------------------------------------------- Phase 2
+    _heading("Phase 2 - candidate lemma lookup (database, no LLM)")
+    candidates = lookup_candidate_lemmas(
+        session=session,
+        translations=translations,
+        source_languages=list(translations.keys()),
+    )
+    result.candidate_lemmas = list(candidates)
+    print(f"  {len(candidates)} candidate lemma(s) offered to Phase 3")
+    print()
+    if candidates:
+        print(f"  {'guid':<12}{'lemma':<20}{'score':>5}  matched languages")
+        for candidate in candidates:
+            print(
+                f"  {candidate.guid:<12}{candidate.lemma_text:<20}"
+                f"{candidate.match_score:>5}  {', '.join(candidate.matched_languages)}"
+            )
+        print()
+        print(
+            "  NOTE: match_score is a sort key, never a threshold. A candidate\n"
+            "  confirmed by one language can still be adopted by Phase 3 even when\n"
+            "  other languages disagree -- that is how a zh homograph linked\n"
+            "  'procedure' to the lemma 'program'."
+        )
+
+    # ----------------------------------------------------------------- Phase 3
+    _heading("Phase 3 - word decomposition (LLM)")
+    target_translations = {
+        lang: translations[lang] for lang in decompose_languages if lang in translations
+    }
+    missing = [lang for lang in decompose_languages if lang not in translations]
+    if missing:
+        print(f"  skipping (no Phase 1 translation): {', '.join(missing)}")
+    phase3_estimate = estimate_decomposition_output_tokens(target_translations=target_translations)
+    print(f"  estimated output tokens : {phase3_estimate}")
+    print(f"  requested max_tokens    : {limit_from_estimate(phase3_estimate)}")
+
+    phase3_mark = len(client.calls)
+    decompose_with_existing_translations(
+        sentence_text=source_text,
+        source_language=source_language,
+        translations=translations,
+        session=session,
+        client=client,
+        decompose_languages=list(target_translations.keys()),
+        model=args.model,
+        result=result,
+    )
+    phase3_actual = client.tokens_out_since(phase3_mark)
+
+    for language_code, decomposition in result.decompositions.items():
+        print()
+        print(f"  --- {language_code} " + _THIN[: 74 - len(language_code)])
+        print(f"    translation : {decomposition.translation}")
+        print(f"    success     : {decomposition.success}")
+        if decomposition.error:
+            print(f"    error       : {decomposition.error}")
+        if decomposition.missing_surface_forms:
+            # Tokens present in the translation but absent from the breakdown.
+            # A trailing run of these is the signature of a truncated response.
+            print(f"    MISSING     : {', '.join(decomposition.missing_surface_forms)}")
+        print(f"    words       : {len(decomposition.words)}")
+        _print_words(decomposition.words)
+
+    ledger.record(
+        "Phase 3 decompose",
+        phase3_estimate,
+        limit_from_estimate(phase3_estimate),
+        phase3_actual,
+    )
+
+    # ----------------------------------------------------------------- Phase 4
+    if args.annotate_dependencies:
+        _heading("Phase 4 - Universal Dependencies (LLM, one call per language)")
+        total_estimate = 0
+        for language_code, decomposition in result.decompositions.items():
+            if not decomposition.success or not decomposition.words:
+                continue
+            estimate = estimate_dependency_output_tokens(word_count=len(decomposition.words))
+            total_estimate += estimate
+            print(
+                f"  {language_code}: {len(decomposition.words)} words, "
+                f"estimated {estimate}, requested {limit_from_estimate(estimate)}"
+            )
+
+        phase4_mark = len(client.calls)
+        annotated = annotate_dependencies_for_result(result=result, client=client, model=args.model)
+        phase4_actual = client.tokens_out_since(phase4_mark)
+
+        print()
+        for language_code, decomposition in result.decompositions.items():
+            status = "annotated" if decomposition.ud_annotated else "NOT annotated"
+            print(f"  {language_code}: {status}")
+            if decomposition.ud_error:
+                # The distinction the pipeline used to discard: a rejected tree
+                # and a tree that was never requested both leave zero UD rows.
+                print(f"    reason: {decomposition.ud_error}")
+            if decomposition.ud_annotated:
+                for word in decomposition.words:
+                    print(
+                        f"      {str(word.get('position', '')):>3}  "
+                        f"{str(word.get('surface_form', '')):<18}"
+                        f"{str(word.get('ud_relation', '')):<12}"
+                        f"head={word.get('ud_head_position')}"
+                    )
+        ledger.record("Phase 4 dependencies", total_estimate, None, phase4_actual)
+        print()
+        print(f"  annotated {sum(1 for ok in annotated.values() if ok)}/{len(annotated)} languages")
+
+    # ---------------------------------------------------------------- Persist
+    _heading("Database writes")
+    if args.dry_run:
+        print("  --dry-run: nothing written.")
+    else:
+        sentence = add_sentence(
+            session,
+            source_filename=args.source_filename,
+            notes=f"trace_sentence_pipeline: {source_text[:60]}",
+        )
+        session.flush()
+        print(f"  created Sentence id={sentence.id} guid={sentence.guid}")
+
+        # Flatten into the {lang: text, words_lang: [...]} shape the ordinary
+        # persistence path consumes, so this exercises the same writer the real
+        # callers use rather than a bespoke one.
+        payload: Dict[str, Any] = dict(result.translations)
+        for language_code, decomposition in result.decompositions.items():
+            if not decomposition.success:
+                print(f"  skipping words_{language_code}: decomposition failed")
+                continue
+            payload[f"words_{language_code}"] = list(decomposition.words)
+
+        store_translation_results(sentence.id, payload, session)
+        session.commit()
+
+        stored_translations = (
+            session.query(SentenceTranslation).filter_by(sentence_id=sentence.id).all()
+        )
+        stored_words = session.query(SentenceWord).filter_by(sentence_id=sentence.id).all()
+        print(f"  wrote {len(stored_translations)} SentenceTranslation row(s)")
+        print(f"  wrote {len(stored_words)} SentenceWord row(s)")
+        print()
+        by_language: Dict[str, int] = {}
+        linked = 0
+        for word_row in stored_words:
+            language_key = word_row.language_code
+            by_language[language_key] = by_language.get(language_key, 0) + 1
+            if word_row.lemma_id is not None:
+                linked += 1
+        for language_code, count in sorted(by_language.items()):
+            print(f"    {language_code}: {count} word(s)")
+        print(f"    {linked} of {len(stored_words)} word(s) linked to an existing lemma")
+
+    ledger.report()
+    return 0
+
+
+def get_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run one sentence through the pipeline, printing every step",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_common_args(parser)
+    add_llm_args(parser, default_model=DEFAULT_MODEL)
+    add_backend_args(parser)
+
+    parser.add_argument("--sentence", required=True, help="Sentence text to process")
+    parser.add_argument(
+        "--language", default="en", help="Source language code of the sentence (default: en)"
+    )
+    parser.add_argument(
+        "--target-languages",
+        default="en,es,fr,zh,lt",
+        help="Comma-separated Phase-1 target languages (default: en,es,fr,zh,lt)",
+    )
+    parser.add_argument(
+        "--decompose-languages",
+        default="en",
+        help=(
+            "Comma-separated languages to decompose in Phase 3. Each must be a "
+            "Phase-1 target. Default 'en' matches what genys does today."
+        ),
+    )
+    parser.add_argument(
+        "--annotate-dependencies",
+        action="store_true",
+        help="Run the Phase-4 UD pass; costs one extra LLM call per language",
+    )
+    parser.add_argument(
+        "--source-filename",
+        default="trace_sentence_pipeline",
+        help="Value stored in Sentence.source_filename",
+    )
+    # --dry-run and --debug come from add_common_args.
+    return parser
+
+
+def main() -> int:
+    args = get_argument_parser().parse_args()
+    return trace_pipeline(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/sentences/batch_completion.py
+++ b/src/sentences/batch_completion.py
@@ -36,6 +36,31 @@ TRANSLATE_AGENT_NAME = "barsukas_translate"
 DECOMPOSE_AGENT_NAME = "barsukas_decompose"
 
 
+def _extract_batch_content(response: Dict[str, Any]) -> str:
+    """Pull the message content out of one batch result, refusing truncated ones.
+
+    ``finish_reason`` sits right next to the content and says whether the model
+    finished or ran out of room. Without this check a response cut off at the
+    token limit fails later on ``json.loads`` and is logged as an unspecified
+    parse error -- which, for a batch applied hours after submission, gives no
+    hint that the fix is a larger limit rather than a bad schema.
+
+    Raises:
+        ValueError: If the response was truncated or is missing its content.
+    """
+    choice = response["body"]["choices"][0]
+    finish_reason = choice.get("finish_reason")
+    if finish_reason == "length":
+        raise ValueError(
+            "Response truncated at the output token limit (finish_reason='length'); "
+            "the request needs a larger max_completion_tokens"
+        )
+    content = choice["message"]["content"]
+    if not content:
+        raise ValueError(f"Empty response content (finish_reason={finish_reason!r})")
+    return str(content)
+
+
 def apply_results_for_agent(
     agent_name: str, requests: Iterable[BatchQueue], session: Any, batch_id: str
 ) -> Dict[str, int]:
@@ -76,7 +101,7 @@ def apply_sentence_translation_results(
             if not req.response_body:
                 continue
             response = json.loads(req.response_body)
-            content = response["body"]["choices"][0]["message"]["content"]
+            content = _extract_batch_content(response)
             translations = json.loads(content)
 
             store_translation_results(sentence_id, translations, session)
@@ -118,7 +143,7 @@ def apply_phase1_translation_results(
             if not req.response_body:
                 continue
             response = json.loads(req.response_body)
-            content = response["body"]["choices"][0]["message"]["content"]
+            content = _extract_batch_content(response)
             translations = json.loads(content)
 
             translations_only = {

--- a/src/sentences/decomposition.py
+++ b/src/sentences/decomposition.py
@@ -501,14 +501,24 @@ def query_sentence_decomposition(
     model: str,
     json_schema: Dict[str, Any],
     context: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Execute a sentence decomposition/translation query and return structured JSON."""
+    """Execute a sentence decomposition/translation query and return structured JSON.
+
+    ``max_tokens`` should come from ``clients.lib.limit_from_estimate()`` applied
+    to an estimate from ``sentences.token_estimates``; a decomposition's size is
+    predictable from its word count, and the backend default is not large enough
+    for long sentences. A backend that hits its limit raises
+    ``TruncatedResponseError``, which is caught below and reported as a failed
+    call rather than a short one.
+    """
     try:
         response = client.generate_chat(
             prompt=prompt,
             model=model,
             json_schema=json_schema,
             context=context,
+            max_tokens=max_tokens,
         )
     except Exception as error:
         logger.error("Error querying sentence decomposition: %s", error)

--- a/src/sentences/dependencies.py
+++ b/src/sentences/dependencies.py
@@ -82,13 +82,18 @@ def build_dependency_schema(*, word_count: int) -> Dict[str, Any]:
     ``ud_head_position`` is bounded to ``[-1, word_count - 1]`` so a provider
     that enforces the schema rejects out-of-range heads structurally, and
     ``ud_relation`` is a closed enum of the core UD labels.
+
+    Only ``maxItems`` is pinned to the word count. Requiring ``minItems`` too
+    made a short response a provider-side schema violation, which surfaces as an
+    opaque API error; letting it through means ``validate_dependency_tree``
+    handles it instead and names the exact positions that are missing.
     """
     return {
         "type": "object",
         "properties": {
             "words": {
                 "type": "array",
-                "minItems": word_count,
+                "minItems": 1,
                 "maxItems": word_count,
                 "items": {
                     "type": "object",
@@ -120,7 +125,9 @@ def build_dependency_schema(*, word_count: int) -> Dict[str, Any]:
     }
 
 
-def validate_dependency_tree(words: List[Dict[str, Any]]) -> List[str]:
+def validate_dependency_tree(
+    words: List[Dict[str, Any]], *, expected_word_count: Optional[int] = None
+) -> List[str]:
     """Return human-readable structural problems with a dependency parse.
 
     Structural checks only — exactly one root, every position covered exactly
@@ -128,10 +135,18 @@ def validate_dependency_tree(words: List[Dict[str, Any]]) -> List[str]:
     linguistically apt (a ``det`` on a verb, say) is a judgment call the model
     makes better than a rule table would, so it is deliberately not checked.
 
+    ``expected_word_count`` is how many words the sentence actually has. Pass it:
+    without it the expected count is inferred from the response itself, so a
+    response that stops early is internally consistent and validates clean --
+    a truncated tree covering the first 30 of 45 words looks like a complete
+    30-word tree.
+
     An empty list means the parse is usable.
     """
     problems: List[str] = []
-    word_count = len(words)
+    word_count = expected_word_count if expected_word_count is not None else len(words)
+    if not words:
+        return ["No words returned"]
     if word_count == 0:
         return ["No words returned"]
 
@@ -229,14 +244,21 @@ def query_sentence_dependencies(
     model: str,
     json_schema: Dict[str, Any],
     context: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Execute a Phase-4 dependency query and return structured JSON."""
+    """Execute a Phase-4 dependency query and return structured JSON.
+
+    ``max_tokens`` should come from ``clients.lib.limit_from_estimate()`` applied
+    to ``token_estimates.estimate_dependency_output_tokens()``; the response is
+    one entry per word, so its size is known before the call.
+    """
     try:
         response = client.generate_chat(
             prompt=prompt,
             model=model,
             json_schema=json_schema,
             context=context,
+            max_tokens=max_tokens,
         )
     except Exception as error:
         logger.error("Error querying sentence dependencies: %s", error)

--- a/src/sentences/token_estimates.py
+++ b/src/sentences/token_estimates.py
@@ -1,0 +1,130 @@
+"""Output-size estimates for the sentence pipeline's LLM calls.
+
+Phase 3 (decomposition) and Phase 4 (dependencies) emit one JSON object per word
+per language, so their response size is predictable from the input: count the
+words, multiply. Every other property of the call is fixed.
+
+That matters because the alternative is discovering the size after the fact. A
+45-word sentence decomposed into several languages overruns a 4096-token default
+and comes back truncated mid-array, which is not distinguishable from a short
+answer without checking the provider's finish reason. Estimating up front and
+asking for the room we need turns that into a non-event.
+
+The estimate is deliberately generous. Guessing low truncates the response and
+fails the whole call; guessing high costs nothing, because output tokens are
+billed as generated, not as reserved. Callers pass the estimate through
+``clients.lib.limit_from_estimate()``, which owns the safety-margin policy.
+"""
+
+import logging
+from typing import Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Output tokens for one decomposed word. Each emits the seven fields of
+# build_decomposed_word_schema() -- position, part_of_speech, english_gloss,
+# surface_form, grammatical_form, lemma_guid, lemma -- as JSON with quoted keys.
+#
+# Measured at ~42 tokens/word on a real 5-language run (37 words, 1580 output
+# tokens; see scripts/trace_sentence_pipeline.py, which prints estimated vs.
+# actual). 60 keeps roughly 1.4x over that before limit_from_estimate() adds its
+# own margin. Isolated JSON objects encode at 55-60 tokens, but a real response
+# is compact and most words are short function words -- do not re-tune from a
+# hand-built sample.
+TOKENS_PER_DECOMPOSED_WORD: int = 60
+
+# Output tokens for one dependency entry: position, ud_relation,
+# ud_head_position. Much smaller than a decomposed word -- three short fields,
+# one of them a closed enum of relation labels. Measured at ~16 tokens/word.
+TOKENS_PER_DEPENDENCY_WORD: int = 22
+
+# Output tokens per word of a Phase-1 translated sentence. Phase 1 emits only
+# the sentence text per language, no per-word breakdown, so this is ordinary
+# prose. Measured at ~2 tokens/word/language for Latin and CJK targets; 5 keeps
+# headroom for scripts that tokenize far less efficiently (Cyrillic,
+# Devanagari, Kannada), which the measured run did not include.
+TOKENS_PER_TRANSLATED_WORD: int = 5
+
+# Fixed per-call cost that does not scale with word count: the response
+# envelope, per-language wrapper objects, and any word_count field.
+DECOMPOSITION_OVERHEAD_TOKENS: int = 400
+DEPENDENCY_OVERHEAD_TOKENS: int = 200
+TRANSLATION_OVERHEAD_TOKENS: int = 200
+
+# Per-language overhead in a combined multi-language decomposition, which nests
+# each language's word array under its own key.
+DECOMPOSITION_PER_LANGUAGE_OVERHEAD_TOKENS: int = 60
+
+# Languages that do not separate words with whitespace, so splitting on it
+# undercounts badly. Kept in sync with the set of the same name in
+# translate_and_decompose; duplicated rather than imported to avoid a circular
+# import, since that module imports this one.
+_NO_WHITESPACE_LANGUAGES = frozenset({"zh", "ja", "th", "lo", "km", "my"})
+
+# Characters per word assumed for the languages above. CJK averages well under
+# two characters per word, so this over-counts, which is the safe direction.
+_CHARS_PER_WORD_NO_WHITESPACE: int = 2
+
+
+def estimate_word_count(text: str, language_code: str) -> int:
+    """Estimate how many words the LLM will emit for a translation.
+
+    Whitespace splitting for languages that use it, character count for those
+    that do not. This only has to be close enough to size a request; it is not
+    the tokenization used for coverage checks.
+    """
+    if not text or not text.strip():
+        return 0
+    if language_code.lower() in _NO_WHITESPACE_LANGUAGES:
+        stripped = "".join(text.split())
+        return max(len(stripped) // _CHARS_PER_WORD_NO_WHITESPACE, 1)
+    return len(text.split())
+
+
+def estimate_decomposition_output_tokens(*, target_translations: Mapping[str, str]) -> int:
+    """Estimate the response size of a Phase-3 decomposition call.
+
+    Args:
+        target_translations: language_code -> translation text, exactly the
+            mapping the decomposition call will be asked to break down. A
+            single-language call passes a one-entry mapping.
+
+    Returns:
+        Estimated output tokens. Pass to clients.lib.limit_from_estimate() to
+        get a token limit; do not use as the limit directly.
+    """
+    if not target_translations:
+        return DECOMPOSITION_OVERHEAD_TOKENS
+
+    total = DECOMPOSITION_OVERHEAD_TOKENS
+    for language_code, text in target_translations.items():
+        word_count = estimate_word_count(text, language_code)
+        total += word_count * TOKENS_PER_DECOMPOSED_WORD
+        total += DECOMPOSITION_PER_LANGUAGE_OVERHEAD_TOKENS
+    return total
+
+
+def estimate_translation_output_tokens(
+    *, source_text: str, source_language: str, target_languages: Sequence[str]
+) -> int:
+    """Estimate the response size of a Phase-1 translation call.
+
+    The translations do not exist yet, so their length is estimated from the
+    source sentence. Translations vary in length, but not by enough to matter
+    against the headroom ``limit_from_estimate()`` adds.
+    """
+    word_count = estimate_word_count(source_text, source_language)
+    return TRANSLATION_OVERHEAD_TOKENS + word_count * TOKENS_PER_TRANSLATED_WORD * max(
+        len(target_languages), 1
+    )
+
+
+def estimate_dependency_output_tokens(*, word_count: int) -> int:
+    """Estimate the response size of a Phase-4 dependency call.
+
+    Phase 4 runs per language over an already-decomposed word list, so the word
+    count is known exactly rather than estimated.
+    """
+    if word_count < 0:
+        word_count = 0
+    return DEPENDENCY_OVERHEAD_TOKENS + word_count * TOKENS_PER_DEPENDENCY_WORD

--- a/src/sentences/translate_and_decompose.py
+++ b/src/sentences/translate_and_decompose.py
@@ -37,6 +37,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from sqlalchemy.orm import Session
 
+from clients.lib import limit_from_estimate
 from clients.unified_client import UnifiedLLMClient
 from langtools.dialect_overrides import get_dialect_display_name, get_llm_prompt_note
 from langtools.directions import get_language_direction_note
@@ -61,6 +62,10 @@ from sentences.dependencies import (
     query_sentence_dependencies,
     validate_dependency_tree,
 )
+from sentences.token_estimates import (
+    estimate_decomposition_output_tokens,
+    estimate_dependency_output_tokens,
+)
 from storage.translation_helpers import LANGUAGE_NAMES, normalize_llm_language_codes
 from util.prompt_loader import get_context, get_prompt
 
@@ -68,7 +73,16 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL: str = "gpt-5.4-mini"
 
-# Synthetic GUID prefix — LLM-emitted placeholder for "no DB lemma matched".
+# DEPRECATED. Synthetic GUID prefix — an LLM-emitted placeholder for "no DB
+# lemma matched", e.g. SYN001. No prompt asks for these any more: every
+# decomposition path now says to use NONE, which the same checks already reject.
+#
+# It never carried information. Consumers only ever asked "is this a real GUID?",
+# so a synthetic id and NONE were treated identically, and the instruction to
+# reuse one id for the same concept across languages produced a grouping that was
+# discarded on arrival. Keeping the checks is cheap insurance against a model
+# emitting the old format from memory; a run that trips them is worth
+# investigating rather than trusting.
 SYNTHETIC_GUID_PREFIX: str = "SYN"
 
 
@@ -82,6 +96,13 @@ class DecomposedLanguage:
     success: bool = True
     error: Optional[str] = None
     missing_surface_forms: List[str] = field(default_factory=list)
+    # Phase 4 outcome. ud_annotated is True only when a complete, valid tree was
+    # written. The pair distinguishes "Phase 4 never ran" (False, None) from
+    # "Phase 4 ran and its tree was rejected" (False, "Cycle in head graph: ..."),
+    # which is otherwise invisible -- a rejected sentence and an unannotated one
+    # look identical in the database.
+    ud_annotated: bool = False
+    ud_error: Optional[str] = None
 
 
 # Languages that don't separate words with whitespace; per-word coverage cannot
@@ -164,6 +185,56 @@ def _find_missing_surface_forms(
             continue
         missing.append(token)
     return translation_tokens, missing
+
+
+# How many missing surface forms to tolerate before failing a decomposition.
+# _find_missing_surface_forms is deliberately lenient -- the LLM may merge or
+# split tokens legitimately -- so an isolated miss is usually a tokenization
+# artifact rather than lost data. A truncation is not isolated: it drops
+# everything from some point to the end of the sentence, which
+# _missing_is_trailing_run detects regardless of count.
+MAX_TOLERATED_MISSING_TOKENS: int = 1
+
+
+def _incompleteness_error(
+    translation_tokens: List[str], missing_tokens: List[str]
+) -> Optional[str]:
+    """Return an error message when a decomposition is too incomplete to store.
+
+    Returns None when the gaps are within tolerance and the result should be
+    kept. Storing a truncated breakdown as if it were complete is how a
+    45-word sentence ends up with half its words missing and a dependency tree
+    built over the remainder.
+    """
+    if not missing_tokens:
+        return None
+    if _missing_is_trailing_run(translation_tokens, missing_tokens):
+        return (
+            f"Decomposition truncated: the last {len(missing_tokens)} of "
+            f"{len(translation_tokens)} translation tokens are absent from the word "
+            f"list ({', '.join(missing_tokens)})"
+        )
+    if len(missing_tokens) > MAX_TOLERATED_MISSING_TOKENS:
+        return (
+            f"Decomposition incomplete: {len(missing_tokens)} of "
+            f"{len(translation_tokens)} translation tokens are absent from the word "
+            f"list ({', '.join(missing_tokens)})"
+        )
+    return None
+
+
+def _missing_is_trailing_run(translation_tokens: List[str], missing_tokens: List[str]) -> bool:
+    """True when the missing tokens are exactly the tail of the translation.
+
+    The signature of a response cut off at the output-token limit: the word list
+    stops partway and every token after that point is absent. A scattered miss
+    in the middle of an otherwise complete breakdown is a different problem and
+    is tolerated by the caller.
+    """
+    if not missing_tokens or not translation_tokens:
+        return False
+    tail = translation_tokens[-len(missing_tokens) :]
+    return tail == missing_tokens
 
 
 @dataclass
@@ -371,12 +442,16 @@ def decompose_language(
     context = build_sentence_decomposition_context()
     schema = build_single_language_decomposition_schema()
 
+    estimated_tokens = estimate_decomposition_output_tokens(
+        target_translations={target_language: target_translation}
+    )
     result = query_sentence_decomposition(
         prompt=prompt,
         client=client,
         model=model,
         json_schema=schema,
         context=context,
+        max_tokens=limit_from_estimate(estimated_tokens),
     )
     if not result.get("success"):
         return DecomposedLanguage(
@@ -438,11 +513,13 @@ def decompose_language(
                 last_surface,
             )
 
+    incomplete_error = _incompleteness_error(translation_tokens, missing_tokens)
     return DecomposedLanguage(
         language_code=target_language,
         translation=target_translation,
         words=words,
-        success=True,
+        success=incomplete_error is None,
+        error=incomplete_error,
         missing_surface_forms=missing_tokens,
     )
 
@@ -479,12 +556,17 @@ def decompose_languages_combined(
     context = build_multi_language_decomposition_context()
     schema = build_multi_language_decomposition_schema(target_languages=target_languages)
 
+    # Size the request from the work it asks for: the response carries one word
+    # object per token per language, so a long sentence in several languages
+    # overruns the backend default and comes back truncated.
+    estimated_tokens = estimate_decomposition_output_tokens(target_translations=target_translations)
     result = query_sentence_decomposition(
         prompt=prompt,
         client=client,
         model=model,
         json_schema=schema,
         context=context,
+        max_tokens=limit_from_estimate(estimated_tokens),
     )
     if not result.get("success"):
         error = str(result.get("error", "unknown error"))
@@ -539,11 +621,13 @@ def decompose_languages_combined(
                     last_surface,
                 )
 
+        incomplete_error = _incompleteness_error(translation_tokens, missing_tokens)
         decompositions[lang] = DecomposedLanguage(
             language_code=lang,
             translation=target_translation,
             words=words,
-            success=True,
+            success=incomplete_error is None,
+            error=incomplete_error,
             missing_surface_forms=missing_tokens,
         )
     return decompositions
@@ -577,13 +661,16 @@ def annotate_language_dependencies(
         model=model,
         json_schema=build_dependency_schema(word_count=word_count),
         context=build_dependency_context(),
+        max_tokens=limit_from_estimate(estimate_dependency_output_tokens(word_count=word_count)),
     )
     if not result.get("success"):
+        error = str(result.get("error", "unknown error"))
         logger.warning(
             "Phase 4 dependency call failed for language=%s: %s",
             decomposition.language_code,
-            result.get("error", "unknown error"),
+            error,
         )
+        decomposition.ud_error = error
         return False
 
     raw_words = result.get("words")
@@ -591,14 +678,16 @@ def annotate_language_dependencies(
         [w for w in raw_words if isinstance(w, dict)] if isinstance(raw_words, list) else []
     )
 
-    problems = validate_dependency_tree(annotations)
+    problems = validate_dependency_tree(annotations, expected_word_count=word_count)
     if problems:
+        joined = "; ".join(problems)
         logger.warning(
             "Phase 4 dependency tree rejected for language=%s (translation=%r): %s",
             decomposition.language_code,
             decomposition.translation,
-            "; ".join(problems),
+            joined,
         )
+        decomposition.ud_error = f"Dependency tree rejected: {joined}"
         return False
 
     annotations_by_position = {entry["position"]: entry for entry in annotations}
@@ -615,10 +704,12 @@ def annotate_language_dependencies(
                 decomposition.language_code,
                 position,
             )
+            decomposition.ud_error = f"No annotation returned for position {position}"
             return False
         word["ud_relation"] = annotation["ud_relation"]
         word["ud_head_position"] = annotation["ud_head_position"]
 
+    decomposition.ud_annotated = True
     return True
 
 
@@ -627,14 +718,31 @@ def annotate_dependencies_for_result(
     result: "TranslateAndDecomposeResult",
     client: UnifiedLLMClient,
     model: str = DEFAULT_MODEL,
-) -> None:
-    """Run Phase 4 over every successfully decomposed language in ``result``."""
-    for decomposition in result.decompositions.values():
-        annotate_language_dependencies(
+) -> Dict[str, bool]:
+    """Run Phase 4 over every successfully decomposed language in ``result``.
+
+    Returns language_code -> whether that language was annotated. Callers should
+    look at it: a rejected tree leaves the sentence with no UD data at all, and
+    silently discarding this made that indistinguishable from Phase 4 never
+    having been requested.
+    """
+    annotated: Dict[str, bool] = {}
+    for language_code, decomposition in result.decompositions.items():
+        annotated[language_code] = annotate_language_dependencies(
             decomposition=decomposition,
             client=client,
             model=model,
         )
+
+    failed = [lang for lang, ok in annotated.items() if not ok]
+    if failed:
+        logger.info(
+            "Phase 4 annotated %d/%d languages; no UD data for: %s",
+            len(annotated) - len(failed),
+            len(annotated),
+            ", ".join(sorted(failed)),
+        )
+    return annotated
 
 
 # --------------------------------------------------------------------------- #

--- a/src/sentences/translation.py
+++ b/src/sentences/translation.py
@@ -378,13 +378,25 @@ def store_translation_results(
 
         # Add detailed word records
         for position, word_data in enumerate(words_data):
-            # Find matching lemma by GUID if provided. Synthetic GUIDs are
-            # placeholders emitted for words with no real lemma; never resolve them.
+            # Find matching lemma by GUID if provided. "NONE" is what the prompts
+            # ask for when no database lemma matches the word.
             lemma_id = None
             guid = _clean_word_field(word_data.get("lemma_guid"))
+            # DEPRECATED: no prompt asks for SYN### ids any more. Kept because a
+            # model can still emit the old format from memory, in which case the
+            # id must not be looked up -- see SYNTHETIC_GUID_PREFIX in
+            # sentences.translate_and_decompose.
             is_synthetic_guid = guid.startswith("SYN") and guid[3:].isdigit()
+            if is_synthetic_guid:
+                logger.warning(
+                    "Deprecated synthetic lemma_guid %r for sentence %s; prompts ask "
+                    "for NONE. Treating as unmatched.",
+                    guid,
+                    sentence_id,
+                )
+            is_unmatched = guid.lower() in {"none", "null"}
 
-            if guid and not is_synthetic_guid:
+            if guid and not is_synthetic_guid and not is_unmatched:
                 # Look up lemma by GUID
                 lemma = session.query(Lemma).filter_by(guid=guid).first()
                 if lemma:

--- a/src/tests/clients/test_truncation_detection.py
+++ b/src/tests/clients/test_truncation_detection.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python3
+"""Tests for output-token limits and truncation detection.
+
+The bug these cover: a response cut off at the token limit used to be reported
+as a *successful* call. The OpenAI client returned ``{"error": ...}`` as its
+structured data, and callers merge structured data into their result dict, so
+the truncated fragment arrived downstream looking like an answer. A 45-word
+sentence would be stored with half its words missing.
+"""
+
+import os
+import sys
+import unittest
+from typing import Any, Dict, Optional
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from clients import lib
+from clients.openai.client import OpenAIClient
+
+
+class LimitFromEstimateTestCase(unittest.TestCase):
+    """The estimate -> limit policy, tuned in one place for every caller."""
+
+    def test_applies_headroom_above_the_floor(self) -> None:
+        # 1.35x + 100, so a 1000-token estimate asks for 1450.
+        self.assertEqual(lib.limit_from_estimate(1000), 1450)
+
+    def test_small_estimates_get_the_floor(self) -> None:
+        """A tiny estimate should not produce an absurdly tight limit."""
+        self.assertEqual(lib.limit_from_estimate(0), lib.MIN_ESTIMATED_LIMIT_TOKENS)
+        self.assertEqual(lib.limit_from_estimate(10), lib.MIN_ESTIMATED_LIMIT_TOKENS)
+
+    def test_is_monotonic(self) -> None:
+        limits = [lib.limit_from_estimate(estimate) for estimate in (500, 1000, 2000, 4000)]
+        self.assertEqual(limits, sorted(limits))
+
+    def test_long_sentence_estimate_exceeds_the_old_hardcoded_cap(self) -> None:
+        """The regression that motivated all of this.
+
+        A 45-word sentence decomposed into several languages needs more than the
+        4096 tokens that used to be hardcoded; if this stops holding, long
+        sentences are silently back to being truncated.
+        """
+        self.assertGreater(lib.limit_from_estimate(3600), 4096)
+
+
+class ResolveOutputTokensTestCase(unittest.TestCase):
+    """Backwards compatibility is the point: no caller should shift silently."""
+
+    def test_none_reproduces_the_backend_default(self) -> None:
+        self.assertEqual(
+            lib.resolve_output_tokens(
+                "gpt-5.4-mini", brief=False, requested=None, backend_default=4096
+            ),
+            4096,
+        )
+
+    def test_none_with_brief_reproduces_the_brief_default(self) -> None:
+        self.assertEqual(
+            lib.resolve_output_tokens(
+                "gpt-5.4-mini", brief=True, requested=None, backend_default=4096
+            ),
+            512,
+        )
+        # Gemini's brief default differs and must be preserved.
+        self.assertEqual(
+            lib.resolve_output_tokens(
+                "gemini-2.5-flash",
+                brief=True,
+                requested=None,
+                backend_default=1536,
+                brief_default=256,
+            ),
+            256,
+        )
+
+    def test_explicit_request_wins_over_brief(self) -> None:
+        """max_tokens is the more specific knob, so it overrides the coarse one."""
+        self.assertEqual(
+            lib.resolve_output_tokens(
+                "gpt-5.4-mini", brief=True, requested=8000, backend_default=4096
+            ),
+            8000,
+        )
+
+    def test_request_is_clamped_to_the_model_ceiling(self) -> None:
+        resolved = lib.resolve_output_tokens(
+            "gemini-2.5-flash", brief=False, requested=999_999, backend_default=1536
+        )
+        self.assertEqual(resolved, lib.ceiling_for_model("gemini-2.5-flash"))
+
+    def test_unknown_model_falls_back_to_the_default_ceiling(self) -> None:
+        self.assertEqual(lib.ceiling_for_model("some-new-model"), lib.DEFAULT_OUTPUT_CEILING)
+
+    def test_default_pipeline_model_has_a_real_ceiling(self) -> None:
+        """Catches a model rename quietly dropping the pipeline to the fallback."""
+        from sentences.translate_and_decompose import DEFAULT_MODEL
+
+        self.assertGreater(lib.ceiling_for_model(DEFAULT_MODEL), lib.DEFAULT_OUTPUT_CEILING)
+
+
+def _openai_envelope(
+    *,
+    text: str,
+    status: str = "completed",
+    output_tokens: int = 10,
+    incomplete_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    """A minimal OpenAI Responses envelope in the shape the client parses."""
+    envelope: Dict[str, Any] = {
+        "status": status,
+        "output": [
+            {"type": "message", "content": [{"type": "output_text", "text": text}]},
+        ],
+        "usage": {"input_tokens": 5, "output_tokens": output_tokens},
+    }
+    if incomplete_reason is not None:
+        envelope["incomplete_details"] = {"reason": incomplete_reason}
+    return envelope
+
+
+class OpenAITruncationTestCase(unittest.TestCase):
+    """Truncation must surface as a raised error, never as response data."""
+
+    def setUp(self) -> None:
+        self.client = OpenAIClient()
+        self.client.api_key = "test-key-not-used"
+        self.schema = {"type": "object", "properties": {"words": {"type": "array"}}}
+
+    def _patch_response(self, envelope: Dict[str, Any]) -> None:
+        self.client._create_response = lambda **kwargs: (envelope, 1.0)  # type: ignore[method-assign]
+
+    def test_spending_the_whole_budget_is_truncation(self) -> None:
+        """The signal that needs no cooperation from the provider.
+
+        A response that ended on its own terms stops short of the cap, so
+        landing on it means the cap did the stopping -- true even when the
+        status flags say nothing.
+        """
+        self._patch_response(
+            _openai_envelope(text='{"words": [{"a": 1}', status="completed", output_tokens=512)
+        )
+        with self.assertRaises(lib.TruncatedResponseError) as caught:
+            self.client.generate_chat(
+                prompt="decompose this",
+                model="gpt-5.4-mini",
+                json_schema=self.schema,
+                max_tokens=512,
+            )
+        self.assertIn("512", str(caught.exception))
+
+    def test_incomplete_status_is_truncation(self) -> None:
+        self._patch_response(
+            _openai_envelope(
+                text='{"words": [',
+                status="incomplete",
+                output_tokens=100,
+                incomplete_reason="max_output_tokens",
+            )
+        )
+        with self.assertRaises(lib.TruncatedResponseError):
+            self.client.generate_chat(
+                prompt="decompose this",
+                model="gpt-5.4-mini",
+                json_schema=self.schema,
+                max_tokens=4096,
+            )
+
+    def test_incomplete_with_no_message_content_is_truncation(self) -> None:
+        """Reasoning models can return an incomplete envelope with no message."""
+        envelope: Dict[str, Any] = {
+            "status": "incomplete",
+            "output": [{"type": "reasoning", "summary": []}],
+            "usage": {"input_tokens": 5, "output_tokens": 100},
+        }
+        self._patch_response(envelope)
+        with self.assertRaises(lib.TruncatedResponseError):
+            self.client.generate_chat(
+                prompt="decompose this",
+                model="gpt-5.4-mini",
+                json_schema=self.schema,
+                max_tokens=4096,
+            )
+
+    def test_unparseable_json_raises_instead_of_returning_an_error_dict(self) -> None:
+        """The specific regression: an error payload used to read as success.
+
+        structured_data is merged into the caller's result, so returning
+        {"error": ...} produced a "successful" call with no words in it.
+        """
+        self._patch_response(
+            _openai_envelope(text="this is not json", status="completed", output_tokens=10)
+        )
+        with self.assertRaises(ValueError) as caught:
+            self.client.generate_chat(
+                prompt="decompose this",
+                model="gpt-5.4-mini",
+                json_schema=self.schema,
+                max_tokens=4096,
+            )
+        self.assertNotIsInstance(caught.exception, lib.TruncatedResponseError)
+
+    def test_complete_response_is_returned_normally(self) -> None:
+        """The common path stays untouched."""
+        self._patch_response(
+            _openai_envelope(text='{"words": ["ok"]}', status="completed", output_tokens=42)
+        )
+        response = self.client.generate_chat(
+            prompt="decompose this", model="gpt-5.4-mini", json_schema=self.schema, max_tokens=4096
+        )
+        self.assertEqual(response.structured_data, {"words": ["ok"]})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/tests/sentences/test_dependencies.py
+++ b/src/tests/sentences/test_dependencies.py
@@ -107,15 +107,42 @@ def test_schema_head_bounds_span_root_through_last_position() -> None:
     assert position_schema["maximum"] == word_count - 1
 
 
-def test_schema_requires_one_entry_per_token() -> None:
-    words_schema = build_dependency_schema(word_count=7)["properties"]["words"]
-    assert words_schema["minItems"] == 7
-    assert words_schema["maxItems"] == 7
+def test_schema_caps_entries_at_the_token_count() -> None:
+    """The upper bound is structural; the lower bound is left to validation.
+
+    Pinning ``minItems`` to the word count too made a short answer a provider
+    schema violation, which surfaces as an opaque API error instead of the
+    "Missing positions: ..." message validate_dependency_tree can produce.
+    """
+    word_count = 7
+    words_schema = build_dependency_schema(word_count=word_count)["properties"]["words"]
+    assert words_schema["minItems"] == 1
+    assert words_schema["maxItems"] == word_count
     assert set(words_schema["items"]["required"]) == {
         "position",
         "ud_relation",
         "ud_head_position",
     }
+
+
+def test_short_dependency_response_is_caught_by_validation() -> None:
+    """What the relaxed minItems delegates to validate_dependency_tree.
+
+    The expected count has to be supplied: a truncated response is internally
+    consistent, so inferring the count from the response itself makes a tree
+    covering the first 3 of 4 words look like a complete 3-word tree.
+    """
+    complete: List[Dict[str, Any]] = [
+        {"position": position, "ud_relation": "dep", "ud_head_position": 0} for position in range(4)
+    ]
+    complete[0]["ud_relation"] = "root"
+    complete[0]["ud_head_position"] = ROOT_HEAD_POSITION
+    assert validate_dependency_tree(complete, expected_word_count=4) == []
+
+    truncated = complete[:-1]
+    assert validate_dependency_tree(truncated) == []
+    problems = validate_dependency_tree(truncated, expected_word_count=4)
+    assert any("Missing positions: 3" in problem for problem in problems)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/tests/sentences/test_translate_and_decompose.py
+++ b/src/tests/sentences/test_translate_and_decompose.py
@@ -43,6 +43,7 @@ class _ScriptedLLMClient:
         model: str,
         json_schema: Optional[Dict[str, Any]] = None,
         context: Optional[str] = None,
+        max_tokens: Optional[int] = None,
     ) -> _FakeResponse:
         if not self._responses:
             raise AssertionError("Unexpected extra LLM call; no scripted response left")
@@ -53,9 +54,23 @@ class _ScriptedLLMClient:
                 "model": model,
                 "json_schema": json_schema,
                 "context": context,
+                "max_tokens": max_tokens,
             }
         )
         return _FakeResponse(payload)
+
+
+def _decomposed_word(position: int, surface_form: str, part_of_speech: str) -> Dict[str, Any]:
+    """One entry of a Phase-3 word list, in the shape the schema requires."""
+    return {
+        "position": position,
+        "part_of_speech": part_of_speech,
+        "english_gloss": surface_form,
+        "surface_form": surface_form,
+        "grammatical_form": None,
+        "lemma_guid": "SYN1",
+        "lemma": surface_form,
+    }
 
 
 def _make_session_with_no_candidates() -> Any:
@@ -106,6 +121,9 @@ def test_pipeline_translates_and_decomposes_english_by_default(
         "uk": "Я читаю книгу",
         "kn": "ನಾನು ಪುಸ್ತಕ ಓದುತ್ತೇನೆ",
     }
+    # The word list has to cover the translation: a breakdown that stops short
+    # of the last tokens is how a truncated response looks, and is now a failed
+    # decomposition rather than a partial one.
     phase3_payload = {
         "en": "I read a book",
         "words_en": [
@@ -127,6 +145,15 @@ def test_pipeline_translates_and_decomposes_english_by_default(
                 "lemma_guid": "SYN2",
                 "lemma": "read",
             },
+            {
+                "position": 2,
+                "part_of_speech": "noun",
+                "english_gloss": "a book",
+                "surface_form": "a book",
+                "grammatical_form": "singular",
+                "lemma_guid": "SYN3",
+                "lemma": "book",
+            },
         ],
     }
     client = _ScriptedLLMClient([phase1_payload, phase3_payload])
@@ -145,7 +172,7 @@ def test_pipeline_translates_and_decomposes_english_by_default(
     assert result.translations["fr"] == "Je lis un livre"
     assert "en" in result.decompositions
     assert result.decompositions["en"].success
-    assert len(result.decompositions["en"].words) == 2
+    assert len(result.decompositions["en"].words) == 3
     assert result.decompositions["en"].words[1]["surface_form"] == "read"
 
     assert len(client.calls) == 2
@@ -192,11 +219,19 @@ def test_pipeline_runs_phase3_in_one_combined_call(phase2_returns_a_candidate: N
         "uk": "Я читаю",
         "kn": "ನಾನು ಓದುತ್ತೇನೆ",
     }
+    # Cover every token: an empty word list is now a failed decomposition, and
+    # this test is about the call count, not about coverage.
     phase3_payload = {
         "fr": "Je lis",
-        "words_fr": [],
+        "words_fr": [
+            _decomposed_word(0, "Je", "pronoun"),
+            _decomposed_word(1, "lis", "verb"),
+        ],
         "lt": "Aš skaitau",
-        "words_lt": [],
+        "words_lt": [
+            _decomposed_word(0, "Aš", "pronoun"),
+            _decomposed_word(1, "skaitau", "verb"),
+        ],
     }
     client = _ScriptedLLMClient([phase1_payload, phase3_payload])
 

--- a/src/workqueue/handlers/sentences/batch_decompose_submit.py
+++ b/src/workqueue/handlers/sentences/batch_decompose_submit.py
@@ -23,7 +23,7 @@ from clients.batch_queue import (
     BatchRequestMetadata,
     create_batch_database_session,
 )
-from clients.lib import schema_from_dict, to_openai_schema
+from clients.lib import limit_from_estimate, schema_from_dict, to_openai_schema
 from clients.openai.batch_client import OpenAIBatchClient
 from clients.openai.client import is_gpt5_nano_or_mini_model, reasoning_effort_for_model
 from sentences.candidate_lookup import DEFAULT_SOURCE_LANGUAGES, CandidateLemma
@@ -32,6 +32,7 @@ from sentences.decomposition import (
     build_multi_language_decomposition_prompt,
     build_multi_language_decomposition_schema,
 )
+from sentences.token_estimates import estimate_decomposition_output_tokens
 from sentences.translate_and_decompose import lookup_candidate_lemmas
 from storage.models.schema import Sentence, SentenceTranslation
 from workqueue.tools import workqueue_payload_handler
@@ -146,9 +147,16 @@ def handle_sentences_batch_decompose_submit(
             )
             full_prompt = f"{context}\n\n{prompt}"
 
+            # Size the request from the work it asks for. A batch result is
+            # applied hours after submission, so a truncated one wastes the whole
+            # round trip -- worth more care here than on a synchronous call.
+            max_completion_tokens = limit_from_estimate(
+                estimate_decomposition_output_tokens(target_translations=target_translations)
+            )
             request_body: Dict[str, Any] = {
                 "model": model,
                 "messages": [{"role": "user", "content": full_prompt}],
+                "max_completion_tokens": max_completion_tokens,
                 "response_format": {
                     "type": "json_schema",
                     "json_schema": {

--- a/src/workqueue/handlers/sentences/batch_submit.py
+++ b/src/workqueue/handlers/sentences/batch_submit.py
@@ -25,9 +25,10 @@ from clients.batch_queue import (
     BatchRequestMetadata,
     create_batch_database_session,
 )
-from clients.lib import schema_from_dict, to_openai_schema
+from clients.lib import limit_from_estimate, schema_from_dict, to_openai_schema
 from clients.openai.batch_client import OpenAIBatchClient
 from clients.openai.client import is_gpt5_nano_or_mini_model, reasoning_effort_for_model
+from sentences.token_estimates import estimate_decomposition_output_tokens
 from sentences.translate_and_decompose import lookup_candidate_lemmas
 from sentences.translation import build_response_schema, build_translation_prompt
 from storage.models.schema import Lemma, Sentence, SentenceTranslation, SentenceWord
@@ -140,9 +141,23 @@ def handle_sentences_translate_batch_submit(
             schema = build_response_schema(request_targets, include_english)
             full_prompt = f"{context}\n\n{prompt}"
 
+            # The target translations do not exist yet -- this batch produces
+            # them -- so estimate every requested language from the source text.
+            # Word counts differ across languages, but not by enough to matter
+            # against the headroom limit_from_estimate() adds.
+            source_text = existing_translations[source_language]
+            estimate_languages = list(request_targets)
+            if include_english and "en" not in estimate_languages:
+                estimate_languages.append("en")
+            max_completion_tokens = limit_from_estimate(
+                estimate_decomposition_output_tokens(
+                    target_translations={lang: source_text for lang in estimate_languages}
+                )
+            )
             request_body: Dict[str, Any] = {
                 "model": model,
                 "messages": [{"role": "user", "content": full_prompt}],
+                "max_completion_tokens": max_completion_tokens,
                 "response_format": {
                     "type": "json_schema",
                     "json_schema": {

--- a/src/workqueue/handlers/sentences/batch_translate_submit.py
+++ b/src/workqueue/handlers/sentences/batch_translate_submit.py
@@ -24,10 +24,11 @@ from clients.batch_queue import (
     BatchRequestMetadata,
     create_batch_database_session,
 )
-from clients.lib import schema_from_dict, to_openai_schema
+from clients.lib import limit_from_estimate, schema_from_dict, to_openai_schema
 from clients.openai.batch_client import OpenAIBatchClient
 from clients.openai.client import is_gpt5_nano_or_mini_model, reasoning_effort_for_model
 from sentences.candidate_lookup import DEFAULT_SOURCE_LANGUAGES
+from sentences.token_estimates import estimate_translation_output_tokens
 from sentences.translate_and_decompose import build_phase1_prompt
 from storage.models.schema import Sentence, SentenceTranslation
 from workqueue.tools import workqueue_payload_handler
@@ -132,9 +133,17 @@ def handle_sentences_batch_translate_submit(
                 continue
             _context, _prompt, full_prompt, schema, _normalized_targets = built
 
+            max_completion_tokens = limit_from_estimate(
+                estimate_translation_output_tokens(
+                    source_text=source_translation,
+                    source_language=source_language,
+                    target_languages=_normalized_targets or phase1_targets,
+                )
+            )
             request_body: Dict[str, Any] = {
                 "model": model,
                 "messages": [{"role": "user", "content": full_prompt}],
+                "max_completion_tokens": max_completion_tokens,
                 "response_format": {
                     "type": "json_schema",
                     "json_schema": {


### PR DESCRIPTION
Long sentences silently overflowed the output token limit and the truncated result was stored as if complete. Three separate places laundered truncation into success:

* The OpenAI client returned {"error": ...} as structured_data on a JSON parse failure. Callers merge structured data into their result dict, so the fragment arrived downstream looking like an answer.
* No backend checked why generation stopped -- a grep for finish_reason / stop_reason / incomplete_details across src/clients returned nothing.
* _find_missing_surface_forms detected the dropped tokens, logged a warning whose comment already named truncation as the cause, then returned success=True anyway. Phase 4 then built a UD tree over the partial word list.

The token limit itself was hardcoded (4096 for OpenAI) with no override path.

Clients now take an optional max_tokens. clients.lib owns the policy in one tunable place: limit_from_estimate() turns a caller's estimate of its own response size into a limit, and resolve_output_tokens() clamps to a per-model ceiling. Passing nothing reproduces each backend's previous number exactly, so no existing caller shifts.

Truncation is detected primarily by output_tokens reaching the limit, which needs no cooperation from the provider -- a response that ended on its own terms stops short of the cap. Provider flags are checked too, since they name the reason. Backends raise TruncatedResponseError; the query wrappers' existing try/except converts that to {"success": False} with no downstream change.

sentences/token_estimates.py sizes Phase 1/3/4 from word and language counts. Constants are calibrated against two real 5-language runs (~42 tokens per decomposed word, ~16 per dependency entry) rather than arithmetic, landing at ~1.6x actual before the safety margin.

Also in this change:

* Incomplete decompositions now fail rather than storing as complete, with a trailing-run check separating truncation from a scattered tokenization artifact.
* validate_dependency_tree takes expected_word_count. It previously derived the count from the returned list, so a tree covering the first 30 of 45 words was internally consistent and validated clean.
* DecomposedLanguage carries ud_annotated/ud_error, and annotate_dependencies_for_result returns its per-language results instead of discarding them -- "Phase 4 never ran" and "its tree was rejected" were indistinguishable.
* The batch path sets max_completion_tokens (it set no limit at all) and checks finish_reason when applying results. A truncated batch is worse than a synchronous one because it surfaces hours later.
* SYN### synthetic lemma ids are removed from the prompts. They never carried information: consumers only asked "is this a real GUID?", so SYN001 and NONE were handled identically. The checks stay, marked deprecated and now logging, in case a model emits the old format from memory.
* Decomposition prompts state that the English lemma and definition are what a GUID means, and that a near-miss should be NONE. A broader lemma that covers the word is still fine.

scripts/trace_sentence_pipeline.py runs one sentence through all four phases, printing every LLM result, lemma link, and database write, plus estimated vs. actual output tokens per phase. It is how the estimates above were calibrated and how they should be re-checked.